### PR TITLE
Fix process hanging bug. Add hive field ETL process.

### DIFF
--- a/backend-service/app/actors/CmdUtil.java
+++ b/backend-service/app/actors/CmdUtil.java
@@ -48,7 +48,7 @@ public class CmdUtil {
     }
 
     String classPath = System.getProperty("java.class.path");
-    sb.append("-cp").append(" \"").append(classPath).append("\" ");
+    sb.append("-cp").append(" '").append(classPath).append("' ");
     sb.append("metadata.etl.Launcher");
 
     return sb.toString();

--- a/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
+++ b/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
@@ -167,10 +167,10 @@ public class SchemaFetch {
           } else if (scanFs.listStatus(n).length > 0 || scanFs.getContentSummary(n).getLength() > 0) {
             scanPath(n);
           } else {
-            System.err.println("* scanPath() size = 0: " + curPath);
+            logger.info("* scanPath() size = 0: " + curPath);
           }
         } catch (AccessControlException e) {
-          System.err.println("* scanPath(e) Permission denied. Cannot access: " + curPath +
+          logger.error("* scanPath(e) Permission denied. Cannot access: " + curPath +
             " owner:" + fstat.getOwner() + " group: " + fstat.getGroup() + "with current user " +
             UserGroupInformation.getCurrentUser());
           // System.err.println(e);
@@ -277,7 +277,7 @@ public class SchemaFetch {
         }
       }
     } catch (AccessControlException e) {
-      System.err.println("* TblInfo() Cannot access " + fstat.getPath().toUri().getPath());
+      logger.error("* TblInfo() Cannot access " + fstat.getPath().toUri().getPath());
       return;
     }
 
@@ -286,7 +286,7 @@ public class SchemaFetch {
     if (datasetSchemaRecord != null) {
       schemaFileWriter.append(datasetSchemaRecord);
     } else {
-      System.err.println("* Cannot resolve the schema of " + fullPath);
+      logger.error("* Cannot resolve the schema of " + fullPath);
     }
 
     SampleDataRecord sampleDataRecord = fileAnalyzerFactory.getSampleData(fstat.getPath(), path.toUri().getPath());

--- a/metadata-etl/src/main/java/metadata/etl/EtlJob.java
+++ b/metadata-etl/src/main/java/metadata/etl/EtlJob.java
@@ -164,6 +164,8 @@ public abstract class EtlJob {
 
   public void setup()
     throws Exception {
+    // redirect error to out
+    System.setErr(System.out);
 
   }
 

--- a/metadata-etl/src/main/java/metadata/etl/dataset/hive/HiveViewDependency.java
+++ b/metadata-etl/src/main/java/metadata/etl/dataset/hive/HiveViewDependency.java
@@ -27,6 +27,9 @@ public class HiveViewDependency {
   static LineageInfo lineageInfoTool =  new LineageInfo();
 
   public static String[] getViewDependency(String hiveQl) {
+    if (hiveQl == null)
+      return new String[]{};
+
     try {
       lineageInfoTool.getLineageInfo(hiveQl);
       TreeSet<String> inputs = lineageInfoTool.getInputTableList();

--- a/metadata-etl/src/main/resources/jython/AvroColumnParser.py
+++ b/metadata-etl/src/main/resources/jython/AvroColumnParser.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+import json
+
+class AvroColumnParser:
+  """
+  This class is used to parse the avro schema, get a list of columns inside it.
+  As avro is nested, we use a recursive way to parse it.
+  Currently used in HDFS avro file schema parsing and Hive avro schema parsing.
+  """
+
+  def __init__(self, avro_schema, urn = None):
+    """
+    :param avro_schema: json of schema
+    :param urn: optional, could contain inside schema
+    :return:
+    """
+    self.sort_id = 0
+    if not urn:
+      self.urn = avro_schema['uri'] if 'uri' in avro_schema else None
+    else:
+      self.urn = urn
+    self.result = []
+    self.fields_json_to_csv(self.result, '', avro_schema['fields'])
+
+  def get_column_list_result(self):
+    """
+
+    :return:
+    """
+    return self.result
+
+  def fields_json_to_csv(self, output_list_, parent_field_path, field_list_):
+    """
+        Recursive function, extract nested fields out of avro.
+    """
+    parent_id = self.sort_id
+
+    for f in field_list_:
+      self.sort_id += 1
+
+      o_field_name = f['name']
+      o_field_data_type = ''
+      o_field_data_size = None
+      o_field_nullable = 'N'
+      o_field_default = ''
+      o_field_namespace = ''
+      o_field_doc = ''
+      effective_type_index_in_type = -1
+
+      if f.has_key('namespace'):
+        o_field_namespace = f['namespace']
+
+      if f.has_key('default') and type(f['default']) != None:
+        o_field_default = f['default']
+
+      if not f.has_key('type'):
+        o_field_data_type = None
+      elif type(f['type']) == list:
+        i = effective_type_index = -1
+        for data_type in f['type']:
+          i += 1  # current index
+          if type(data_type) is None or (data_type == 'null'):
+            o_field_nullable = 'Y'
+          elif type(data_type) == dict:
+            o_field_data_type = data_type['type']
+            effective_type_index_in_type = i
+
+            if data_type.has_key('namespace'):
+              o_field_namespace = data_type['namespace']
+            elif data_type.has_key('name'):
+              o_field_namespace = data_type['name']
+
+            if data_type.has_key('size'):
+              o_field_data_size = data_type['size']
+            else:
+              o_field_data_size = None
+
+          else:
+            o_field_data_type = data_type
+            effective_type_index_in_type = i
+      elif type(f['type']) == dict:
+        o_field_data_type = f['type']['type']
+      else:
+        o_field_data_type = f['type']
+        if f.has_key('attributes') and f['attributes'].has_key('nullable'):
+          o_field_nullable = 'Y' if f['attributes']['nullable'] else 'N'
+        if f.has_key('attributes') and f['attributes'].has_key('size'):
+          o_field_data_size = f['attributes']['size']
+
+      if f.has_key('doc'):
+        if len(f['doc']) == 0 and f.has_key('attributes'):
+          o_field_doc = json.dumps(f['attributes'])
+        else:
+          o_field_doc = f['doc']
+      elif f.has_key('comment'):
+        o_field_doc = f['comment']
+
+      output_list_.append(
+        [self.urn, self.sort_id, parent_id, parent_field_path, o_field_name, o_field_data_type, o_field_nullable,
+         o_field_default, o_field_data_size, o_field_namespace,
+         o_field_doc.replace("\n", ' ') if o_field_doc is not None else None])
+
+      # check if this field is a nested record
+      if type(f['type']) == dict and f['type'].has_key('fields'):
+        current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
+        self.fields_json_to_csv(output_list_, current_field_path, f['type']['fields'])
+      elif type(f['type']) == dict and f['type'].has_key('items') and type(f['type']['items']) == dict and f['type']['items'].has_key('fields'):
+        current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
+        self.fields_json_to_csv(output_list_, current_field_path, f['type']['items']['fields'])
+
+      if effective_type_index_in_type >= 0 and type(f['type'][effective_type_index_in_type]) == dict:
+        if f['type'][effective_type_index_in_type].has_key('items') and type(
+            f['type'][effective_type_index_in_type]['items']) == list:
+
+          for item in f['type'][effective_type_index_in_type]['items']:
+            if type(item) == dict and item.has_key('fields'):
+              current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
+              self.fields_json_to_csv(output_list_, current_field_path, item['fields'])
+        elif f['type'][effective_type_index_in_type].has_key('items') and type(f['type'][effective_type_index_in_type]['items'])== dict and f['type'][effective_type_index_in_type]['items'].has_key('fields'):
+          # type: [ null, { type: array, items: { name: xxx, type: record, fields: [] } } ]
+          current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
+          self.fields_json_to_csv(output_list_, current_field_path, f['type'][effective_type_index_in_type]['items']['fields'])
+        elif f['type'][effective_type_index_in_type].has_key('fields'):
+          # if f['type'][effective_type_index_in_type].has_key('namespace'):
+          # o_field_namespace = f['type'][effective_type_index_in_type]['namespace']
+          current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
+          self.fields_json_to_csv(output_list_, current_field_path, f['type'][effective_type_index_in_type]['fields'])
+
+          # End of function
+

--- a/metadata-etl/src/main/resources/jython/HdfsTransform.py
+++ b/metadata-etl/src/main/resources/jython/HdfsTransform.py
@@ -19,6 +19,7 @@ from org.slf4j import LoggerFactory
 from wherehows.common.writers import FileWriter
 from wherehows.common.schemas import DatasetSchemaRecord, DatasetFieldRecord
 from wherehows.common import Constant
+from AvroColumnParser import AvroColumnParser
 
 
 class HdfsTransform:
@@ -36,105 +37,6 @@ class HdfsTransform:
     self.sort_id = 0
     o_urn = ''
     p = ''
-
-    def fields_json_to_csv(output_list_, parent_field_path, field_list_):
-      # string, list, int, optional int
-      self.sort_id
-      parent_field_path
-      parent_id = self.sort_id
-
-      for f in field_list_:
-        self.sort_id += 1
-
-        o_field_name = f['name']
-        o_field_data_type = ''
-        o_field_data_size = None
-        o_field_nullable = 'N'
-        o_field_default = ''
-        o_field_namespace = ''
-        o_field_doc = ''
-        effective_type_index_in_type = -1
-
-        if f.has_key('namespace'):
-          o_field_namespace = f['namespace']
-
-        if f.has_key('default') and type(f['default']) != None:
-          o_field_default = f['default']
-
-        if not f.has_key('type'):
-          o_field_data_type = None
-        elif type(f['type']) == list:
-          i = effective_type_index = -1
-          for data_type in f['type']:
-            i += 1  # current index
-            if type(data_type) is None or (data_type == 'null'):
-              o_field_nullable = 'Y'
-            elif type(data_type) == dict:
-              o_field_data_type = data_type['type']
-              effective_type_index_in_type = i
-
-              if data_type.has_key('namespace'):
-                o_field_namespace = data_type['namespace']
-              elif data_type.has_key('name'):
-                o_field_namespace = data_type['name']
-
-              if data_type.has_key('size'):
-                o_field_data_size = data_type['size']
-              else:
-                o_field_data_size = None
-
-            else:
-              o_field_data_type = data_type
-              effective_type_index_in_type = i
-        elif type(f['type']) == dict:
-          o_field_data_type = f['type']['type']
-        else:
-          o_field_data_type = f['type']
-          if f.has_key('attributes') and f['attributes'].has_key('nullable'):
-            o_field_nullable = 'Y' if f['attributes']['nullable'] else 'N'
-          if f.has_key('attributes') and f['attributes'].has_key('size'):
-            o_field_data_size = f['attributes']['size']
-
-        if f.has_key('doc'):
-          if len(f['doc']) == 0 and f.has_key('attributes'):
-            o_field_doc = json.dumps(f['attributes'])
-          else:
-            o_field_doc = f['doc']
-        elif f.has_key('comment'):
-          o_field_doc = f['comment']
-
-        output_list_.append(
-          [o_urn, self.sort_id, parent_id, parent_field_path, o_field_name, o_field_data_type, o_field_nullable,
-           o_field_default, o_field_data_size, o_field_namespace,
-           o_field_doc.replace("\n", ' ') if o_field_doc is not None else None])
-
-        # check if this field is a nested record
-        if type(f['type']) == dict and f['type'].has_key('fields'):
-          current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
-          fields_json_to_csv(output_list_, current_field_path, f['type']['fields'])
-        elif type(f['type']) == dict and f['type'].has_key('items') and type(f['type']['items']) == dict and f['type']['items'].has_key('fields'):
-          current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
-          fields_json_to_csv(output_list_, current_field_path, f['type']['items']['fields'])
-
-        if effective_type_index_in_type >= 0 and type(f['type'][effective_type_index_in_type]) == dict:
-          if f['type'][effective_type_index_in_type].has_key('items') and type(
-              f['type'][effective_type_index_in_type]['items']) == list:
-
-            for item in f['type'][effective_type_index_in_type]['items']:
-              if type(item) == dict and item.has_key('fields'):
-                current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
-                fields_json_to_csv(output_list_, current_field_path, item['fields'])
-          elif f['type'][effective_type_index_in_type].has_key('items') and f['type'][effective_type_index_in_type]['items'].has_key('fields'):
-            # type: [ null, { type: array, items: { name: xxx, type: record, fields: [] } } ]
-            current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
-            fields_json_to_csv(output_list_, current_field_path, f['type'][effective_type_index_in_type]['items']['fields'])
-          elif f['type'][effective_type_index_in_type].has_key('fields'):
-            # if f['type'][effective_type_index_in_type].has_key('namespace'):
-            # o_field_namespace = f['type'][effective_type_index_in_type]['namespace']
-            current_field_path = o_field_name if parent_field_path == '' else parent_field_path + '.' + o_field_name
-            fields_json_to_csv(output_list_, current_field_path, f['type'][effective_type_index_in_type]['fields'])
-
-            # End of function
 
     for line in input_json_file:
       try:
@@ -200,7 +102,8 @@ class HdfsTransform:
             f['attributes'] = json.loads(f['attributes_json'])
             del f['attributes_json']
 
-        fields_json_to_csv(o_field_list_, '', j['fields'])
+        acp = AvroColumnParser(j, o_urn)
+        o_field_list_ += acp.get_column_list_result()
 
       else:
         o_fields = {"doc": None}

--- a/metadata-etl/src/main/resources/jython/HiveColumnParser.py
+++ b/metadata-etl/src/main/resources/jython/HiveColumnParser.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+
+import re
+import json
+
+
+class HiveColumnParser:
+  """
+  This class used for parsing a Hive metastore schema.
+  Major effort is parse complex column types :
+  Reference : https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types
+  """
+  def string_interface(self, dataset_urn, input):
+    schema = json.loads(input)
+    return HiveColumnParser(dataset_urn, schema)
+
+  def __init__(self, avro_schema, urn = None):
+    """
+
+    :param avro_schema json schema
+    :param urn:
+    :return:
+    """
+    self.prefix = ''
+    if not urn:
+      self.dataset_urn = avro_schema['uri'] if 'uri' in avro_schema else None
+    else:
+      self.dataset_urn = urn
+    self.column_type_dict = avro_schema
+    self.column_type_list = []
+    self.sort_id = 0
+    for index, f in enumerate(avro_schema['fields']):
+      avro_schema['fields'][index] = self.parse_column(f['ColumnName'], f['TypeName'], f['Comment'])
+
+    # padding list for rest 4 None, skip  is_nullable, default_value, data_size, namespace for now
+    self.column_type_list = [(x[:6] + [None] * 4 + x[6:]) for x in self.column_type_list]
+
+  def parse_column(self, column_name, type_string, comment=None):
+    """
+    Returns a dictionary of a Hive column's type metadata and
+     any complex or nested type info
+    """
+    simple_type, inner, comment_inside = self._parse_type(type_string)
+    comment = comment if comment else comment_inside
+    column = {'name': column_name, 'type' : simple_type, 'doc': comment}
+
+    self.sort_id += 1
+    self.column_type_list.append([self.dataset_urn, self.sort_id, 0, self.prefix, column_name, simple_type, comment])
+    if inner:
+      self.prefix = column_name
+      column.update(self._parse_complex(simple_type, inner, self.sort_id))
+    return column
+
+  def is_scalar_type(self, type_string):
+    return not (type_string.startswith('array') or type_string.startswith('map') or type_string.startswith(
+      'struct') or type_string.startswith('uniontype'))
+
+  def _parse_type(self, type_string):
+    pattern = re.compile(r"^([a-z]+[(),0-9]*)(<(.+)>)?( comment '(.*)')?$", re.IGNORECASE)
+    match = re.search(pattern, type_string)
+    return match.group(1), match.group(3), match.group(5)
+
+  def _parse_complex(self, simple_type, inner, parent_id):
+    complex_type = {}
+    if simple_type == "array":
+      complex_type['item'] = self._parse_array_item(inner, parent_id)
+    elif simple_type == "map":
+      complex_type['key'] = self._parse_map_key(inner)
+      complex_type['value'] = self._parse_map_value(inner, parent_id)
+    elif simple_type == "struct":
+      complex_type['fields'] = self._parse_struct_fields(inner, parent_id)
+    elif simple_type == "uniontype":
+      complex_type['union'] = self._parse_union_types(inner, parent_id)
+    return complex_type
+
+  def _parse_array_item(self, inner, parent_id):
+    item = {}
+    simple_type, inner, comment = self._parse_type(inner)
+    item['type'] = simple_type
+    item['doc'] = comment
+    if inner:
+      item.update(self._parse_complex(simple_type, inner, parent_id))
+    return item
+
+  def _parse_map_key(self, inner):
+    key = {}
+    key_type = inner.split(',', 1)[0]
+    key['type'] = key_type
+    return key
+
+  def _parse_map_value(self, inner, parent_id):
+    value = {}
+    value_type = inner.split(',', 1)[1]
+    simple_type, inner, comment = self._parse_type(value_type)
+    value['type'] = simple_type
+    value['doc'] = comment
+    if inner:
+      value.update(self._parse_complex(simple_type, inner, parent_id))
+    return value
+
+  def _parse_struct_fields(self, inner, parent_id):
+    current_prefix = self.prefix
+    fields = []
+    field_tuples = self._split_struct_fields(inner)
+    for (name, value) in field_tuples:
+      field = {}
+      name = name.strip(',')
+      field['name'] = name
+      simple_type, inner, comment = self._parse_type(value)
+      field['type'] = simple_type
+      field['doc'] = comment
+      self.sort_id += 1
+      self.column_type_list.append([self.dataset_urn, self.sort_id, parent_id, self.prefix, name, simple_type, comment])
+      if inner:
+        self.prefix += '.' + name
+        field.update(self._parse_complex(simple_type, inner, self.sort_id))
+        self.prefix = current_prefix
+      fields.append(field)
+    return fields
+
+  def _split_struct_fields(self, fields_string):
+    fields = []
+    remaining = fields_string
+    while remaining:
+      (fieldname, fieldvalue), remaining = self._get_next_struct_field(remaining)
+      fields.append((fieldname, fieldvalue))
+    return fields
+
+  def _get_next_struct_field(self, fields_string):
+    fieldname, rest = fields_string.split(':', 1)
+    balanced = 0
+    for pos, char in enumerate(rest):
+      balanced += {'<': 1, '>': -1, '(': 100, ')': -100}.get(char, 0)
+      if balanced == 0 and char in ['>', ',']:
+        if rest[pos + 1:].startswith(' comment '):
+          pattern = re.compile(r"( comment '.*?')(,[a-z_0-9]+:)?", re.IGNORECASE)
+          match = re.search(pattern, rest[pos + 1:])
+          cm_len = len(match.group(1))
+          return (fieldname, rest[:pos + 1 + cm_len].strip(',')), rest[pos + 2 + cm_len:]
+        return (fieldname, rest[:pos + 1].strip(',')), rest[pos + 1:]
+    return (fieldname, rest), None
+
+  def _parse_union_types(self, inner, parent_id):
+    current_prefix = self.prefix
+    types = []
+    type_tuples = []
+    bracket_level = 0
+    current = []
+
+    for c in (inner + ","):
+      if c == "," and bracket_level == 0:
+        type_tuples.append("".join(current))
+        current = []
+      else:
+        if c == "<":
+          bracket_level += 1
+        elif c == ">":
+          bracket_level -= 1
+        current.append(c)
+
+
+    for pos, value in enumerate(type_tuples):
+      field = {}
+      name = 'type' + str(pos)
+      field['name'] = name
+      #print 'type' + str(pos) + "\t" + value
+      simple_type, inner, comment = self._parse_type(value)
+      field['type'] = simple_type
+      field['doc'] = comment
+      self.sort_id += 1
+      self.column_type_list.append([self.dataset_urn, self.sort_id, parent_id, self.prefix, name, simple_type, comment])
+
+      if inner:
+        self.prefix += '.' + name
+        field.update(self._parse_complex(simple_type, inner, self.sort_id))
+        self.prefix = current_prefix
+      types.append(field)
+    return types

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -39,7 +39,7 @@ class TableInfo:
   is_storedassubdirectories = 'is_storedassubdirectories'
   etl_source = 'etl_source'
 
-  field_list = 'field_list'
+  field_list = 'fields'
   schema_literal = 'schema_literal'
 
   optional_prop = [create_time, serialization_format, field_delimiter, schema_url, db_id, table_id, serde_id,
@@ -63,8 +63,9 @@ class HiveExtract:
     """
     get table, column info from table columns_v2
     :param database_name:
-    :return: (DB_NAME, TBL_NAME, SERDE_FORMAT, TBL_CREATE_TIME, INTEGER_IDX, COLUMN_NAME, TYPE_NAME, COMMENT
-    DB_ID, TBL_ID, SD_ID, LOCATION, VIEW_EXPANDED_TEXT, TBL_TYPE, INPUT_FORMAT)
+    :return: (0 DB_NAME, 1 TBL_NAME, 2 SERDE_FORMAT, 3 TBL_CREATE_TIME
+    4 DB_ID, 5 TBL_ID,6 SD_ID, 7 LOCATION, 8 VIEW_EXPANDED_TEXT, 9 TBL_TYPE, 10 VIEW_EXPENDED_TEXT, 11 INPUT_FORMAT,12  OUTPUT_FORMAT,
+    13IS_COMPRESSED, 14 IS_STOREDASSUBDIRECTORIES, 15 INTEGER_IDX, 16 COLUMN_NAME, 17 TYPE_NAME, 18 COMMENT)
     """
     curs = self.conn_hms.cursor()
     tbl_info_sql = """select d.NAME DB_NAME, t.TBL_NAME TBL_NAME,
@@ -151,8 +152,7 @@ class HiveExtract:
 
     field_list = []
     for row_index, row_value in enumerate(rows):
-
-      field_list.append({'IntegerIndex': row_value[14], 'ColumnName': row_value[15], 'TypeName': row_value[16], # TODO the type name need to process
+      field_list.append({'IntegerIndex': row_value[14], 'ColumnName': row_value[15], 'TypeName': row_value[16],
                          'Comment': row_value[17]})
       if row_index == len(rows) - 1 or (row_value[0] != rows[row_index+1][0] or row_value[1] != rows[row_index+1][1]): # if this is last record of current table
         # process the record of table

--- a/metadata-etl/src/main/resources/jython/HiveLoad.py
+++ b/metadata-etl/src/main/resources/jython/HiveLoad.py
@@ -107,7 +107,7 @@ class HiveLoad:
 
   def load_field(self):
     """
-    TODO: Load field is not used for now, as we need to open the nested structure type
+    Load fields
     :return:
     """
     cursor = self.conn_mysql.cursor()
@@ -117,25 +117,121 @@ class HiveLoad:
         LOAD DATA LOCAL INFILE '{source_file}'
         INTO TABLE stg_dict_field_detail
         FIELDS TERMINATED BY '\Z'
-        (urn, sort_id, parent_sort_id, @parent_path, field_name, field_label, data_type,
-         @data_size, @precision, @scale, @is_nullable, @is_indexed, @is_partitioned, @default_value, @namespace, description,
-         @dummy
-        )
-        SET
-          parent_path=nullif(@parent_path,'null')
-        , data_size=nullif(@data_size,'null')
-        , data_precision=nullif(@precision,'null')
-        , data_scale=nullif(@scale,'null')
+        (urn, sort_id, parent_sort_id, parent_path, field_name, data_type,
+         @is_nullable, @default_value, @data_size, @namespace, @description)
+        SET db_id = {db_id}
         , is_nullable=nullif(@is_nullable,'null')
-        , is_indexed=nullif(@is_indexed,'null')
-        , is_partitioned=nullif(@is_partitioned,'null')
         , default_value=nullif(@default_value,'null')
+        , data_size=nullif(@data_size,'null')
         , namespace=nullif(@namespace,'null')
-        , db_id = {db_id}
-        ;
+        , description=nullif(@description,'null');
+
 
         ANALYZE TABLE stg_dict_field_detail;
 
+
+        insert into field_comments (
+          user_id, comment, created, comment_crc32_checksum
+        )
+        select 0 user_id, description, now() created, crc32(description) from
+        (
+          select sf.description
+          from stg_dict_field_detail sf left join field_comments fc
+            on sf.description = fc.comment
+          where sf.description is not null
+            and fc.id is null
+            and sf.db_id = {db_id}
+          group by 1 order by 1
+        ) d;
+
+        analyze table field_comments;
+
+        -- delete old record if it does not exist in this load batch anymore (but have the dataset id)
+        create temporary table if not exists t_deleted_fields (primary key (field_id))
+          select x.field_id
+            from stg_dict_field_detail s
+              join dict_dataset i
+                on s.urn = i.urn
+                and s.db_id = {db_id}
+              right join dict_field_detail x
+                on i.id = x.dataset_id
+                and s.field_name = x.field_name
+                and s.parent_path = x.parent_path
+          where s.field_name is null
+            and x.dataset_id in (
+                       select d.id dataset_id
+                       from stg_dict_field_detail k join dict_dataset d
+                         on k.urn = d.urn
+                        and k.db_id = {db_id}
+            )
+        ; -- run time : ~2min
+
+        delete from dict_field_detail where field_id in (select field_id from t_deleted_fields);
+
+        -- update the old record if some thing changed
+        update dict_field_detail t join
+        (
+          select x.field_id, s.*
+          from stg_dict_field_detail s join dict_dataset d
+            on s.urn = d.urn
+               join dict_field_detail x
+           on s.field_name = x.field_name
+          and coalesce(s.parent_path, '*') = coalesce(x.parent_path, '*')
+          and d.id = x.dataset_id
+          where s.db_id = {db_id}
+            and (x.sort_id <> s.sort_id
+                or x.parent_sort_id <> s.parent_sort_id
+                or x.data_type <> s.data_type
+                or x.data_size <> s.data_size or (x.data_size is null XOR s.data_size is null)
+                or x.data_precision <> s.data_precision or (x.data_precision is null XOR s.data_precision is null)
+                or x.is_nullable <> s.is_nullable or (x.is_nullable is null XOR s.is_nullable is null)
+                or x.is_partitioned <> s.is_partitioned or (x.is_partitioned is null XOR s.is_partitioned is null)
+                or x.is_distributed <> s.is_distributed or (x.is_distributed is null XOR s.is_distributed is null)
+                or x.default_value <> s.default_value or (x.default_value is null XOR s.default_value is null)
+                or x.namespace <> s.namespace or (x.namespace is null XOR s.namespace is null)
+            )
+        ) p
+          on t.field_id = p.field_id
+        set t.sort_id = p.sort_id,
+            t.parent_sort_id = p.parent_sort_id,
+            t.data_type = p.data_type,
+            t.data_size = p.data_size,
+            t.data_precision = p.data_precision,
+            t.is_nullable = p.is_nullable,
+            t.is_partitioned = p.is_partitioned,
+            t.is_distributed = p.is_distributed,
+            t.default_value = p.default_value,
+            t.namespace = p.namespace,
+            t.modified = now()
+        ;
+
+        insert into dict_field_detail (
+          dataset_id, fields_layout_id, sort_id, parent_sort_id, parent_path,
+          field_name, namespace, data_type, data_size, is_nullable, default_value,
+          default_comment_id, modified
+        )
+        select
+          d.id, 0, sf.sort_id, sf.parent_sort_id, sf.parent_path,
+          sf.field_name, sf.namespace, sf.data_type, sf.data_size, sf.is_nullable, sf.default_value,
+          coalesce(fc.id, t.default_comment_id) fc_id, now()
+        from stg_dict_field_detail sf join dict_dataset d
+          on sf.urn = d.urn
+             left join field_comments fc
+          on sf.description = fc.comment
+             left join dict_field_detail t
+          on d.id = t.dataset_id
+         and sf.field_name = t.field_name
+         and sf.parent_path = t.parent_path
+        where db_id = {db_id} and t.field_id is null
+
+        on duplicate key update
+          data_type = sf.data_type, data_size = sf.data_size,
+          is_nullable = sf.is_nullable, default_value = sf.default_value,
+          namespace = sf.namespace,
+          default_comment_id = coalesce(fc.id, t.default_comment_id),
+          modified=now()
+        ;
+        analyze table dict_field_detail;
         """.format(source_file=self.input_field_file, db_id=self.db_id)
 
     # didn't load into final table for now
@@ -165,6 +261,6 @@ if __name__ == "__main__":
   l.conn_mysql = zxJDBC.connect(JDBC_URL, username, password, JDBC_DRIVER)
   try:
     l.load_metadata()
-    # l.load_field()
+    l.load_field()
   finally:
     l.conn_mysql.close()

--- a/metadata-etl/src/main/resources/log4j.properties
+++ b/metadata-etl/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@
 #
 
 # Root logger option
-log4j.rootLogger=INFO, stdout, file
+log4j.rootLogger=INFO, file
 
 # Redirect log messages to console
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/metadata-etl/src/test/java/metadata/etl/LaunchJython.java
+++ b/metadata-etl/src/test/java/metadata/etl/LaunchJython.java
@@ -1,0 +1,39 @@
+package metadata.etl;
+
+import java.io.File;
+import java.net.URL;
+import org.python.core.PyString;
+import org.python.core.PySystemState;
+import org.python.util.PythonInterpreter;
+
+
+/**
+ * Created by zsun on 3/9/16.
+ */
+public class LaunchJython {
+
+  public PythonInterpreter setUp() {
+    PySystemState sys = new PySystemState();
+    addJythonToPath(sys);
+    return new PythonInterpreter(null, sys);
+  }
+
+  /**
+   * Need to add the jython scripts in main/resource/jython into the PySystemState
+   * Note the jython resource folder name in test must be different from the one in main,
+   * otherwise it will overwrite the path.
+   * @param pySystemState
+   */
+  private void addJythonToPath(PySystemState pySystemState) {
+    URL url = getClass().getClassLoader().getResource("jython");
+    if (url != null) {
+      File file = new File(url.getFile());
+      String path = file.getPath();
+      System.out.println(path);
+      if (path.startsWith("file:")) {
+        path = path.substring(5);
+      }
+      pySystemState.path.append(new PyString(path.replace("!", "")));
+    }
+  }
+}

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hive/AvroColumnParserTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hive/AvroColumnParserTest.java
@@ -1,0 +1,22 @@
+package metadata.etl.dataset.hive;
+
+import java.io.InputStream;
+import metadata.etl.LaunchJython;
+import org.python.util.PythonInterpreter;
+import org.testng.annotations.Test;
+
+
+public class AvroColumnParserTest {
+
+  @Test
+  public void avroTest() {
+
+    LaunchJython l = new LaunchJython();
+    PythonInterpreter interpreter = l.setUp();
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream("jython-test/AvroColumnParserTest.py");
+    interpreter.execfile(inputStream);
+
+  }
+}

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveColumnParserTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveColumnParserTest.java
@@ -1,0 +1,25 @@
+package metadata.etl.dataset.hive;
+
+import java.io.InputStream;
+import metadata.etl.LaunchJython;
+import org.python.util.PythonInterpreter;
+import org.testng.annotations.Test;
+
+
+/**
+ * Created by zsun on 3/9/16.
+ */
+public class HiveColumnParserTest {
+
+  @Test
+  public void hiveColumnParserTest() {
+
+    LaunchJython l = new LaunchJython();
+    PythonInterpreter interpreter = l.setUp();
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream("jython-test/HiveColumnParserTest.py");
+    interpreter.execfile(inputStream);
+
+  }
+}

--- a/metadata-etl/src/test/resources/jython-test/AvroColumnParserTest.py
+++ b/metadata-etl/src/test/resources/jython-test/AvroColumnParserTest.py
@@ -1,0 +1,90 @@
+__author__ = 'zsun'
+import unittest
+import json
+from AvroColumnParser import AvroColumnParser
+
+sample_avro_with_complex_field ='''
+  {
+    "doc": "sample avro array",
+    "fields": [{
+      "doc": "doc1",
+      "name": "emailAddresses",
+      "type": {
+        "items": {
+          "doc": "Stores details about an email address that a user has associated with their account.",
+          "fields": [{
+            "doc": "The email address, e.g. `foo@example.com`",
+            "name": "address",
+            "type": "string"
+          }, {
+            "default": false,
+            "doc": "true if the user has clicked the link in a confirmation email to this address.",
+            "name": "verified",
+            "type": "boolean"
+          }, {
+            "name": "dateAdded",
+            "type": "long"
+          }, {
+            "name": "dateBounced",
+            "type": ["null", "long"]
+          }, {
+            "name": "nestedField",
+            "type": {
+              "type":"record",
+              "items": {
+                "fields": [{
+                "name": "nested1",
+                "type": "string"
+                }]
+              }
+            }
+          }],
+          "name": "EmailAddress",
+          "type": "record"
+        },
+        "type": "array"
+      }
+    },
+    {
+  		"doc": "this is a enum type",
+  		"type": "enum",
+  		"name": "Suit",
+  		"symbols": ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+
+  	}
+    ],
+    "name": "User",
+    "namespace": "com.example.avro",
+    "type": "record",
+    "uri": "hdfs:///data/sample1"
+  }
+  '''
+# output value : List[List[]] : uri, sort_id, parent_sort_id, prefix, column_name, data_type, is_nullable, default_value, data_size, namespace, description
+expect_result = [[u'hdfs:///data/sample1', 1, 0, '', u'emailAddresses', u'array', 'N', '', None, '', u'doc1'],
+ [u'hdfs:///data/sample1', 2, 1, u'emailAddresses', u'address', u'string', 'N', '', None, '', u'The email address, e.g. `foo@example.com`'],
+ [u'hdfs:///data/sample1', 3, 1, u'emailAddresses', u'verified', u'boolean', 'N', False, None, '', u'true if the user has clicked the link in a confirmation email to this address.'],
+ [u'hdfs:///data/sample1', 4, 1, u'emailAddresses', u'dateAdded', u'long', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 5, 1, u'emailAddresses', u'dateBounced', u'long', 'Y', '', None, '', ''],
+ [u'hdfs:///data/sample1', 6, 1, u'emailAddresses', u'nestedField', u'record', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 7, 6, u'emailAddresses.nestedField', u'nested1', u'string', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 8, 0, '', u'Suit', u'enum', 'N', '', None, '', u'this is a enum type']]
+
+
+class AvroColumnParserTest(unittest.TestCase):
+
+  def test_parse_complex(self):
+    avro_json = json.loads(sample_avro_with_complex_field)
+    acp = AvroColumnParser(avro_json)
+    result = acp.get_column_list_result()
+    self.assertEqual(result, expect_result)
+
+
+  def runTest(self):
+    pass
+
+
+if __name__ == '__main__':
+
+  a = AvroColumnParserTest()
+  a.test_parse_complex()
+

--- a/metadata-etl/src/test/resources/jython-test/HiveColumnParserTest.py
+++ b/metadata-etl/src/test/resources/jython-test/HiveColumnParserTest.py
@@ -1,0 +1,91 @@
+import unittest
+import json
+from HiveColumnParser import HiveColumnParser
+import pprint
+
+complex_type_kw = ['array', 'map', 'struct', 'uniontype']
+
+sample_hive_schema ='''
+
+  '''
+
+sample_hive_schema_complex_types = "Complex Types"
+
+expect_result = []
+
+sample_input_simple = '{"fields" : [{"Comment": "document of field test", "TypeName": "struct<resultid:decimal(1,2),result:string>", "ColumnName": "test"}]}'
+
+# output value : List[List[]] : uri, sort_id, parent_sort_id, prefix, column_name, data_type, is_nullable, default_value, data_size, namespace, description
+
+expect_result_simple = [['hdfs:///test/urn', 1, 0, '', u'test', u'struct', None, None, None, None, u'document of field test'],
+                 ['hdfs:///test/urn', 2, 1, u'test', u'resultid', u'decimal(1,2)', None, None, None, None, None],
+                 ['hdfs:///test/urn', 3, 1, u'test', u'result', u'string', None, None, None, None, None]]
+
+
+sample_input_complex = '''
+{"fields" : [{"Comment": null, "TypeName": "struct<advancedfields:map<string,string>,\
+facetvaluemap:map<string,string> comment 'MFC-J475',\
+searchcomponents:array<struct<componenttype:string comment 'Work Smart Series',\
+position:string,results:struct<numsearchresults:decimal(15,2),results:array<struct\
+<resultid:bigint,result:varchar(10),resulttype:string,resultindex:int,relevance:float,\
+additionalinfo:map<string,string>>>> comment 'com.brother.innobella.printer',\
+additionalinfo:map<string,string>>>,searchtime:int comment '1~1024',\
+extratag:uniontype<int,double,struct<aaa:int,bbb:char>,array<varchar>> comment '*',\
+querytagger:string>", "ColumnName": "testcomplex"}]}
+'''
+
+expect_result_complex = [['hdfs:///test/urn', 1, 0, '', u'testcomplex', u'struct', None, None, None, None, None],
+['hdfs:///test/urn', 2, 1, u'testcomplex', u'advancedfields', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 3, 1, u'testcomplex', u'facetvaluemap', u'map', None, None, None, None, u'MFC-J475'],
+['hdfs:///test/urn', 4, 1, u'testcomplex', u'searchcomponents', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 5, 4, u'testcomplex.searchcomponents', u'componenttype', u'string', None, None, None, None, u'Work Smart Series'],
+['hdfs:///test/urn', 6, 4, u'testcomplex.searchcomponents', u'position', u'string', None, None, None, None, None],
+['hdfs:///test/urn', 7, 4, u'testcomplex.searchcomponents', u'results', u'struct', None, None, None, None, u'com.brother.innobella.printer'],
+['hdfs:///test/urn', 8, 7, u'testcomplex.searchcomponents.results', u'numsearchresults', u'decimal(15,2)', None, None, None, None, None],
+['hdfs:///test/urn', 9, 7, u'testcomplex.searchcomponents.results', u'results', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 10, 9, u'testcomplex.searchcomponents.results.results', u'resultid', u'bigint', None, None, None, None, None],
+['hdfs:///test/urn', 11, 9, u'testcomplex.searchcomponents.results.results', u'result', u'varchar(10)', None, None, None, None, None],
+['hdfs:///test/urn', 12, 9, u'testcomplex.searchcomponents.results.results', u'resulttype', u'string', None, None, None, None, None],
+['hdfs:///test/urn', 13, 9, u'testcomplex.searchcomponents.results.results', u'resultindex', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 14, 9, u'testcomplex.searchcomponents.results.results', u'relevance', u'float', None, None, None, None, None],
+['hdfs:///test/urn', 15, 9, u'testcomplex.searchcomponents.results.results', u'additionalinfo', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 16, 4, u'testcomplex.searchcomponents', u'additionalinfo', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 17, 1, u'testcomplex', u'searchtime', u'int', None, None, None, None, u'1~1024'],
+['hdfs:///test/urn', 18, 1, u'testcomplex', u'extratag', u'uniontype', None, None, None, None, u'*'],
+['hdfs:///test/urn', 19, 18, u'testcomplex.extratag', 'type0', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 20, 18, u'testcomplex.extratag', 'type1', u'double', None, None, None, None, None],
+['hdfs:///test/urn', 21, 18, u'testcomplex.extratag', 'type2', u'struct', None, None, None, None, None],
+['hdfs:///test/urn', 22, 21, u'testcomplex.extratag.type2', u'aaa', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 23, 21, u'testcomplex.extratag.type2', u'bbb', u'char', None, None, None, None, None],
+['hdfs:///test/urn', 24, 18, u'testcomplex.extratag', 'type3', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 25, 1, u'testcomplex', u'querytagger', u'string', None, None, None, None, None]]
+class HiveColumnParserTest(unittest.TestCase):
+
+  def test_parse_simple(self):
+    schema = json.loads(sample_input_simple)
+    hcp = HiveColumnParser(schema, urn = 'hdfs:///test/urn')
+
+    #pprint.pprint(hcp.column_type_dict)
+
+    self.assertEqual(hcp.column_type_list, expect_result_simple)
+
+  def test_parse_complex(self):
+
+    schema = json.loads(sample_input_complex)
+    hcp = HiveColumnParser(schema, urn = 'hdfs:///test/urn')
+
+    #pprint.pprint(hcp.column_type_dict)
+
+    self.assertEqual(hcp.column_type_list,expect_result_complex)
+
+  def runTest(self):
+    pass
+
+
+if __name__ == '__main__':
+
+  a = HiveColumnParserTest()
+  a.test_parse_simple()
+  a.test_parse_complex()
+
+

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldRecord.java
@@ -78,6 +78,7 @@ public class DatasetFieldRecord implements Record {
 
   public DatasetFieldRecord(Object[] allFields) {
     // TODO need to make a check
+    // sequence should be : uri, sort_id, parent_sort_id, prefix, column_name, data_type, is_nullable, default_value, data_size, namespace, description
     this.allFields = new ArrayList<Object>(Arrays.asList(allFields));
   }
 
@@ -85,6 +86,10 @@ public class DatasetFieldRecord implements Record {
   public String toCsvString() {
     StringBuilder sb = new StringBuilder();
     for (Object o : allFields) {
+      // comment have new line
+      if (o != null && o.toString().contains("\n")) {
+        o = o.toString().replace("\n", "\\n");
+      }
       sb.append(o);
       sb.append(SEPR);
     }


### PR DESCRIPTION
* Fix bug of process hanging:
 - Reason is the process stdout and stderr need to be consumed, otherwise when buffer full, it will hanging there.

* Add Hive field ETL process
  - Hive schema get from two different source, COLUMN_V2 and SERDE_PARAM. Two schemas are totally different.
 - SERDE_PARAM : Schema is avro schema. We can reuse the schema parse procedure in HDFS transform steps. So I reorganize HDFS transform steps to separate them out, for the ease of reuse.
 - COLUMN_V2 : Get type from table and construct the schema by ourself. But the 'type' is nested. see here: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types. Thanks for @ericsun2 help, and leverage his script to parse it out.