### PR TITLE
Add field comments ETL

### DIFF
--- a/backend-service/app/models/daos/CfgDao.java
+++ b/backend-service/app/models/daos/CfgDao.java
@@ -33,10 +33,10 @@ public class CfgDao {
   public static final String FIND_DB_INFO_BY_ID = "SELECT * from cfg_database where db_id = :id";
   public static final String GET_ALL_APPS = "SELECT * FROM cfg_application order by app_id";
   public static final String GET_ALL_DBS = "SELECT * from cfg_database order by db_id";
-  public static final String INSERT_NEW_APP = "INSERT INTO cfg_application (app_id, app_code, description, uri, short_connection_string, parent_app_id, app_status, is_logical) "
-    + "VALUES (:appId, :appCode, :description, :uri, :shortConnectionString, :parentAppId, :appStatus, :isLogical)";
+  public static final String INSERT_NEW_APP = "INSERT INTO cfg_application (app_id, app_code, description, uri, short_connection_string, tech_matrix_id, parent_app_id, app_status, is_logical) "
+    + "VALUES (:appId, :appCode, :description, :uri, :shortConnectionString, :techMatrixId, :parentAppId, :appStatus, :isLogical)";
   public static final String UPDATE_APP = "UPDATE cfg_application SET app_code = :appCode, description = :description, uri = :uri, short_connection_string = :shortConnectionString, " +
-    " parent_app_id = :parentAppId, app_status = :appStatus, is_logical = :isLogical WHERE app_id = :appId";
+    " tech_matrix_id = :techMatrixId, parent_app_id = :parentAppId, app_status = :appStatus, is_logical = :isLogical WHERE app_id = :appId";
   public static final String INSERT_NEW_DB = "INSERT INTO cfg_database (db_id, db_code, db_type_id, description, cluster_size, associated_data_centers, replication_role, uri, short_connection_string, jdbc_url, is_logical) "
     + "VALUES (:dbId, :dbCode, :dbTypeId, :description, :clusterSize, :associatedDataCenters, :replicationRole, :uri, :shortConnectionString, :jdbcUrl, :isLogical)";
   public static final String UPDATE_DB = "UPDATE cfg_database SET db_code = :dbCode, db_type_id = :dbTypeId, description = :description, cluster_size = :clusterSize, associated_data_centers = :associatedDataCenters, " +
@@ -90,6 +90,7 @@ public class CfgDao {
     params.put("description", JsonUtil.getJsonValue(app, "description", String.class, null));
     params.put("uri", JsonUtil.getJsonValue(app, "uri", String.class, null));
     params.put("shortConnectionString", JsonUtil.getJsonValue(app, "short_connection_string", String.class));
+    params.put("techMatrixId", JsonUtil.getJsonValue(app, "techMatrixId", Integer.class, null));
     params.put("parentAppId", JsonUtil.getJsonValue(app, "parent_app_id", Integer.class, null));
     params.put("appStatus", JsonUtil.getJsonValue(app, "app_status", String.class, null));
     params.put("isLogical", ((boolean) JsonUtil.getJsonValue(app, "is_logical", Boolean.class, false) ? "Y" : "N"));

--- a/data-model/DDL/ETL_DDL/dataset_metadata.sql
+++ b/data-model/DDL/ETL_DDL/dataset_metadata.sql
@@ -148,6 +148,8 @@ CREATE TABLE `stg_dict_field_detail` (
   `namespace`      VARCHAR(200)                  DEFAULT NULL,
   `description`    VARCHAR(1000)                 DEFAULT NULL,
   `last_modified`  TIMESTAMP            NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY `urn_idx` (`urn`),
+  KEY `stg_comment_key` (`description`(100)),
   PRIMARY KEY (`db_id`, `urn`, `sort_id`)
 )
   ENGINE = InnoDB
@@ -212,7 +214,17 @@ CREATE TABLE `dict_dataset_schema_history` (
   ENGINE = InnoDB
   AUTO_INCREMENT = 0;
 
--- field comments
+-- staging table table of fields to comments mapping
+CREATE TABLE `stg_dict_dataset_field_comment` (
+  `field_id` bigint(20) NOT NULL,
+  `comment_id` bigint(20) NOT NULL,
+  `dataset_id` bigint(20) NOT NULL,
+  `db_id` smallint(6) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`field_id`,`comment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+;
+
+-- fields to comments mapping
 CREATE TABLE `dict_dataset_field_comment` (
   `field_id`   BIGINT(20) NOT NULL,
   `comment_id` BIGINT(20) NOT NULL,
@@ -251,6 +263,7 @@ CREATE TABLE `field_comments` (
   `comment_crc32_checksum` INT(11) UNSIGNED          DEFAULT NULL
   COMMENT '4-byte CRC32',
   PRIMARY KEY (`id`),
+  KEY `comment_key` (`comment`(100)),
   FULLTEXT KEY `fti_comment` (`comment`)
 )
   ENGINE = InnoDB

--- a/data-model/DDL/ETL_DDL/etl_configure_tables.sql
+++ b/data-model/DDL/ETL_DDL/etl_configure_tables.sql
@@ -104,7 +104,7 @@ CREATE TABLE `cfg_application` (
   `app_id`                  SMALLINT    UNSIGNED NOT NULL,
   `app_code`                VARCHAR(128)         NOT NULL,
   `description`             VARCHAR(512)         NOT NULL,
-  `tech_matrix_id`          SMALLINT(5) UNSIGNED NOT NULL,
+  `tech_matrix_id`          SMALLINT(5) UNSIGNED DEFAULT '0',
   `doc_url`                 VARCHAR(512)                  DEFAULT NULL,
   `parent_app_id`           INT(11) UNSIGNED     NOT NULL,
   `app_status`              CHAR(1)              NOT NULL,

--- a/metadata-etl/src/main/resources/jython/HiveLoad.py
+++ b/metadata-etl/src/main/resources/jython/HiveLoad.py
@@ -134,7 +134,61 @@ class HiveLoad:
         , db_id = {db_id}
         ;
 
-        ANALYZE TABLE stg_dict_field_detail;
+
+       ANALYZE TABLE stg_dict_field_detail;
+
+       insert into dict_field_detail (
+          dataset_id, fields_layout_id, sort_id, parent_sort_id, parent_path,
+          field_name, namespace, data_type, data_size, is_nullable, default_value,
+           modified
+        )
+        select
+          d.id, 0, sf.sort_id, sf.parent_sort_id, sf.parent_path,
+          sf.field_name, sf.namespace, sf.data_type, sf.data_size, sf.is_nullable, sf.default_value, now()
+        from stg_dict_field_detail sf join dict_dataset d
+          on sf.urn = d.urn
+             left join dict_field_detail t
+          on d.id = t.dataset_id
+         and sf.field_name = t.field_name
+         and sf.parent_path = t.parent_path
+        where db_id = {db_id} and t.field_id is null
+        ;
+
+        analyze table dict_field_detail;
+
+
+        -- delete old record in stagging
+        delete from stg_dict_dataset_field_comment where db_id = {db_id};
+
+        -- insert
+        insert into stg_dict_dataset_field_comment
+        select t.field_id field_id, fc.id comment_id,  d.id dataset_id, {db_id}
+                from stg_dict_field_detail sf join dict_dataset d
+                  on sf.urn = d.urn
+                      join field_comments fc
+                  on sf.description = fc.comment
+                      join dict_field_detail t
+                  on d.id = t.dataset_id
+                 and sf.field_name = t.field_name
+                 and sf.parent_path = t.parent_path
+        where sf.db_id = {db_id};
+
+        -- have default comment, insert it set default to 0
+        insert ignore into dict_dataset_field_comment
+        select field_id, comment_id, dataset_id, 0 is_default from stg_dict_dataset_field_comment where field_id in (
+          select field_id from dict_dataset_field_comment
+          where field_id in (select field_id from stg_dict_dataset_field_comment)
+        and is_default = 1 ) and db_id = {db_id};
+
+
+        -- doesn't have this comment before, insert into it and set as default
+        insert ignore into dict_dataset_field_comment
+        select sd.field_id, sd.comment_id, sd.dataset_id, 1 from stg_dict_dataset_field_comment sd
+        left join dict_dataset_field_comment d
+        on d.field_id = sd.field_id
+         and d.comment_id = sd.comment_id
+        where d.comment_id is null
+        and sd.db_id = {db_id};
 
         """.format(source_file=self.input_field_file, db_id=self.db_id)
 

--- a/metadata-etl/src/main/resources/jython/TeradataLoad.py
+++ b/metadata-etl/src/main/resources/jython/TeradataLoad.py
@@ -220,6 +220,39 @@ class TeradataLoad:
         where db_id = {db_id} and f.field_id is null;
 
         analyze table dict_field_detail;
+
+        -- delete old record in stagging
+        delete from stg_dict_dataset_field_comment where db_id = {db_id};
+
+        -- insert
+        insert into stg_dict_dataset_field_comment
+        select t.field_id field_id, fc.id comment_id,  d.id dataset_id, {db_id}
+                from stg_dict_field_detail sf join dict_dataset d
+                  on sf.urn = d.urn
+                      join field_comments fc
+                  on sf.description = fc.comment
+                      join dict_field_detail t
+                  on d.id = t.dataset_id
+                 and sf.field_name = t.field_name
+                 and sf.parent_path = t.parent_path
+        where sf.db_id = {db_id};
+
+        -- have default comment, insert it set default to 0
+        insert ignore into dict_dataset_field_comment
+        select field_id, comment_id, dataset_id, 0 is_default from stg_dict_dataset_field_comment where field_id in (
+          select field_id from dict_dataset_field_comment
+          where field_id in (select field_id from stg_dict_dataset_field_comment)
+        and is_default = 1 ) and db_id = {db_id};
+
+
+        -- doesn't have this comment before, insert into it and set as default
+        insert ignore into dict_dataset_field_comment
+        select sd.field_id, sd.comment_id, sd.dataset_id, 1 from stg_dict_dataset_field_comment sd
+        left join dict_dataset_field_comment d
+        on d.field_id = sd.field_id
+         and d.comment_id = sd.comment_id
+        where d.comment_id is null
+        and sd.db_id = {db_id};
         '''.format(source_file=self.input_field_file, db_id=self.db_id)
 
     for state in load_cmd.split(";"):

--- a/metadata-etl/src/test/java/metadata/etl/LaunchJython.java
+++ b/metadata-etl/src/test/java/metadata/etl/LaunchJython.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package metadata.etl;
+
+import java.io.File;
+import java.net.URL;
+import org.python.core.PyString;
+import org.python.core.PySystemState;
+import org.python.util.PythonInterpreter;
+
+
+/**
+ * Created by zsun on 3/9/16.
+ */
+public class LaunchJython {
+
+  public PythonInterpreter setUp() {
+    PySystemState sys = new PySystemState();
+    addJythonToPath(sys);
+    return new PythonInterpreter(null, sys);
+  }
+
+  /**
+   * Need to add the jython scripts in main/resource/jython into the PySystemState
+   * Note the jython resource folder name in test must be different from the one in main,
+   * otherwise it will overwrite the path.
+   * @param pySystemState
+   */
+  private void addJythonToPath(PySystemState pySystemState) {
+    URL url = getClass().getClassLoader().getResource("jython");
+    if (url != null) {
+      File file = new File(url.getFile());
+      String path = file.getPath();
+      System.out.println(path);
+      if (path.startsWith("file:")) {
+        path = path.substring(5);
+      }
+      pySystemState.path.append(new PyString(path.replace("!", "")));
+    }
+  }
+}

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hdfs/HdfsMetadataEtlTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hdfs/HdfsMetadataEtlTest.java
@@ -26,7 +26,7 @@ public class HdfsMetadataEtlTest {
   @BeforeTest
   public void setUp()
     throws Exception {
-    ds = new HdfsMetadataEtl(21, 0L);
+    ds = new HdfsMetadataEtl(2, 0L);
   }
 
   @Test(groups = {"needConfig"})

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hive/AvroColumnParserTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hive/AvroColumnParserTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package metadata.etl.dataset.hive;
+
+import java.io.InputStream;
+import metadata.etl.LaunchJython;
+import org.python.util.PythonInterpreter;
+import org.testng.annotations.Test;
+
+
+public class AvroColumnParserTest {
+
+  @Test
+  public void avroTest() {
+
+    LaunchJython l = new LaunchJython();
+    PythonInterpreter interpreter = l.setUp();
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream("jython-test/AvroColumnParserTest.py");
+    interpreter.execfile(inputStream);
+
+  }
+}

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveColumnParserTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveColumnParserTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package metadata.etl.dataset.hive;
+
+import java.io.InputStream;
+import metadata.etl.LaunchJython;
+import org.python.util.PythonInterpreter;
+import org.testng.annotations.Test;
+
+
+/**
+ * Created by zsun on 3/9/16.
+ */
+public class HiveColumnParserTest {
+
+  @Test
+  public void hiveColumnParserTest() {
+
+    LaunchJython l = new LaunchJython();
+    PythonInterpreter interpreter = l.setUp();
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream("jython-test/HiveColumnParserTest.py");
+    interpreter.execfile(inputStream);
+
+  }
+}

--- a/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveTest.java
+++ b/metadata-etl/src/test/java/metadata/etl/dataset/hive/HiveTest.java
@@ -26,7 +26,7 @@ public class HiveTest {
   @BeforeTest
   public void setUp()
     throws Exception {
-    hm = new HiveMetadataEtl(0, 0L);
+    hm = new HiveMetadataEtl(3, 0L);
   }
 
   @Test

--- a/metadata-etl/src/test/resources/jython-test/AvroColumnParserTest.py
+++ b/metadata-etl/src/test/resources/jython-test/AvroColumnParserTest.py
@@ -1,0 +1,104 @@
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+__author__ = 'zsun'
+import unittest
+import json
+from AvroColumnParser import AvroColumnParser
+
+sample_avro_with_complex_field ='''
+  {
+    "doc": "sample avro array",
+    "fields": [{
+      "doc": "doc1",
+      "name": "emailAddresses",
+      "type": {
+        "items": {
+          "doc": "Stores details about an email address that a user has associated with their account.",
+          "fields": [{
+            "doc": "The email address, e.g. `foo@example.com`",
+            "name": "address",
+            "type": "string"
+          }, {
+            "default": false,
+            "doc": "true if the user has clicked the link in a confirmation email to this address.",
+            "name": "verified",
+            "type": "boolean"
+          }, {
+            "name": "dateAdded",
+            "type": "long"
+          }, {
+            "name": "dateBounced",
+            "type": ["null", "long"]
+          }, {
+            "name": "nestedField",
+            "type": {
+              "type":"record",
+              "items": {
+                "fields": [{
+                "name": "nested1",
+                "type": "string"
+                }]
+              }
+            }
+          }],
+          "name": "EmailAddress",
+          "type": "record"
+        },
+        "type": "array"
+      }
+    },
+    {
+  		"doc": "this is a enum type",
+  		"type": "enum",
+  		"name": "Suit",
+  		"symbols": ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+
+  	}
+    ],
+    "name": "User",
+    "namespace": "com.example.avro",
+    "type": "record",
+    "uri": "hdfs:///data/sample1"
+  }
+  '''
+# output value : List[List[]] : uri, sort_id, parent_sort_id, prefix, column_name, data_type, is_nullable, default_value, data_size, namespace, description
+expect_result = [[u'hdfs:///data/sample1', 1, 0, '', u'emailAddresses', u'array', 'N', '', None, '', u'doc1'],
+ [u'hdfs:///data/sample1', 2, 1, u'emailAddresses', u'address', u'string', 'N', '', None, '', u'The email address, e.g. `foo@example.com`'],
+ [u'hdfs:///data/sample1', 3, 1, u'emailAddresses', u'verified', u'boolean', 'N', False, None, '', u'true if the user has clicked the link in a confirmation email to this address.'],
+ [u'hdfs:///data/sample1', 4, 1, u'emailAddresses', u'dateAdded', u'long', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 5, 1, u'emailAddresses', u'dateBounced', u'long', 'Y', '', None, '', ''],
+ [u'hdfs:///data/sample1', 6, 1, u'emailAddresses', u'nestedField', u'record', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 7, 6, u'emailAddresses.nestedField', u'nested1', u'string', 'N', '', None, '', ''],
+ [u'hdfs:///data/sample1', 8, 0, '', u'Suit', u'enum', 'N', '', None, '', u'this is a enum type']]
+
+
+class AvroColumnParserTest(unittest.TestCase):
+
+  def test_parse_complex(self):
+    avro_json = json.loads(sample_avro_with_complex_field)
+    acp = AvroColumnParser(avro_json)
+    result = acp.get_column_list_result()
+    self.assertEqual(result, expect_result)
+
+
+  def runTest(self):
+    pass
+
+
+if __name__ == '__main__':
+
+  a = AvroColumnParserTest()
+  a.test_parse_complex()
+

--- a/metadata-etl/src/test/resources/jython-test/HiveColumnParserTest.py
+++ b/metadata-etl/src/test/resources/jython-test/HiveColumnParserTest.py
@@ -1,0 +1,105 @@
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+import unittest
+import json
+from HiveColumnParser import HiveColumnParser
+import pprint
+
+complex_type_kw = ['array', 'map', 'struct', 'uniontype']
+
+sample_hive_schema ='''
+
+  '''
+
+sample_hive_schema_complex_types = "Complex Types"
+
+expect_result = []
+
+sample_input_simple = '{"fields" : [{"Comment": "document of field test", "TypeName": "struct<resultid:decimal(1,2),result:string>", "ColumnName": "test"}]}'
+
+# output value : List[List[]] : uri, sort_id, parent_sort_id, prefix, column_name, data_type, is_nullable, default_value, data_size, namespace, description
+
+expect_result_simple = [['hdfs:///test/urn', 1, 0, '', u'test', u'struct', None, None, None, None, u'document of field test'],
+                 ['hdfs:///test/urn', 2, 1, u'test', u'resultid', u'decimal(1,2)', None, None, None, None, None],
+                 ['hdfs:///test/urn', 3, 1, u'test', u'result', u'string', None, None, None, None, None]]
+
+
+sample_input_complex = '''
+{"fields" : [{"Comment": null, "TypeName": "struct<advancedfields:map<string,string>,\
+facetvaluemap:map<string,string> comment 'MFC-J475',\
+searchcomponents:array<struct<componenttype:string comment 'Work Smart Series',\
+position:string,results:struct<numsearchresults:decimal(15,2),results:array<struct\
+<resultid:bigint,result:varchar(10),resulttype:string,resultindex:int,relevance:float,\
+additionalinfo:map<string,string>>>> comment 'com.brother.innobella.printer',\
+additionalinfo:map<string,string>>>,searchtime:int comment '1~1024',\
+extratag:uniontype<int,double,struct<aaa:int,bbb:char>,array<varchar>> comment '*',\
+querytagger:string>", "ColumnName": "testcomplex"}]}
+'''
+
+expect_result_complex = [['hdfs:///test/urn', 1, 0, '', u'testcomplex', u'struct', None, None, None, None, None],
+['hdfs:///test/urn', 2, 1, u'testcomplex', u'advancedfields', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 3, 1, u'testcomplex', u'facetvaluemap', u'map', None, None, None, None, u'MFC-J475'],
+['hdfs:///test/urn', 4, 1, u'testcomplex', u'searchcomponents', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 5, 4, u'testcomplex.searchcomponents', u'componenttype', u'string', None, None, None, None, u'Work Smart Series'],
+['hdfs:///test/urn', 6, 4, u'testcomplex.searchcomponents', u'position', u'string', None, None, None, None, None],
+['hdfs:///test/urn', 7, 4, u'testcomplex.searchcomponents', u'results', u'struct', None, None, None, None, u'com.brother.innobella.printer'],
+['hdfs:///test/urn', 8, 7, u'testcomplex.searchcomponents.results', u'numsearchresults', u'decimal(15,2)', None, None, None, None, None],
+['hdfs:///test/urn', 9, 7, u'testcomplex.searchcomponents.results', u'results', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 10, 9, u'testcomplex.searchcomponents.results.results', u'resultid', u'bigint', None, None, None, None, None],
+['hdfs:///test/urn', 11, 9, u'testcomplex.searchcomponents.results.results', u'result', u'varchar(10)', None, None, None, None, None],
+['hdfs:///test/urn', 12, 9, u'testcomplex.searchcomponents.results.results', u'resulttype', u'string', None, None, None, None, None],
+['hdfs:///test/urn', 13, 9, u'testcomplex.searchcomponents.results.results', u'resultindex', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 14, 9, u'testcomplex.searchcomponents.results.results', u'relevance', u'float', None, None, None, None, None],
+['hdfs:///test/urn', 15, 9, u'testcomplex.searchcomponents.results.results', u'additionalinfo', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 16, 4, u'testcomplex.searchcomponents', u'additionalinfo', u'map', None, None, None, None, None],
+['hdfs:///test/urn', 17, 1, u'testcomplex', u'searchtime', u'int', None, None, None, None, u'1~1024'],
+['hdfs:///test/urn', 18, 1, u'testcomplex', u'extratag', u'uniontype', None, None, None, None, u'*'],
+['hdfs:///test/urn', 19, 18, u'testcomplex.extratag', 'type0', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 20, 18, u'testcomplex.extratag', 'type1', u'double', None, None, None, None, None],
+['hdfs:///test/urn', 21, 18, u'testcomplex.extratag', 'type2', u'struct', None, None, None, None, None],
+['hdfs:///test/urn', 22, 21, u'testcomplex.extratag.type2', u'aaa', u'int', None, None, None, None, None],
+['hdfs:///test/urn', 23, 21, u'testcomplex.extratag.type2', u'bbb', u'char', None, None, None, None, None],
+['hdfs:///test/urn', 24, 18, u'testcomplex.extratag', 'type3', u'array', None, None, None, None, None],
+['hdfs:///test/urn', 25, 1, u'testcomplex', u'querytagger', u'string', None, None, None, None, None]]
+class HiveColumnParserTest(unittest.TestCase):
+
+  def test_parse_simple(self):
+    schema = json.loads(sample_input_simple)
+    hcp = HiveColumnParser(schema, urn = 'hdfs:///test/urn')
+
+    #pprint.pprint(hcp.column_type_dict)
+
+    self.assertEqual(hcp.column_type_list, expect_result_simple)
+
+  def test_parse_complex(self):
+
+    schema = json.loads(sample_input_complex)
+    hcp = HiveColumnParser(schema, urn = 'hdfs:///test/urn')
+
+    #pprint.pprint(hcp.column_type_dict)
+
+    self.assertEqual(hcp.column_type_list,expect_result_complex)
+
+  def runTest(self):
+    pass
+
+
+if __name__ == '__main__':
+
+  a = HiveColumnParserTest()
+  a.test_parse_simple()
+  a.test_parse_complex()
+
+


### PR DESCRIPTION
* Add license header of last commit
* Add field comments ETL process
 * `dict_dataset_field_comment` is the mapping table store which field contain which comments
 * `dict_field_detail` have the field info
 * `field_comments` have the comments info
 * the ETL process is 
    1. raw info load into `stg_dict_field_detail` first, insert into `field_comments` and `dict_field_detail`
    2. delete old record of `stg_dict_dataset_field_comment` based on db_id
    3. insert into `stg_dict_dataset_field_comment` 
    4. compare and insert into final table
      * if the field already have a default comment, insert ignore the new comment with default set to 0
      * if the field doesn't have this comments before, insert ignore the new comment with default set to 1. ( notice if we already insert this record in the first step, this new insert will abort based on primary key)
   
* Fix API bug #73 
* Add index on `field_comments` table to improve ETL efficiency.