### PR TITLE
fix the invalid json error for schema

### DIFF
--- a/web/public/javascripts/routers/datasets.js
+++ b/web/public/javascripts/routers/datasets.js
@@ -173,6 +173,10 @@ App.DatasetRoute = Ember.Route.extend({
         source = params.source;
         urn = params.urn;
         datasetController.set("detailview", true);
+        if (params.originalSchema)
+        {
+          Ember.set(params, 'schema', params.originalSchema);
+        }
         controller.set('model', params);
 
       }

--- a/web/public/javascripts/routers/search.js
+++ b/web/public/javascripts/routers/search.js
@@ -68,6 +68,7 @@ App.SearchRoute = Ember.Route.extend({
                 for(var index = 0; index < result.data.length; index++) {
                     var schema = result.data[index].schema;
                     if (schema) {
+                        result.data[index].originalSchema = result.data[index].schema;
                         highlightResults(result.data, index, keyword);
                     }
                 }


### PR DESCRIPTION
After search, in order to highlight the search keyword, we need change the schema content.
We need to reset the schema content to original before Ember go to detail page.