### PR TITLE
To avoid requiring the user to be logged into github, use https:

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Execute the [DDL files][DDL] to create the required repository tables in **where
 
 ### Build
 
-1. Get the source code: ```git clone git@github.com:linkedin/WhereHows.git```
+1. Get the source code: ```git clone https://github.com/linkedin/WhereHows.git```
 2. Put a few 3rd-party jar files to **metadata-etl/extralibs** directory. Some of these jar files may not be available in Maven Central or Artifactory. See [the download instrucitons][EXJAR] for more detail. ```cd WhereHows/metadata-etl/extralibs``` 
 3. Go back to the **WhereHows** root directory and build all the modules: ```gradle build```
 4. Go back to the **WhereHows** root directory and start the metadata ETL and API service: ```cd backend-service ; $PLAY_HOME/play run```


### PR DESCRIPTION
…rather than git.  A contributor would probably want the git: link, but someone just trying the software out won't want to have to do so from a computer with a github auth on it.