### PR TITLE
update DDL for job_execution_ext_reference tables for mysql 5.7.x

### DIFF
--- a/data-model/DDL/ETL_DDL/executor_metadata.sql
+++ b/data-model/DDL/ETL_DDL/executor_metadata.sql
@@ -441,7 +441,7 @@ CREATE TABLE stg_flow_owner_permission (
 CREATE TABLE job_execution_ext_reference ( 
 	app_id         	smallint(5) UNSIGNED COMMENT 'application id of the flow'  NOT NULL,
 	job_exec_id    	bigint(20) UNSIGNED COMMENT 'job execution id either inherit or generated'  NOT NULL,
-	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  NULL DEFAULT '0',
+	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  DEFAULT '0',
 	ext_ref_type	varchar(50) COMMENT 'YARN_JOB_ID, DB_SESSION_ID, PID, INFA_WORKFLOW_RUN_ID, CASSCADE_WORKFLOW_ID'  NOT NULL,
     ext_ref_sort_id smallint(6) COMMENT 'sort id 0..n within each ext_ref_type' NOT NULL DEFAULT '0',
 	ext_ref_id      varchar(100) COMMENT 'external reference id' NOT NULL,
@@ -470,7 +470,7 @@ CREATE INDEX idx_job_execution_ext_ref__ext_ref_id USING BTREE
 CREATE TABLE stg_job_execution_ext_reference ( 
 	app_id         	smallint(5) UNSIGNED COMMENT 'application id of the flow'  NOT NULL,
 	job_exec_id    	bigint(20) UNSIGNED COMMENT 'job execution id either inherit or generated'  NOT NULL,
-	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  NULL DEFAULT '0',
+	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  DEFAULT '0',
 	ext_ref_type	varchar(50) COMMENT 'YARN_JOB_ID, DB_SESSION_ID, PID, INFA_WORKFLOW_RUN_ID, CASSCADE_WORKFLOW_ID'  NOT NULL,
     ext_ref_sort_id smallint(6) COMMENT 'sort id 0..n within each ext_ref_type' NOT NULL DEFAULT '0',
 	ext_ref_id      varchar(100) COMMENT 'external reference id' NOT NULL,


### PR DESCRIPTION
Hello,
after last changes DDLs support MySQL 5.7.x, thanks a lot! Unfortunately, tables `job_execution_ext_reference` and `stg_job_execition_ext_reference` still having problems:

`ERROR 1171 (42000) at line 441 in file: 'ETL_DDL/executor_metadata.sql': All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead`

and

`ERROR 1171 (42000) at line 470 in file: 'ETL_DDL/executor_metadata.sql': All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead`.

I'm understand that this NULLs in definition should be removed or changed to NOT NULL. This PR assumes that it can be removed (this works with MySQL 5.7.10). If that is not the case please let me know to change. 

Kind regards,
Rafal Kluszczynski
