### PR TITLE
Fixing tree builder scripts when ES is not used

### DIFF
--- a/metadata-etl/src/main/resources/jython/DatasetTreeBuilder.py
+++ b/metadata-etl/src/main/resources/jython/DatasetTreeBuilder.py
@@ -12,14 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
-import sys
-from com.ziclix.python.sql import zxJDBC
-from wherehows.common import Constant
-from ElasticSearchIndex import ElasticSearchIndex
-from datetime import datetime
 import calendar
 import json
 import shutil
+import sys
+from com.ziclix.python.sql import zxJDBC
+from wherehows.common import Constant
+from datetime import datetime
+
+from jython.ElasticSearchIndex import ElasticSearchIndex
 
 
 class DatasetTreeBuilder:
@@ -79,10 +80,16 @@ class DatasetTreeBuilder:
     self.write_to_file()
 
 
+def saveTreeInElasticSearchIfApplicable(args):
+  es_url = args.get(Constant.WH_ELASTICSEARCH_URL_KEY, None)
+  es_port = args.get(Constant.WH_ELASTICSEARCH_PORT_KEY, None)
+  if es_url is not None and es_port is not None:
+    esi = ElasticSearchIndex(args)
+    d = datetime.utcnow()
+    unixtime = calendar.timegm(d.utctimetuple())
+    esi.update_dataset(unixtime)
+
 if __name__ == "__main__":
   d = DatasetTreeBuilder(sys.argv[1])
   d.run()
-  esi = ElasticSearchIndex(sys.argv[1])
-  d = datetime.utcnow()
-  unixtime = calendar.timegm(d.utctimetuple())
-  esi.update_dataset(unixtime)
+  saveTreeInElasticSearchIfApplicable(sys.argv[1])

--- a/metadata-etl/src/main/resources/jython/DatasetTreeBuilder.py
+++ b/metadata-etl/src/main/resources/jython/DatasetTreeBuilder.py
@@ -83,7 +83,7 @@ class DatasetTreeBuilder:
 def saveTreeInElasticSearchIfApplicable(args):
   es_url = args.get(Constant.WH_ELASTICSEARCH_URL_KEY, None)
   es_port = args.get(Constant.WH_ELASTICSEARCH_PORT_KEY, None)
-  if es_url is not None and es_port is not None:
+  if es_url and es_port:
     esi = ElasticSearchIndex(args)
     d = datetime.utcnow()
     unixtime = calendar.timegm(d.utctimetuple())

--- a/metadata-etl/src/main/resources/jython/FlowTreeBuilder.py
+++ b/metadata-etl/src/main/resources/jython/FlowTreeBuilder.py
@@ -86,7 +86,7 @@ class FlowTreeBuilder:
 def saveTreeInElasticSearchIfApplicable(args):
   es_url = args.get(Constant.WH_ELASTICSEARCH_URL_KEY, None)
   es_port = args.get(Constant.WH_ELASTICSEARCH_PORT_KEY, None)
-  if es_url is not None and es_port is not None:
+  if es_url and es_port:
     esi = ElasticSearchIndex(args)
     d = datetime.utcnow()
     unixtime = calendar.timegm(d.utctimetuple())

--- a/metadata-etl/src/main/resources/jython/FlowTreeBuilder.py
+++ b/metadata-etl/src/main/resources/jython/FlowTreeBuilder.py
@@ -12,14 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
-import sys
-from com.ziclix.python.sql import zxJDBC
-from wherehows.common import Constant
-from ElasticSearchIndex import ElasticSearchIndex
-from datetime import datetime
 import calendar
 import json
 import shutil
+import sys
+from com.ziclix.python.sql import zxJDBC
+from datetime import datetime
+from wherehows.common import Constant
+
+from jython.ElasticSearchIndex import ElasticSearchIndex
 
 
 class FlowTreeBuilder:
@@ -82,10 +83,16 @@ class FlowTreeBuilder:
     self.write_to_file()
 
 
+def saveTreeInElasticSearchIfApplicable(args):
+  es_url = args.get(Constant.WH_ELASTICSEARCH_URL_KEY, None)
+  es_port = args.get(Constant.WH_ELASTICSEARCH_PORT_KEY, None)
+  if es_url is not None and es_port is not None:
+    esi = ElasticSearchIndex(args)
+    d = datetime.utcnow()
+    unixtime = calendar.timegm(d.utctimetuple())
+    esi.update_flow_jobs(unixtime)
+
 if __name__ == "__main__":
   ftb = FlowTreeBuilder(sys.argv[1])
   ftb.run()
-  esi = ElasticSearchIndex(sys.argv[1])
-  d = datetime.utcnow()
-  unixtime = calendar.timegm(d.utctimetuple())
-  esi.update_flow_jobs(unixtime)
+  saveTreeInElasticSearchIfApplicable(sys.argv[1])


### PR DESCRIPTION
Hello, 
after adding ES support for search, Jython scripts building trees have been broken. Here is the fix and also if url or port for ES is not configured in *wh_property* table, pushing data to ES is skipped (our case at the moment).

Could you review this PR?

Kind regards,
Rafal Kluszczynski