### PR TITLE
Fix problems with legacy views and trailing spaces in Teradata ETL

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 16 14:53:29 CEST 2016
+#Fri Jun 10 19:56:47 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/metadata-etl/src/main/java/metadata/etl/dataset/oracle/OracleMetadataEtl.java
+++ b/metadata-etl/src/main/java/metadata/etl/dataset/oracle/OracleMetadataEtl.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package metadata.etl.dataset.oracle;
+
+import metadata.etl.EtlJob;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Changed by aig on 2016-06-10
+ */
+public class OracleMetadataEtl extends EtlJob {
+
+    /**
+     * Constructor used in test
+     * @param dbId
+     * @param whExecId
+     */
+    @Deprecated
+    public OracleMetadataEtl(int dbId, long whExecId) {
+        super(null, dbId, whExecId);
+    }
+
+    public OracleMetadataEtl(int dbId, long whExecId, Properties prop) {
+        super(null, dbId, whExecId, prop);
+    }
+
+    @Override
+    public void extract()
+            throws Exception {
+        logger.info("In oracle metadata ETL, launch extract jython scripts");
+        InputStream inputStream = classLoader.getResourceAsStream("jython/OracleExtract.py");
+        interpreter.execfile(inputStream);
+        inputStream.close();
+    }
+
+    @Override
+    public void transform()
+            throws Exception {
+        logger.info("In oracle metadata ETL, launch transform jython scripts");
+        InputStream inputStream = classLoader.getResourceAsStream("jython/OracleTransform.py");
+        interpreter.execfile(inputStream);
+        inputStream.close();
+    }
+
+    @Override
+    public void load()
+            throws Exception {
+        logger.info("In oracle metadata ETL, launch load jython scripts");
+        InputStream inputStream = classLoader.getResourceAsStream("jython/OracleLoad.py");
+        interpreter.execfile(inputStream);
+        logger.info("Oracle dataset ETL finished");
+        inputStream.close();
+    }
+
+}

--- a/metadata-etl/src/main/java/metadata/etl/models/EtlJobFactory.java
+++ b/metadata-etl/src/main/java/metadata/etl/models/EtlJobFactory.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 import metadata.etl.EtlJob;
 import metadata.etl.dataset.hdfs.HdfsMetadataEtl;
 import metadata.etl.dataset.hive.HiveMetadataEtl;
+import metadata.etl.dataset.oracle.OracleMetadataEtl;
 import metadata.etl.dataset.teradata.TeradataMetadataEtl;
 import metadata.etl.elasticsearch.ElasticSearchBuildIndexETL;
 import metadata.etl.git.GitMetadataEtl;
@@ -43,6 +44,8 @@ public class EtlJobFactory {
         return new HdfsMetadataEtl(refId, whExecId, properties);
       case TERADATA_DATASET_METADATA_ETL:
         return new TeradataMetadataEtl(refId, whExecId, properties);
+      case ORACLE_DATASET_METADATA_ETL:
+        return new OracleMetadataEtl(refId, whExecId, properties);
       case AZKABAN_LINEAGE_METADATA_ETL:
         return new AzLineageMetadataEtl(refId, whExecId, properties);
       case HADOOP_DATASET_OWNER_ETL:

--- a/metadata-etl/src/main/java/metadata/etl/models/EtlJobName.java
+++ b/metadata-etl/src/main/java/metadata/etl/models/EtlJobName.java
@@ -27,6 +27,7 @@ public enum EtlJobName {
   GIT_MEDATA_ETL(EtlType.VCS, RefIdType.APP),
   HIVE_DATASET_METADATA_ETL(EtlType.DATASET, RefIdType.DB),
   ELASTICSEARCH_EXECUTION_INDEX_ETL(EtlType.OPERATION, RefIdType.APP),
+  ORACLE_DATASET_METADATA_ETL(EtlType.DATASET, RefIdType.DB)
   ;
 
   EtlType etlType;

--- a/metadata-etl/src/main/resources/jython/OracleExtract.py
+++ b/metadata-etl/src/main/resources/jython/OracleExtract.py
@@ -12,40 +12,49 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
+# Changed by aig on 2016-06-10
+
 from com.ziclix.python.sql import zxJDBC
 import sys, os
 from wherehows.common import Constant
 from org.slf4j import LoggerFactory
 
-class TeradataExtract:
+class OracleExtract:
     def __init__(self):
         self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
+
+    def run(self, database_name, table_name, schema_output_file, sample_output_file, sample=True):
+        """
+        The entrance of the class, extract schema and sample data
+        Notice the database need to have a order that the databases have more info (DWH_STG) should be scaned first.
+        :param database_name:
+        :param table_name:
+        :param schema_output_file:
+        :return:
+        """
+        cur = self.conn_or.cursor()
+        cur.close()
 
 if __name__ == "__main__":
     args = sys.argv[1]
 
     # connection
-    username = args[Constant.TD_DB_USERNAME_KEY]
-    password = args[Constant.TD_DB_PASSWORD_KEY]
-    JDBC_DRIVER = args[Constant.TD_DB_DRIVER_KEY]
-    JDBC_URL = args[Constant.TD_DB_URL_KEY]
+    username = args[Constant.OR_DB_USERNAME_KEY]
+    password = args[Constant.OR_DB_PASSWORD_KEY]
+    JDBC_DRIVER = args[Constant.OR_DB_DRIVER_KEY]
+    JDBC_URL = args[Constant.OR_DB_URL_KEY]
 
-    e = TeradataExtract()
-    e.conn_td = zxJDBC.connect(JDBC_URL, username, password, JDBC_DRIVER)
+    e = OracleExtract()
+    e.conn_or = zxJDBC.connect(JDBC_URL, username, password, JDBC_DRIVER)
     do_sample = True
-    if Constant.TD_LOAD_SAMPLE in args:
-        do_sample = bool(args[Constant.TD_LOAD_SAMPLE])
+    if Constant.OR_LOAD_SAMPLE in args:
+        do_sample = bool(args[Constant.OR_LOAD_SAMPLE])
     try:
-        e.conn_td.cursor().execute(
-            "SET QUERY_BAND = 'script=%s; pid=%d; ' FOR SESSION;" % ('TeradataExtract.py', os.getpid()))
-        e.conn_td.commit()
-        e.log_file = args[Constant.TD_LOG_KEY]
-        e.databases = args[Constant.TD_TARGET_DATABASES_KEY].split(',')
-        e.default_database = args[Constant.TD_DEFAULT_DATABASE_KEY]
-        index_type = {'P': 'Primary Index', 'K': 'Primary Key', 'S': 'Secondary Index', 'Q': 'Partitioned Primary Index',
-                      'J': 'Join Index', 'U': 'Unique Index'}
+        e.log_file = args[Constant.OR_LOG_KEY]
+        e.databases = args[Constant.OR_TARGET_DATABASES_KEY].split(',')
+        e.default_database = args[Constant.OR_DEFAULT_DATABASE_KEY]
 
-        e.run(None, None, args[Constant.TD_SCHEMA_OUTPUT_KEY], args[Constant.TD_SAMPLE_OUTPUT_KEY], sample=do_sample)
+        e.run(None, None, args[Constant.OR_SCHEMA_OUTPUT_KEY], args[Constant.OR_SAMPLE_OUTPUT_KEY], sample=do_sample)
     finally:
-        e.conn_td.close()
+        e.conn_or.close()
 

--- a/metadata-etl/src/main/resources/jython/OracleExtract.py
+++ b/metadata-etl/src/main/resources/jython/OracleExtract.py
@@ -1,0 +1,51 @@
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+from com.ziclix.python.sql import zxJDBC
+import sys, os
+from wherehows.common import Constant
+from org.slf4j import LoggerFactory
+
+class TeradataExtract:
+    def __init__(self):
+        self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
+
+if __name__ == "__main__":
+    args = sys.argv[1]
+
+    # connection
+    username = args[Constant.TD_DB_USERNAME_KEY]
+    password = args[Constant.TD_DB_PASSWORD_KEY]
+    JDBC_DRIVER = args[Constant.TD_DB_DRIVER_KEY]
+    JDBC_URL = args[Constant.TD_DB_URL_KEY]
+
+    e = TeradataExtract()
+    e.conn_td = zxJDBC.connect(JDBC_URL, username, password, JDBC_DRIVER)
+    do_sample = True
+    if Constant.TD_LOAD_SAMPLE in args:
+        do_sample = bool(args[Constant.TD_LOAD_SAMPLE])
+    try:
+        e.conn_td.cursor().execute(
+            "SET QUERY_BAND = 'script=%s; pid=%d; ' FOR SESSION;" % ('TeradataExtract.py', os.getpid()))
+        e.conn_td.commit()
+        e.log_file = args[Constant.TD_LOG_KEY]
+        e.databases = args[Constant.TD_TARGET_DATABASES_KEY].split(',')
+        e.default_database = args[Constant.TD_DEFAULT_DATABASE_KEY]
+        index_type = {'P': 'Primary Index', 'K': 'Primary Key', 'S': 'Secondary Index', 'Q': 'Partitioned Primary Index',
+                      'J': 'Join Index', 'U': 'Unique Index'}
+
+        e.run(None, None, args[Constant.TD_SCHEMA_OUTPUT_KEY], args[Constant.TD_SAMPLE_OUTPUT_KEY], sample=do_sample)
+    finally:
+        e.conn_td.close()
+

--- a/metadata-etl/src/main/resources/jython/OracleLoad.py
+++ b/metadata-etl/src/main/resources/jython/OracleLoad.py
@@ -1,0 +1,72 @@
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+# Changed by aig on 2016-06-10
+
+import sys
+from com.ziclix.python.sql import zxJDBC
+from wherehows.common import Constant
+from org.slf4j import LoggerFactory
+
+
+class OracleLoad:
+    def __init__(self):
+        self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
+
+    def load_metadata(self):
+        cursor = self.conn_mysql.cursor()
+        cursor.close()
+
+    def load_field(self):
+        cursor = self.conn_mysql.cursor()
+        cursor.close()
+
+    def load_sample(self):
+        cursor = self.conn_mysql.cursor()
+        cursor.close()
+
+
+if __name__ == "__main__":
+    args = sys.argv[1]
+
+    l = OracleLoad()
+
+    # set up connection
+    username = args[Constant.WH_DB_USERNAME_KEY]
+    password = args[Constant.WH_DB_PASSWORD_KEY]
+    JDBC_DRIVER = args[Constant.WH_DB_DRIVER_KEY]
+    JDBC_URL = args[Constant.WH_DB_URL_KEY]
+
+    l.input_file = args[Constant.OR_METADATA_KEY]
+    l.input_field_file = args[Constant.OR_FIELD_METADATA_KEY]
+    l.input_sampledata_file = args[Constant.OR_SAMPLE_OUTPUT_KEY]
+
+    do_sample = True # default load sample
+    if Constant.OR_LOAD_SAMPLE in args:
+        do_sample = bool(args[Constant.OR_LOAD_SAMPLE])
+    l.db_id = args[Constant.DB_ID_KEY]
+    l.wh_etl_exec_id = args[Constant.WH_EXEC_ID_KEY]
+    l.conn_mysql = zxJDBC.connect(JDBC_URL, username, password, JDBC_DRIVER)
+
+    if Constant.INNODB_LOCK_WAIT_TIMEOUT in args:
+        lock_wait_time = args[Constant.INNODB_LOCK_WAIT_TIMEOUT]
+        l.conn_mysql.cursor().execute("SET innodb_lock_wait_timeout = %s;" % lock_wait_time)
+
+    try:
+        l.load_metadata()
+        l.load_field()
+        if do_sample:
+            l.load_sample()
+    finally:
+        l.conn_mysql.close()

--- a/metadata-etl/src/main/resources/jython/OracleTransform.py
+++ b/metadata-etl/src/main/resources/jython/OracleTransform.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+# Changed by aig on 2016-06-10
+
+import sys, os
+from org.slf4j import LoggerFactory
+
+
+class OracleTransform:
+    def __init__(self):
+        self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
+
+if __name__ == "__main__":
+    args = sys.argv[1]
+    t = OracleTransform()
+    t.log_file = args['oracle.log']
+

--- a/wherehows-common/src/main/java/wherehows/common/Constant.java
+++ b/wherehows-common/src/main/java/wherehows/common/Constant.java
@@ -15,6 +15,7 @@ package wherehows.common;
 
 /**
  * Created by zsun on 9/29/15.
+ * Changed by aig on 2016-06-10.
  */
 public class Constant {
 
@@ -67,6 +68,29 @@ public class Constant {
 
   /** Optional. The property_name field in wh_etl_job_property table. Set innodb_lock_wait_timeout for mysql */
   public static final String INNODB_LOCK_WAIT_TIMEOUT = "innodb_lock_wait_timeout";
+
+  // Oracle
+  /** The property_name field in wh_etl_job_property table. Oracle connection info */
+  public static final String OR_DB_URL_KEY = "oracle.db.jdbc.url";
+  public static final String OR_DB_USERNAME_KEY = "oracle.db.username";
+  public static final String OR_DB_PASSWORD_KEY = "oracle.db.password";
+  public static final String OR_DB_DRIVER_KEY = "oracle.db.driver";
+  /** The property_name field in wh_etl_job_property table. Oracle metadata raw interim file store location */
+  public static final String OR_METADATA_KEY = "oracle.metadata";
+  /** The property_name field in wh_etl_job_property table. Oracle field metadata interim file store location */
+  public static final String OR_FIELD_METADATA_KEY = "oracle.field_metadata";
+  /** The property_name field in wh_etl_job_property table. Oracle schema interim file store location */
+  public static final String OR_SCHEMA_OUTPUT_KEY = "oracle.schema_output";
+  /** The property_name field in wh_etl_job_property table. Oracle sample data interim file store location */
+  public static final String OR_SAMPLE_OUTPUT_KEY = "oracle.sample_output";
+  /** The property_name field in wh_etl_job_property table. Oracle log file store location */
+  public static final String OR_LOG_KEY = "oracle.log";
+  /** The property_name field in wh_etl_job_property table. Oracle databases to collect metadata */
+  public static final String OR_TARGET_DATABASES_KEY = "oracle.databases";
+  /** The property_name field in wh_etl_job_property table. Used for connecting */
+  public static final String OR_DEFAULT_DATABASE_KEY = "oracle.default_database";
+  /** Optional. The property_name field in wh_etl_job_property table. Decide whether load sample data or not */
+  public static final String OR_LOAD_SAMPLE = "oracle.load_sample";
 
   // Teradata
   /** The property_name field in wh_etl_job_property table. Teradata connection info */


### PR DESCRIPTION
Several problems in Teradata Metadata ETL with legacy views (without trailing V) and trailing spaces:

Error 6706: The string contains an untranslatable character due lack of long names support in legacy views.
ValueError "unconverted data remains" in convert_timestamp due to trailing spaces after timestamps.
