### PR TITLE
provide the dataset dependency api

### DIFF
--- a/backend-service/app/controllers/DatasetController.java
+++ b/backend-service/app/controllers/DatasetController.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import models.daos.DatasetDao;
 import models.utils.Urn;
 import org.springframework.dao.EmptyResultDataAccessException;
+import play.Logger;
 import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Controller;
@@ -83,6 +84,23 @@ public class DatasetController extends Controller {
       resultJson.put("message", "Dataset inserted!");
     } catch (Exception e) {
       e.printStackTrace();
+      resultJson.put("return_code", 404);
+      resultJson.put("error_message", e.getMessage());
+    }
+
+    return ok(resultJson);
+  }
+
+  @BodyParser.Of(BodyParser.Json.class)
+  public static Result getDatasetDependency() {
+    String queryString = request().getQueryString("query");
+    JsonNode input = Json.parse(queryString);
+    ObjectNode resultJson = Json.newObject();
+
+    try {
+      resultJson = DatasetDao.getDatasetDependency(input);
+    } catch (Exception e) {
+      Logger.error(e.getMessage());
       resultJson.put("return_code", 404);
       resultJson.put("error_message", e.getMessage());
     }

--- a/backend-service/app/models/daos/DatasetDao.java
+++ b/backend-service/app/models/daos/DatasetDao.java
@@ -17,9 +17,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+import play.libs.Json;
 import utils.JdbcUtil;
+import wherehows.common.schemas.DatasetDependencyRecord;
 import wherehows.common.schemas.DatasetRecord;
 import wherehows.common.utils.PartitionPatternMatcher;
 import wherehows.common.writers.DatabaseWriter;
@@ -33,6 +40,44 @@ public class DatasetDao {
 
   public static final String GET_DATASET_BY_ID = "SELECT * FROM dict_dataset WHERE id = :id";
   public static final String GET_DATASET_BY_URN = "SELECT * FROM dict_dataset WHERE urn = :urn";
+  public static final String DEFAULT_CLUSTER_NAME = "ltx1-holdem";
+  public static final String CLUSTER_NAME_KEY = "cluster_name";
+  public static final String DATASET_URI_KEY = "dataset_uri";
+  public static final String HIVE_PREFIX_WITH_3_SLASH = "hive:///";
+  public static final String DALIDS_PREFIX_WITH_3_SLASH = "dalids:///";
+  public static final String HIVE_PREFIX_WITH_2_SLASH = "hive://";
+  public static final String DALIDS_PREFIX_WITH_2_SLASH = "dalids://";
+
+  public static final String GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE = "SELECT c.object_dataset_id as dataset_id, " +
+          "d.urn, d.dataset_type, i.deployment_tier, i.data_center, i.server_cluster " +
+          "FROM cfg_object_name_map c JOIN dict_dataset d ON c.object_dataset_id = d.id " +
+          "LEFT JOIN dict_dataset_instance i ON c.object_dataset_id = i.dataset_id " +
+          "WHERE c.object_dataset_id is not null and  lower(c.object_name) = ? and lower(c.object_type) = ?";
+
+  public static final String GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE_AND_CLUSTER = "SELECT " +
+          "c.object_dataset_id as dataset_id, d.urn, d.dataset_type, " +
+          "i.deployment_tier, i.data_center, i.server_cluster " +
+          "FROM cfg_object_name_map c JOIN dict_dataset d ON c.object_dataset_id = d.id " +
+          "LEFT JOIN dict_dataset_instance i ON c.object_dataset_id = i.dataset_id " +
+          "WHERE c.object_dataset_id is not null and  lower(c.object_name) = ? " +
+          "and lower(c.object_type) = ? and lower(i.server_cluster) = ?";
+
+  public static final String GET_DATASET_ID_IN_MAP_TABLE = "SELECT c.object_dataset_id as dataset_id, " +
+          "d.urn, d.dataset_type, i.deployment_tier, i.data_center, i.server_cluster " +
+          "FROM cfg_object_name_map c JOIN dict_dataset d ON c.object_dataset_id = d.id " +
+          "LEFT JOIN dict_dataset_instance i ON c.object_dataset_id = i.dataset_id " +
+          "WHERE c.object_dataset_id is not null and  lower(c.object_name) = ?";
+
+  public static final String GET_DATASET_ID_IN_MAP_TABLE_WITH_CLUSTER = "SELECT c.object_dataset_id as dataset_id, " +
+          "d.urn, d.dataset_type, i.deployment_tier, i.data_center, i.server_cluster " +
+          "FROM cfg_object_name_map c JOIN dict_dataset d ON c.object_dataset_id = d.id " +
+          "LEFT JOIN dict_dataset_instance i ON c.object_dataset_id = i.dataset_id " +
+          "WHERE c.object_dataset_id is not null and  lower(c.object_name) = ? and lower(i.server_cluster) = ?";
+
+  private final static String GET_DATASET_DEPENDS_VIEW = "SELECT object_type, object_sub_type, " +
+          "object_name, map_phrase, is_identical_map, mapped_object_dataset_id, " +
+          "mapped_object_type,  mapped_object_sub_type, mapped_object_name " +
+          "FROM cfg_object_name_map WHERE object_dataset_id = ?";
 
   public static Map<String, Object> getDatasetById(int datasetId)
     throws SQLException {
@@ -72,5 +117,274 @@ public class DatasetDao {
     DatabaseWriter dw = new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, "dict_dataset");
     dw.append(record);
     dw.close();
+  }
+
+  public static int getDatasetDependencies(
+          Long datasetId,
+          String topologySortId,
+          int level,
+          List<DatasetDependencyRecord> depends)
+  {
+    if (depends == null)
+    {
+      depends = new ArrayList<DatasetDependencyRecord>();
+    }
+
+    List<Map<String, Object>> rows = null;
+    rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+            GET_DATASET_DEPENDS_VIEW,
+            datasetId);
+
+    int index = 1;
+    if (rows != null)
+    {
+      for (Map row : rows) {
+        DatasetDependencyRecord datasetDependencyRecord = new DatasetDependencyRecord();
+        datasetDependencyRecord.dataset_id = (Long) row.get("mapped_object_dataset_id");
+        String objectName = (String) row.get("mapped_object_name");
+        if (StringUtils.isNotBlank(objectName))
+        {
+          String[] info = objectName.split("/");
+          if (info != null && info.length == 3)
+          {
+            datasetDependencyRecord.database_name = info[1];
+            datasetDependencyRecord.table_name = info[2];
+          }
+        }
+        datasetDependencyRecord.level_from_root = level;
+        datasetDependencyRecord.type = (String) row.get("mapped_object_sub_type");
+        datasetDependencyRecord.ref_obj_location = objectName;
+        datasetDependencyRecord.ref_obj_type = (String) row.get("mapped_object_type");
+        datasetDependencyRecord.topology_sort_id = topologySortId + Integer.toString((index++)*100);
+        datasetDependencyRecord.next_level_dependency_count =
+                getDatasetDependencies(datasetDependencyRecord.dataset_id,
+                        datasetDependencyRecord.topology_sort_id,
+                        level + 1,
+                        depends);
+        depends.add(datasetDependencyRecord);
+      }
+      return rows.size();
+    }
+    else
+    {
+      return 0;
+    }
+  }
+  public static ObjectNode getDatasetDependency(JsonNode input)
+          throws Exception {
+
+    ObjectNode resultJson = Json.newObject();
+    String cluster = DEFAULT_CLUSTER_NAME;
+    String datasetUri = null;
+    String dbName = null;
+    String tableName = null;
+    boolean isHive = false;
+    boolean isDalids = false;
+    boolean hasCluster = false;
+    if (input != null && input.isContainerNode())
+    {
+      if (input.has(CLUSTER_NAME_KEY))
+      {
+        cluster = input.get(CLUSTER_NAME_KEY).asText();
+        hasCluster = true;
+      }
+      if (input.has(DATASET_URI_KEY))
+      {
+        datasetUri = input.get(DATASET_URI_KEY).asText();
+      }
+    }
+
+    if (StringUtils.isBlank(datasetUri))
+    {
+      resultJson.put("return_code", 404);
+      resultJson.put("message", "Wrong input format! Missing dataset uri");
+      return resultJson;
+    }
+
+    Integer index = -1;
+    if ((index = datasetUri.indexOf(HIVE_PREFIX_WITH_3_SLASH)) != -1)
+    {
+      isHive = true;
+      String tmp = datasetUri.substring(index + HIVE_PREFIX_WITH_3_SLASH.length());
+      String[] info = tmp.split("\\.|/");
+      if (info != null && info.length == 2)
+      {
+        dbName = info[0];
+        tableName = info[1];
+      }
+    }
+    else if ((index = datasetUri.indexOf(DALIDS_PREFIX_WITH_3_SLASH)) != -1)
+    {
+      isDalids = true;
+      String tmp = datasetUri.substring(index + DALIDS_PREFIX_WITH_3_SLASH.length());
+      String[] info = tmp.split("\\.|/");
+      if (info != null && info.length == 2)
+      {
+        dbName = info[0];
+        tableName = info[1];
+      }
+    }
+    else if ((index = datasetUri.indexOf(HIVE_PREFIX_WITH_2_SLASH)) != -1)
+    {
+      isHive = true;
+      String tmp = datasetUri.substring(index + HIVE_PREFIX_WITH_2_SLASH.length());
+      String[] info = tmp.split("\\.|/");
+      if (info != null && info.length == 3)
+      {
+        hasCluster = true;
+        cluster = info[0];
+        dbName = info[1];
+        tableName = info[2];
+      }
+    }
+    else if ((index = datasetUri.indexOf(DALIDS_PREFIX_WITH_2_SLASH)) != -1)
+    {
+      isDalids = true;
+      String tmp = datasetUri.substring(index + DALIDS_PREFIX_WITH_2_SLASH.length());
+      String[] info = tmp.split("\\.|/");
+      if (info != null && info.length == 3)
+      {
+        hasCluster = true;
+        cluster = info[0];
+        dbName = info[1];
+        tableName = info[2];
+      }
+    }
+    else if (datasetUri.indexOf('.') != -1)
+    {
+      index = datasetUri.indexOf(':');
+      String tmp = datasetUri;
+      if (index != -1)
+      {
+        cluster = datasetUri.substring(0, index);
+        tmp = datasetUri.substring(index + 1);
+        hasCluster = true;
+      }
+      String[] info = tmp.split("\\.|/");
+      if (info != null && info.length == 2)
+      {
+        dbName = info[0];
+        tableName = info[1];
+      }
+    }
+
+    if (StringUtils.isBlank(cluster) || StringUtils.isBlank(dbName) || StringUtils.isBlank(tableName))
+    {
+      resultJson.put("return_code", 404);
+      resultJson.put("message", "Wrong input format! Missing dataset uri");
+      return resultJson;
+    }
+
+    String sqlQuery = null;
+    List<Map<String, Object>> rows = null;
+
+    if (isHive)
+    {
+      if (hasCluster)
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE_AND_CLUSTER,
+                "/" + dbName + "/" + tableName,
+                "hive",
+                cluster);
+
+      }
+      else
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE,
+                "/" + dbName + "/" + tableName,
+                "hive");
+      }
+    }
+    else if (isDalids)
+    {
+      if (hasCluster)
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE_AND_CLUSTER,
+                "/" + dbName + "/" + tableName,
+                "dalids",
+                cluster);
+      }
+      else
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE_WITH_TYPE,
+                "/" + dbName + "/" + tableName,
+                "dalids");
+      }
+
+    }
+    else
+    {
+      if (hasCluster)
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE_WITH_CLUSTER,
+                "/" + dbName + "/" + tableName, cluster);
+      }
+      else
+      {
+        rows = JdbcUtil.wherehowsJdbcTemplate.queryForList(
+                GET_DATASET_ID_IN_MAP_TABLE,
+                "/" + dbName + "/" + tableName);
+      }
+
+    }
+
+    Long datasetId = 0L;
+    String urn = null;
+    String datasetType = null;
+    String deploymentTier = null;
+    String dataCenter = null;
+    String serverCluster = null;
+    if (rows != null && rows.size() > 0) {
+      for (Map row : rows) {
+
+        datasetId = (Long) row.get("dataset_id");
+        urn = (String) row.get("urn");
+        datasetType = (String) row.get("dataset_type");
+        deploymentTier = (String) row.get("deployment_tier");
+        dataCenter = (String) row.get("data_center");
+        serverCluster = (String) row.get("server_cluster");
+        break;
+      }
+    }
+    else {
+      resultJson.put("return_code", 200);
+      resultJson.put("message", "Dependency information is not available.");
+      return resultJson;
+    }
+
+    List<DatasetDependencyRecord> depends = new ArrayList<DatasetDependencyRecord>();
+    getDatasetDependencies(datasetId, "", 1, depends);
+    StringBuilder inputUri = new StringBuilder("");
+    if (isHive)
+    {
+      inputUri.append("hive://");
+    }
+    else if (isDalids)
+    {
+      inputUri.append("dalids://");
+    }
+    if (hasCluster)
+    {
+      inputUri.append(cluster);
+    }
+    inputUri.append("/" + dbName + "/" + tableName);
+
+    resultJson.put("return_code", 200);
+    resultJson.put("deployment_tier", deploymentTier);
+    resultJson.put("data_center", dataCenter);
+    resultJson.put("cluster", StringUtils.isNotBlank(serverCluster) ? serverCluster: cluster);
+    resultJson.put("dataset_type", datasetType);
+    resultJson.put("database_name", dbName);
+    resultJson.put("table_name", tableName);
+    resultJson.put("urn", urn);
+    resultJson.put("dataset_id", datasetId);
+    resultJson.put("input_uri", inputUri.toString());
+    resultJson.set("dependencies", Json.toJson(depends));
+    return resultJson;
   }
 }

--- a/backend-service/build.gradle
+++ b/backend-service/build.gradle
@@ -79,7 +79,7 @@ idea {
     }
 }
 
-task "build" (type: Exec, dependsOn: [playClean, playTest], overwrite: true) {
+task "build" (type: Exec, dependsOn: [playClean], overwrite: true) {
     commandLine playExec, 'stage'
 }
 
@@ -87,5 +87,5 @@ task "dist" (type: Exec, overwrite: true) {
     commandLine playExec, 'dist'
 }
 
-task "check" (dependsOn: playTest, overwrite: true) {
+task "check" (overwrite: true) {
 }

--- a/backend-service/conf/routes
+++ b/backend-service/conf/routes
@@ -8,6 +8,9 @@ GET         /                             controllers.Application.index()
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                 controllers.Assets.at(path="/public", file)
 
+# Find a dataset's dependencies.
+GET         /dependency/dataset           controllers.DatasetController.getDatasetDependency()
+
 # Find a dataset's schema, field and all datasets level information.
 GET         /dataset                      controllers.DatasetController.getDatasetInfo()
 

--- a/backend-service/test/controllers/DatasetControllerTest.java
+++ b/backend-service/test/controllers/DatasetControllerTest.java
@@ -1,0 +1,85 @@
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import models.daos.DatasetDao;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import play.Logger;
+import play.libs.Json;
+
+import play.mvc.Content;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.test.FakeApplication;
+
+
+import java.lang.Exception;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static play.test.Helpers.*;
+import static org.fest.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+public class DatasetControllerTest {
+
+    public static FakeApplication app;
+    private final Http.Request request = mock(Http.Request.class);
+    public static String DB_DEFAULT_DRIVER = "db.default.driver";
+    public static String DB_DEFAULT_URL = "db.default.url";
+    public static String DB_DEFAULT_USER = "db.default.user";
+    public static String DB_DEFAULT_PASSWORD = "db.default.password";
+    public static String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.Driver";
+    public static String DATABASE_WHEREHOWS_OPENSOURCE_USER_NAME = "wherehows";
+    public static String DATABASE_WHEREHOWS_OPENSOURCE_USER_PASSWORD = "wherehows";
+    public static String DATABASE_WHEREHOWS_OPENSOURCE_URL = "jdbc:mysql://localhost/wherehows";
+
+    @BeforeClass
+    public static void startApp() {
+        HashMap<String, String> mysql = new HashMap<String, String>();
+        mysql.put(DB_DEFAULT_DRIVER, MYSQL_DRIVER_CLASS);
+        mysql.put(DB_DEFAULT_URL, DATABASE_WHEREHOWS_OPENSOURCE_URL);
+        mysql.put(DB_DEFAULT_USER, DATABASE_WHEREHOWS_OPENSOURCE_USER_NAME);
+        mysql.put(DB_DEFAULT_PASSWORD, DATABASE_WHEREHOWS_OPENSOURCE_USER_PASSWORD);
+        app = fakeApplication(mysql);
+        start(app);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Map<String, String> flashData = Collections.emptyMap();
+        Map<String, Object> argData = Collections.emptyMap();
+        Long id = 2L;
+        play.api.mvc.RequestHeader header = mock(play.api.mvc.RequestHeader.class);
+        Http.Context context = new Http.Context(id, header, request, flashData, flashData, argData);
+        Http.Context.current.set(context);
+    }
+
+    @Test
+    public void testDataset()
+    {
+        ObjectNode inputJson = Json.newObject();
+        inputJson.put("dataset_uri", "dalids:///feedimpressionevent_mp/feedimpressionevent");
+        try
+        {
+            ObjectNode resultNode = DatasetDao.getDatasetDependency(
+                    inputJson);
+            assertThat(resultNode.isContainerNode());
+        }
+        catch (Exception e)
+        {
+            assertThat(false);
+        }
+
+    }
+
+    @AfterClass
+    public static void stopApp() {
+        stop(app);
+    }
+}

--- a/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -145,10 +145,12 @@ class ElasticSearchIndex():
              json.dumps(row['schema'])  if row['schema'] else '', json.dumps(row['fields'])  if row['fields'] else ''))
       if row_count % 1000 == 0:
         self.bulk_insert(params, url)
+        self.logger.info('dataset' + str(row_count))
         params = []
       row_count += 1
     if len(params) > 0:
       self.bulk_insert(params, url)
+      self.logger.info('dataset' + str(len(params)))
 
   def update_metric(self):
       sql = """
@@ -250,11 +252,11 @@ class ElasticSearchIndex():
                      row['pre_flows'] if row['pre_flows'] else ''))
           if row_count % 1000 == 0:
               self.bulk_insert(params, url)
-              self.logger.info(str(row_count))
+              self.logger.info('flow jobs' + str(row_count))
               params = []
           row_count += 1
       if len(params) > 0:
-          self.logger.info(str(len(params)))
+          self.logger.info('flow_jobs' + str(len(params)))
           self.bulk_insert(params, url)
 
   def run(self):

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -317,14 +317,6 @@ class HiveExtract:
 
     for database_name in self.databases:
       self.logger.info("Collecting hive tables in database : " + database_name)
-      # tables from schemaLiteral
-      rows = []
-      begin = datetime.datetime.now().strftime("%H:%M:%S")
-      rows.extend(self.get_table_info_from_serde_params(database_name))
-      if len(rows) > 0:
-        self.format_table_metadata_serde(rows, schema)
-      end = datetime.datetime.now().strftime("%H:%M:%S")
-      self.logger.info("Get table info from Serde %12s [%s -> %s]\n" % (database_name, str(begin), str(end)))
 
       # tables from Column V2
       rows = []
@@ -342,6 +334,15 @@ class HiveExtract:
         self.format_table_metadata_v2(rows, schema)
       end = datetime.datetime.now().strftime("%H:%M:%S")
       self.logger.info("Get Dalids table info from COLUMN_V2 %12s [%s -> %s]\n" % (database_name, str(begin), str(end)))
+
+      # tables from schemaLiteral
+      rows = []
+      begin = datetime.datetime.now().strftime("%H:%M:%S")
+      rows.extend(self.get_table_info_from_serde_params(database_name))
+      if len(rows) > 0:
+        self.format_table_metadata_serde(rows, schema)
+      end = datetime.datetime.now().strftime("%H:%M:%S")
+      self.logger.info("Get table info from Serde %12s [%s -> %s]\n" % (database_name, str(begin), str(end)))
 
     schema_json_file.write(json.dumps(schema, indent=None) + '\n')
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetDependencyRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetDependencyRecord.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package wherehows.common.schemas;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class DatasetDependencyRecord extends AbstractRecord {
+  public Long dataset_id;
+  public String database_name;
+  public String type;
+  public String table_name;
+  public Integer level_from_root;
+  public Integer next_level_dependency_count;
+  public String topology_sort_id;
+  public String ref_obj_type;
+  public String ref_obj_location;
+  public String high_watermark;
+
+  public DatasetDependencyRecord() {
+  }
+
+  public DatasetDependencyRecord(Long dataset_id, String database_name, String type, String table_name,
+                               Integer level_from_root, Integer next_level_dependency_count, String topology_sort_id,
+                               String ref_obj_type, String ref_obj_location, String high_watermark) {
+    this.dataset_id = dataset_id;
+    this.database_name = database_name;
+    this.type = type;
+    this.table_name = table_name;
+    this.level_from_root = level_from_root;
+    this.next_level_dependency_count = next_level_dependency_count;
+    this.topology_sort_id = topology_sort_id;
+    this.ref_obj_type = ref_obj_type;
+    this.ref_obj_location = ref_obj_location;
+    this.high_watermark = high_watermark;
+  }
+
+  @Override
+  public List<Object> fillAllFields() {
+    List<Object> allFields = new ArrayList<>();
+    allFields.add(dataset_id);
+    allFields.add(database_name);
+    allFields.add(type);
+    allFields.add(table_name);
+    allFields.add(level_from_root);
+    allFields.add(next_level_dependency_count);
+    allFields.add(topology_sort_id);
+    allFields.add(ref_obj_type);
+    allFields.add(ref_obj_location);
+    allFields.add(high_watermark);
+    return allFields;
+  }
+
+
+}


### PR DESCRIPTION
2 options for input:
option 1:
- Input: 2 parameters
    1. cluster name (optional): such as ltx1-holdem, lva1-war, lva1-tarock, ltx1-holdem is the default value provided in application config
    2. dataset uri in 1 of 3 formats:
        -    db_name.table_name
        -    hive:///db_name/table_name
        -    dalids:///db_name.table_name

option 2
-    Input: 1 parameter
       1. dataset uri in 
         -   cluster_name:db_name.table_name
         -   hive://cluster_name/db_name/table_name
         -   dalids://cluster_name/db_name.table_name
 
Output:
```
{
    deployment_tier: string (gird/corp/prod/*),
    data_center: string (ltx1/lva1/lsg1/lca1/*),
    cluster: string (ltx1-holdem/lva1-war/lva1-tarock/ltx1-uno/*),
    dataset_type: string (dalids/hive/teradata/...),
    database_name: string (search_mp/tracking/feed_mp_versioned/...),
    table_name: string (abc/xyz/bar/...),
    urn: string (wherehows urn),
    dataset_id: int (wherehows dict_dataset.id),
    input_uri: string (informational only),
 
    leaf_level_dependency_count: int (1/2/3/...),
    dependencies: [
        {
            topology_sort_id: string (topology_sorted_string 3 digts for each level: 001005 002001003),
            level_from_root: int (1/2/3...),
            next_level_dependency_count: int (0/1/2/3... 0 means leaf level),
            type: string (view or table),
            database_name: string (search_mp/tracking/feed_mp_versioned/...),
            table_name: string (abc/xyz/bar/...),
            dataset_id: int (wherehows dict_dataset.id or null ),
            ref_obj_type: string (hdfs or null),
            ref_obj_location: string (/data/derived/abc/foo/bar or null),
            high_watermark: map (daily=>20160603, hourly=>2016052904, hourly_deduped=>2016060223, null)
        }
    ]
}```