### PR TITLE
update dependency property name and fix the duplicated key issue

### DIFF
--- a/metadata-etl/src/main/resources/jython/HiveTransform.py
+++ b/metadata-etl/src/main/resources/jython/HiveTransform.py
@@ -127,7 +127,7 @@ class HiveTransform:
                                           if one_db_info['type'].lower() == 'dalids'
                                           else 'hive:///' + one_db_info['database'] + '/' + table['dataset_name'],
                                           'depends on',
-                                          'is used by',
+                                          'Y',
                                           row_value[3],
                                           row_value[4],
                                           row_value[2],
@@ -185,7 +185,7 @@ class HiveTransform:
                                                 table['version'],
                                                 table['create_time'],
                                                 json.dumps(schema_json),
-                                                view_expanded_text,
+                                                json.dumps(view_expanded_text),
                                                 dataset_urn)
         instance_file_writer.append(dataset_instance_record)
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/HiveDependencyInstanceRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/HiveDependencyInstanceRecord.java
@@ -26,7 +26,7 @@ public class HiveDependencyInstanceRecord extends AbstractRecord {
   String objectSubType;
   String objectName;
   String mapPhrase;
-  String mapPhraseReversed;
+  String isIdentialMap;
   String mappedObjectType;
   String mappedObjectSubType;
   String mappedObjectName;
@@ -35,7 +35,7 @@ public class HiveDependencyInstanceRecord extends AbstractRecord {
   String mappedObjectUrn;
 
   public HiveDependencyInstanceRecord(String objectType, String objectSubType, String objectName, String objectUrn,
-                               String mapPhrase, String mapPhraseReversed, String mappedObjectType,
+                               String mapPhrase, String isIdentialMap, String mappedObjectType,
                                String mappedObjectSubType, String mappedObjectName,
                                String mappedObjectUrn, String description) {
     this.objectType = objectType;
@@ -43,7 +43,7 @@ public class HiveDependencyInstanceRecord extends AbstractRecord {
     this.objectName = objectName;
     this.objectUrn = objectUrn;
     this.mapPhrase = mapPhrase;
-    this.mapPhraseReversed = mapPhraseReversed;
+    this.isIdentialMap = isIdentialMap;
     this.mappedObjectType = mappedObjectType;
     this.mappedObjectSubType = mappedObjectSubType;
     this.mappedObjectName = mappedObjectName;
@@ -59,7 +59,7 @@ public class HiveDependencyInstanceRecord extends AbstractRecord {
     allFields.add(objectName);
     allFields.add(objectUrn);
     allFields.add(mapPhrase);
-    allFields.add(mapPhraseReversed);
+    allFields.add(isIdentialMap);
     allFields.add(mappedObjectType);
     allFields.add(mappedObjectSubType);
     allFields.add(mappedObjectName);


### PR DESCRIPTION
When update cfg_object_name_map table, the duplicated key exception raised since the t_deleted_depend table does not include all records