### PR TITLE
update the get relations code since info stored by version instead of dataset

### DIFF
--- a/web/app/controllers/api/v1/Dataset.java
+++ b/web/app/controllers/api/v1/Dataset.java
@@ -755,7 +755,7 @@ public class Dataset extends Controller
     {
         ObjectNode result = Json.newObject();
         List<DatasetDependency> depends = new ArrayList<DatasetDependency>();
-        DatasetsDAO.getDatasetDependencies(datasetId, 1, 0, depends);
+        DatasetsDAO.getDependencies(datasetId, depends);
         result.put("status", "ok");
         result.put("depends", Json.toJson(depends));
         return ok(result);
@@ -765,7 +765,7 @@ public class Dataset extends Controller
     {
         ObjectNode result = Json.newObject();
         List<DatasetDependency> references = new ArrayList<DatasetDependency>();
-        DatasetsDAO.getDatasetReferences(datasetId, 1, 0, references);
+        DatasetsDAO.getReferences(datasetId, references);
         result.put("status", "ok");
         result.put("references", Json.toJson(references));
         return ok(result);

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetSchemaRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetSchemaRecord.java
@@ -35,6 +35,22 @@ public class DatasetSchemaRecord extends AbstractRecord {
   Integer sourceModified;
 
   public DatasetSchemaRecord(String name, String schema, String properties, String fields, String urn, String source,
+                             String samplePartitionFullPath, Integer sourceCreated, Integer sourceModified) {
+    this.name = name;
+    this.schema = schema;
+    this.properties = properties;
+    this.fields = fields;
+    this.urn = urn;
+    this.source = source;
+    this.datasetType = null;
+    this.storageType = null;
+    this.samplePartitionFullPath = samplePartitionFullPath;
+    this.sourceCreated = sourceCreated;
+    this.sourceModified = sourceModified;
+
+  }
+
+  public DatasetSchemaRecord(String name, String schema, String properties, String fields, String urn, String source,
                              String datasetType, String storageType, String samplePartitionFullPath,
     Integer sourceCreated, Integer sourceModified) {
     this.name = name;


### PR DESCRIPTION
Currently, the table cfg_object_name_map stores the dependencies for all versions of a dataset, before only store the latest version of a dataset