### PR TITLE
temp fix for hdfs_schema_crawler getRuntime().exec() hangs problem

### DIFF
--- a/backend-service/build.gradle
+++ b/backend-service/build.gradle
@@ -30,11 +30,20 @@ repositories{
         dirs: "${projectDir}/metadata-etl/extralibs"
 }
 
-configurations{
+configurations {
+  // configuration that holds jars to copy into lib
+  extraLibs
+  provided
 
-    //Libraries needed at compilation time but not to be
-    //exported as part of the distribution
-    provided
+  all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  all*.exclude group: 'log4j'
+
+  all*.resolutionStrategy { 
+      dependencySubstitution {
+          substitute module('org.slf4j:slf4j-log4j12') with module('ch.qos.logback:logback-classic:1.1.7')
+          //prefer 'log4j-over-slf4j' over 'log4j'
+      }
+  }
 }
 
 dependencies{

--- a/backend-service/build.gradle
+++ b/backend-service/build.gradle
@@ -67,11 +67,6 @@ dependencies{
     provided project(":metadata-etl")
 }
 
-configurations {
-    all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-    all*.exclude group: 'log4j', module: 'log4j'
-}
-
 clean {
     delete "lib/"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,18 @@ apply plugin: 'idea'
 apply plugin: 'license'
 ext.licenseFile = file('.license_header.txt')
 
+configurations.all {
+  exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  exclude group: 'log4j'
+
+  resolutionStrategy {
+      dependencySubstitution {
+          substitute module('org.slf4j:slf4j-log4j12') with module('ch.qos.logback:logback-classic:1.1.7')
+          //prefer 'log4j-over-slf4j' over 'log4j'
+      }
+  }
+}
+
 subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'java'
@@ -82,8 +94,9 @@ subprojects {
                             "jackson_core"       : "com.fasterxml.jackson.core:jackson-core:2.6.1",
                             "jackson_annotations": "com.fasterxml.jackson.core:jackson-annotations:2.6.1",
 
-                            "slf4j_api"          : "org.slf4j:slf4j-api:1.6.6",
-                            "slf4j_log4j"        : "org.slf4j:slf4j-log4j12:1.7.12",
+                            "slf4j_api"          : "org.slf4j:slf4j-api:1.7.21",
+                            "slf4j_log4j"        : "org.slf4j:log4j-over-slf4j:1.7.21",
+                            "logback"            : "ch.qos.logback:logback-classic:1.1.7",
                             "jasypt"             : "org.jasypt:jasypt:1.9.2",
 
                             "spring_context"     : "org.springframework:spring-context:4.1.1.RELEASE",

--- a/hadoop-dataset-extractor-standalone/build.gradle
+++ b/hadoop-dataset-extractor-standalone/build.gradle
@@ -4,6 +4,17 @@ version = '1.0'
 configurations {
   // configuration that holds jars to copy into lib
   extraLibs
+  provided
+
+  all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  all*.exclude group: 'log4j'
+
+  all*.resolutionStrategy { 
+      dependencySubstitution {
+          substitute module('org.slf4j:slf4j-log4j12') with module('ch.qos.logback:logback-classic:1.1.7')
+          //prefer 'log4j-over-slf4j' over 'log4j'
+      }
+  }
 }
 
 dependencies {
@@ -16,10 +27,8 @@ dependencies {
   extraLibs externalDependency.pig
 
   compile project(":wherehows-common")
-  //compile files("extralibs/linkedin-pig-0.11.1.49.jar")
-  //compile files("extralibs/voldemort-0.91.li1.jar")
   compile externalDependency.hadoop_common
-  compile externalDependency.hadoop_client
+  provided externalDependency.hadoop_client
   compile externalDependency.pig
   compile externalDependency.avro
   compile externalDependency.avro_mapred
@@ -27,8 +36,10 @@ dependencies {
   compile externalDependency.hive_exec
   compile externalDependency.http_client
   compile externalDependency.http_core
+  compile externalDependency.logback
 
   testCompile externalDependency.testng
+  testCompile externalDependency.hadoop_client
 }
 
 jar {

--- a/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
+++ b/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
@@ -126,10 +126,10 @@ public class SchemaFetch {
         if (!fstat.isDirectory()) {
           // file
           fileCount++;
-        } else if (objName.matches("(_|\\.|tmp|temp|_distcp|\\*|test).*")) {
+        } else if (objName.matches("(_|\\.|tmp|temp|_distcp|backup|\\*|test|trash).*")) {
           // hidden/temporary fs object
           hiddenFileCount++;
-        } else if (objName.matches("daily|hourly|monthly|weekly|year=[0-9]+|month=[0-9]+|country=.*")) {
+        } else if (objName.matches("daily|hourly|hourly.deduped|monthly|weekly|(ds|dt|datepartition|year|month|date)=[0-9-]+")) {
           // temporal partition type
           datePartitionCount++;
         } else if (objName.matches(
@@ -167,8 +167,8 @@ public class SchemaFetch {
     throws IOException, InterruptedException, SQLException {
     String curPath = path.toUri().getPath();
     Path n = path;
-    //if (path.getName().matches("^(\\.|_|tmp|temp|test|\\*|archive|ARCHIVE|storkinternal).*"))
-    //    return;
+    if (path.getName().matches("^(\\.|_|tmp|temp|test|trash|backup|archive|ARCHIVE|storkinternal).*"))
+        return;
 
     logger.info("  -- scanPath(" + curPath + ")\n");
     int x = isTable(path, scanFs);

--- a/metadata-etl/build.gradle
+++ b/metadata-etl/build.gradle
@@ -7,6 +7,16 @@ configurations {
   //Libraries needed at compilation time but not to be
   //exported as part of the distribution
   provided
+
+  all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  all*.exclude group: 'log4j'
+
+  all*.resolutionStrategy { 
+      dependencySubstitution {
+          substitute module('org.slf4j:slf4j-log4j12') with module('ch.qos.logback:logback-classic:1.1.7')
+          //prefer 'log4j-over-slf4j' over 'log4j'
+      }
+  }
 }
 
 dependencies {

--- a/metadata-etl/src/main/resources/jython/HdfsLoad.py
+++ b/metadata-etl/src/main/resources/jython/HdfsLoad.py
@@ -225,7 +225,7 @@ class HdfsLoad:
             t.modified = now()
         ;
 
-       insert into dict_field_detail (
+       insert ignore into dict_field_detail (
           dataset_id, fields_layout_id, sort_id, parent_sort_id, parent_path,
           field_name, namespace, data_type, data_size, is_nullable, default_value,
            modified

--- a/metadata-etl/src/main/resources/jython/HiveLoad.py
+++ b/metadata-etl/src/main/resources/jython/HiveLoad.py
@@ -389,7 +389,7 @@ class HiveLoad:
         );
 
         -- insert new depends
-        INSERT INTO cfg_object_name_map
+        INSERT IGNORE INTO cfg_object_name_map
         (
           object_type,
           object_sub_type,


### PR DESCRIPTION
- "schemaFetch.jar' can randomly hang due the issue described in http://dhruba.name/2012/10/16/java-pitfall-how-to-prevent-runtime-getruntime-exec-from-hanging
   Need to switch to ProcessBuilder.redirectErrorStream(true) later. Temporarly discard the log from getRuntime().exec() 
- exclude log4j from the build