### PR TITLE
Use ProcessBuilder and redirected log file for HDFS Extract

### DIFF
--- a/backend-service/app/models/utils/Urn.java
+++ b/backend-service/app/models/utils/Urn.java
@@ -24,25 +24,41 @@ import play.Logger;
  */
 public class Urn {
   public String urnString;
-  public String storageType;
+  public String datasetType;
   public String schemaName;
   public String abstractObjectName;
 
-  static final String[] stoList = new String[] {"teradata", "hdfs"};
-  static final Set<String> storageTypes = new HashSet<String>(Arrays.asList(stoList));
+  static final String[] stoList = new String[] {"teradata", "hdfs", "hive", "dalids", "oracle", "mysql", "pinot"};
+  static final Set<String> datasetTypes = new HashSet<String>(Arrays.asList(stoList));
 
+  /**
+   * Urn can contain 3 parts
+   *      (1)           (2)           (3)
+   * dataset_type://cluster:port/parent/name
+   * the 2nd part is only used to identify deployed dataset instance
+   * for dataset definition, we only use part (1) + (3)
+   */
   public Urn(String urnString) {
     this.urnString = urnString;
     String[] splitResult = urnString.split(":///");
-    storageType = splitResult[0].toLowerCase();
+    datasetType = splitResult[0].toLowerCase();
     Logger.debug(urnString);
-    switch (storageType) {
-            /* example: hdfs://data/tracking/PageViewEvent -> 'hdfs', '', 'data/tracking/PageViewEvent' */
+    switch (datasetType) {
+      /* example: hdfs:///data/tracking/PageViewEvent -> 'hdfs', '', 'data/tracking/PageViewEvent' */
       case "hdfs": abstractObjectName = "/" + splitResult[1];
         schemaName = "";
         break;
-            /* example: teradata://dwh/dwh_dim/domain_name -> 'teradata', 'dwh/dwh_dim', 'domain_name' */
-      case "teradata": String[] split2 = splitResult[1].split("/");
+      /* example: teradata:///dwh_dim/dim_table_name -> 'teradata', 'dwh_dim', 'dim_table_name'
+      *           hive:///db_name/table_name -> 'hive', 'db_name', 'table_name'
+      * */
+      case "teradata":
+      case "oracle":
+      case "mysql":
+      case "espresso":
+      case "pinot":
+      case "hive":
+      case "dalids":
+        String[] split2 = splitResult[1].split("/");
         abstractObjectName = split2[split2.length-1];
         StringBuffer sb = new StringBuffer();
         if (split2.length > 1) {
@@ -58,23 +74,31 @@ public class Urn {
     }
   }
 
-  public Urn(String storageType, String schemaName, String abstractObjectName) {
-    this.storageType = storageType.toLowerCase();
+  public Urn(String datasetType, String schemaName, String abstractObjectName) {
+    this.datasetType = datasetType.toLowerCase();
     if (schemaName != null)
       this.schemaName = schemaName.toLowerCase();
     this.abstractObjectName = abstractObjectName;
-    switch (this.storageType) {
-      case "teradata" : urnString = "teradata:///" + schemaName + "/" + abstractObjectName;
+    switch (this.datasetType) {
+      case "teradata":
+      case "oracle":
+      case "mysql":
+      case "espresso":
+      case "pinot":
+      case "hive":
+      case "dalids":
+        urnString = this.datasetType + ":///" + schemaName + "/" + abstractObjectName;
         break;
       default: String trimName = abstractObjectName.startsWith("/") ? abstractObjectName.substring(1) : abstractObjectName;
-        urnString = this.storageType + ":///" + trimName;
+        urnString = this.datasetType + ":///" + trimName;
     }
   }
 
   public static boolean validateUrn(String urnString) {
 
     String[] splitResult = urnString.split(":///");
-    if (storageTypes.contains(splitResult[0]) && splitResult.length > 1)
+    if ((datasetTypes.contains(splitResult[0]) || splitResult[0].matches("\\w+")) &&
+        splitResult.length > 1)
       return true;
     return false;
   }

--- a/backend-service/build.sbt
+++ b/backend-service/build.sbt
@@ -17,10 +17,11 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5",
   "org.quartz-scheduler" % "quartz" % "2.2.1",
   "org.quartz-scheduler" % "quartz-jobs" % "2.2.1",
-  "org.slf4j" % "slf4j-api" % "1.6.6",
+  "org.slf4j" % "slf4j-api" % "1.7.21",
   "org.jasypt" % "jasypt" % "1.9.2",
   "org.apache.kafka" % "kafka_2.10" % "0.10.0.0",
   "org.apache.kafka" % "kafka-clients" % "0.10.0.0"
-)
+).map(_.exclude("log4j", "log4j"))
+ .map(_.exclude("org.slf4j", "slf4j-log4j12"))
 
 play.Project.playJavaSettings

--- a/metadata-etl/build.gradle
+++ b/metadata-etl/build.gradle
@@ -15,6 +15,7 @@ configurations {
       dependencySubstitution {
           substitute module('org.slf4j:slf4j-log4j12') with module('ch.qos.logback:logback-classic:1.1.7')
           //prefer 'log4j-over-slf4j' over 'log4j'
+          substitute module('log4j:log4j') with module('org.slf4j:log4j-over-slf4j:1.7.21')
       }
   }
 }

--- a/metadata-etl/src/main/resources/jython/HdfsLoad.py
+++ b/metadata-etl/src/main/resources/jython/HdfsLoad.py
@@ -61,7 +61,7 @@ class HdfsLoad:
         update stg_dict_dataset
         set name = substring_index(urn, '/', -2)
         where db_id = {db_id}
-          and name '[0-9]+\\.[0-9]+|dedup|dedupe|[0-9]+-day';
+          and name regexp '[0-9]+\\.[0-9]+|dedup|dedupe|[0-9]+-day';
 
         -- update parent name, this depends on the data from source system
         update stg_dict_dataset

--- a/metadata-etl/src/main/resources/jython/HiveLoad.py
+++ b/metadata-etl/src/main/resources/jython/HiveLoad.py
@@ -204,7 +204,7 @@ class HiveLoad:
         );
 
 
-       insert into dict_field_detail (
+       insert ignore into dict_field_detail (
           dataset_id, fields_layout_id, sort_id, parent_sort_id, parent_path,
           field_name, namespace, data_type, data_size, is_nullable, default_value,
            modified


### PR DESCRIPTION
schemaFetch.jar will generate log file along side with the output temp metadata file (which is defined in wh_etl_job_property under the name "hdfs.local.raw_metadata"). 

If hdfs.local.raw_metadata is set to /my_data/hdfs/abc.json, the log file will be /my_data/hdfs/abc.json.log