### PR TITLE
implement the dataset accessiblities section

### DIFF
--- a/web/app/controllers/api/v1/Dataset.java
+++ b/web/app/controllers/api/v1/Dataset.java
@@ -804,4 +804,20 @@ public class Dataset extends Controller
         return ok(result);
     }
 
+    public static Result getDatasetPartitions(Long datasetId)
+    {
+        ObjectNode result = Json.newObject();
+        result.put("status", "ok");
+        result.put("partitions", Json.toJson(DatasetsDAO.getDatasetPartitionGains(datasetId)));
+        return ok(result);
+    }
+
+    public static Result getDatasetAccess(Long datasetId)
+    {
+        ObjectNode result = Json.newObject();
+        result.put("status", "ok");
+        result.put("access", Json.toJson(DatasetsDAO.getDatasetAccessibilty(datasetId)));
+        return ok(result);
+    }
+
 }

--- a/web/app/models/DatasetAccessItem.java
+++ b/web/app/models/DatasetAccessItem.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package models;
+
+import java.util.List;
+
+public class DatasetAccessItem {
+
+    public String recordCountStr;
+    public String sizeInByteStr;
+    public String logTimeEpochStr;
+    public Boolean isPlaceHolder;
+}

--- a/web/app/models/DatasetAccessibility.java
+++ b/web/app/models/DatasetAccessibility.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package models;
+
+import java.util.List;
+
+public class DatasetAccessibility {
+
+    public Long datasetId;
+    public Integer dbId;
+    public String dbName;
+    public String datasetType;
+    public String partitionGain;
+    public String partitionExpr;
+    public String dataTimeExpr;
+    public Integer dataTimeEpoch;
+    public Long recordCount;
+    public Long sizeInByte;
+    public Integer logTimeEpoch;
+    public String logTimeEpochStr;
+    public List<DatasetAccessItem> itemList;
+}

--- a/web/app/models/DatasetPartition.java
+++ b/web/app/models/DatasetPartition.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package models;
+
+import java.util.List;
+
+public class DatasetPartition {
+
+    public Long datasetId;
+    public List<DatasetAccessibility> accessibilityList;
+    public List<String> instanceList;
+    public String partition;
+}

--- a/web/app/views/index.scala.html
+++ b/web/app/views/index.scala.html
@@ -537,6 +537,43 @@
       {{/if}}
     </script>
 
+    <script type="text/x-handlebars" id="components/dataset-access">
+      {{#if hasAccess}}
+        {{#each accessibilities as |accessibility|}}
+          <h4>Partition By: {{accessibility.partition}}</h4>
+          <table id="references-table" class="columntreegrid tree table table-bordered dataset-detail-table">
+            <thead>
+              <tr class="results-header">
+                <th>Time</th>
+                {{#each accessibility.instanceList as |instance|}}
+                  <th>{{instance}}</th>
+                {{/each}}
+              </tr>
+            </thead>
+            <tbody>
+              {{#each accessibility.accessibilityList as |access|}}
+              <tr>
+                <td>{{access.dataTimeExpr}}</td>
+                {{#each access.itemList as |item|}}
+                  <td>
+                    {{#unless item.isPlaceHolder}}
+                      <div>
+                        <p>Log time: {{item.logTimeEpochStr}}</p>
+                        <p>Record count: {{item.recordCountStr}}</p>
+                      </div>
+                    {{/unless}}
+                  </td>
+                {{/each}}
+              </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        {{/each}}
+      {{else}}
+        <p>Accessibility is not available</p>
+      {{/if}}
+    </script>
+
     <script type="text/x-handlebars" id="components/metric-detail">
       <div id="metric" class="container-fluid">
         <div class="row-fluid">
@@ -932,6 +969,13 @@
               Relations
             </a>
           </li>
+          <li id="access">
+            <a data-toggle="tab"
+              title="Accessibilities"
+              href="#accesstab">
+              Accessibilities
+            </a>
+          </li>
         </ul>
         <div class="tab-content">
           {{#unless isPinot}}
@@ -965,6 +1009,10 @@
           <div id="dependtab" class="tab-pane">
             {{#dataset-relations hasDepends=hasDepends depends=depends hasReferences=hasReferences references=references}}
             {{/dataset-relations}}
+          </div>
+          <div id="accesstab" class="tab-pane">
+            {{#dataset-access hasAccess=hasAccess accessibilities=accessibilities}}
+            {{/dataset-access}}
           </div>
         </div>
       {{else}}
@@ -1091,6 +1139,23 @@
             <div class="panel-body">
               {{#dataset-relations hasDepends=hasDepends depends=depends hasReferences=hasReferences references=references}}
               {{/dataset-relations}}
+            </div>
+          </div>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading" role="tab" id="accessHeading">
+            <h4 class="panel-title">
+              <a class="collapsed" data-toggle="collapse" data-parent="#accordion"
+               href="#accessview" aria-expanded="false" aria-controls="accessData">
+                Accessiblities
+              </a>
+            </h4>
+          </div>
+          <div id="accessview" class="panel-collapse collapse" role="tabpanel" aria-labelledby="accessHeading">
+            <div class="panel-body">
+              {{#dataset-access hasAccess=hasAccess accessibilities=accessibilities}}
+              {{/dataset-access}}
             </div>
           </div>
         </div>

--- a/web/conf/routes
+++ b/web/conf/routes
@@ -71,6 +71,10 @@ GET     /api/v1/datasets/:id/depends        controllers.api.v1.Dataset.getDepend
 
 GET     /api/v1/datasets/:id/references     controllers.api.v1.Dataset.getReferenceViews(id:Long)
 
+GET     /api/v1/datasets/:id/partitions     controllers.api.v1.Dataset.getDatasetPartitions(id:Long)
+
+GET     /api/v1/datasets/:id/access         controllers.api.v1.Dataset.getDatasetAccess(id:Long)
+
 GET     /api/v1/datasets/:id/properties     controllers.api.v1.Dataset.getDatasetPropertiesByID(id:Int)
 
 GET     /api/v1/datasets/:id/sample         controllers.api.v1.Dataset.getDatasetSampleDataByID(id:Int)

--- a/web/public/javascripts/components/components.js
+++ b/web/public/javascripts/components/components.js
@@ -130,6 +130,9 @@ App.DatasetSchemaComponent = Ember.Component.extend({
 App.DatasetSampleComponent = Ember.Component.extend({
 });
 
+App.DatasetAccessComponent = Ember.Component.extend({
+});
+
 App.DatasetImpactComponent = Ember.Component.extend({
 });
 

--- a/web/public/javascripts/routers/datasets.js
+++ b/web/public/javascripts/routers/datasets.js
@@ -516,6 +516,23 @@ App.DatasetRoute = Ember.Route.extend({
       }
     });
 
+    var datasetPartitionsUrl = 'api/v1/datasets/' + id + "/access";
+    var datasetAccessibilities = [];
+    $.get(datasetPartitionsUrl, function(data) {
+      if (data && data.status == "ok")
+      {
+        if (data.access && (data.access.length > 0))
+        {
+          controller.set("hasAccess", true);
+          controller.set("accessibilities", data.access);
+        }
+        else
+        {
+          controller.set("hasAccess", false);
+        }
+      }
+    });
+
     var datasetReferencesUrl = 'api/v1/datasets/' + id + "/references";
     $.get(datasetReferencesUrl, function(data) {
       if (data && data.status == "ok")

--- a/web/test/ControllersTest.java
+++ b/web/test/ControllersTest.java
@@ -142,6 +142,12 @@ public class ControllersTest {
         JsonNode schemaTextNode = Json.parse(contentAsString(result));
         assertThat(schemaTextNode.isContainerNode());
         assertThat(schemaTextNode.get("status").asText()).isEqualTo("ok");
+
+        result = controllers.api.v1.Dataset.getDatasetAccess(datasetId)
+        assertThat(status(result)).isEqualTo(OK);
+        JsonNode accessNode = Json.parse(contentAsString(result));
+        assertThat(accessNode.isContainerNode());
+        assertThat(accessNode.get("status").asText()).isEqualTo("ok");
     }
 
     /*


### PR DESCRIPTION
Display Operational metadata from 2 metadata event/stream sources (Gobblin and Hive Metastore) for datasets:
- cluster
- operation (publish full, publish delta, publish daily, publish hourly, add partition, modify external table...)
- partition type/grain
- partition name/expression
- partition data time
- num of records
- time of log event

The UI typically takes dataset_id as the input first, and find all its instances (across multiple clusters), then retrieve the most recent load status, and display them as pivot table.