### PR TITLE
fix the issue that action getSchema did not fired

### DIFF
--- a/web/app/views/index.scala.html
+++ b/web/app/views/index.scala.html
@@ -321,7 +321,7 @@
               </td>
               <td class="commentsArea">
                 <div class="commentsArea">
-                  {{#schema-comment schema=schema datasetId=this.model.id fieldId=schema.id getSchema="getSchema"}}{{/schema-comment}}
+                  {{#schema-comment schema=schema datasetId=dataset.id fieldId=schema.id}}{{/schema-comment}}
                   {{schema.commentHtml}}
                 </div>
               </td>

--- a/web/public/javascripts/components/components.js
+++ b/web/public/javascripts/components/components.js
@@ -102,6 +102,36 @@ App.DatasetSchemaComponent = Ember.Component.extend({
     }, 500);
   },
   actions: {
+    getSchema: function(){
+      var _this = this
+      var id = _this.get('dataset.id')
+      var columnUrl = 'api/v1/datasets/' + id + "/columns";
+      _this.set("isTable", true);
+      _this.set("isJSON", false);
+      $.get(columnUrl, function(data) {
+        if (data && data.status == "ok")
+        {
+          if (data.columns && (data.columns.length > 0))
+          {
+            _this.set("hasSchemas", true);
+            data.columns = data.columns.map(function(item, idx){
+              item.commentHtml = marked(item.comment).htmlSafe()
+              return item
+            })
+            _this.set("schemas", data.columns);
+            setTimeout(initializeColumnTreeGrid, 500);
+          }
+          else
+          {
+            _this.set("hasSchemas", false);
+          }
+        }
+        else
+        {
+          _this.set("hasSchemas", false);
+        }
+      });
+    },
     setView: function (view) {
       switch (view) {
         case "tabular":

--- a/web/public/javascripts/components/schema-comment.js
+++ b/web/public/javascripts/components/schema-comment.js
@@ -497,7 +497,10 @@ App.SchemaCommentComponent = Ember.Component.extend({
           })
           .on('hidden.bs.modal', function(){
             _this.set('propModal', false)
-            _this.sendAction('getSchema')
+            if (_this.parentView && _this.parentView.controller)
+            {
+              _this.parentView.controller.send('getSchema')
+            }
             $("#datasetSchemaColumnCommentModal").modal('hide');
           })
       }, 300)

--- a/web/public/javascripts/main.js
+++ b/web/public/javascripts/main.js
@@ -339,3 +339,8 @@ function filterListView(category, filter)
     }
 }
 
+function initializeColumnTreeGrid()
+{
+    $('#json-table').treegrid();
+}
+

--- a/web/public/javascripts/routers/datasets.js
+++ b/web/public/javascripts/routers/datasets.js
@@ -1,7 +1,3 @@
-function initializeColumnTreeGrid()
-{
-  $('#json-table').treegrid();
-}
 
 function initializeDependsTreeGrid()
 {


### PR DESCRIPTION
After upgrade the ember to 2.6, the component can't call the parent action directly