### PR TITLE
Add MatadataChangeEvent processor to call seperate APIs

### DIFF
--- a/backend-service/app/models/daos/DatasetInfoDao.java
+++ b/backend-service/app/models/daos/DatasetInfoDao.java
@@ -87,6 +87,8 @@ public class DatasetInfoDao {
       new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, DATASET_CONSTRAINT_TABLE);
   private static final DatabaseWriter INDEX_WRITER =
       new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, DATASET_INDEX_TABLE);
+  private static final DatabaseWriter DICT_DATASET_WRITER =
+      new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, "dict_dataset");
   private static final DatabaseWriter SCHEMA_WRITER =
       new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, DATASET_SCHEMA_TABLE);
   private static final DatabaseWriter FIELD_DETAIL_WRITER =
@@ -183,6 +185,9 @@ public class DatasetInfoDao {
   public static final String GET_DATASET_SCHEMA_BY_URN =
       "SELECT * FROM " + DATASET_SCHEMA_TABLE + " WHERE dataset_urn = :dataset_urn";
 
+  public static final String UPDATE_DICT_DATASET_WITH_SCHEMA_CHANGE =
+      "UPDATE dict_dataset SET `schema`=?, `schema_type`=?, `fields`=?, `source`=?, `modified_time`=? WHERE `id`=?";
+
   public static final String GET_DATASET_FIELDS_BY_DATASET_ID =
       "SELECT * FROM " + DATASET_FIELD_DETAIL_TABLE + " WHERE dataset_id = :dataset_id";
 
@@ -211,9 +216,9 @@ public class DatasetInfoDao {
 
   public static void updateDatasetDeployment(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
-    final JsonNode deployment = root.path("deployment_info");
+    final JsonNode deployment = root.path("deploymentInfo");
 
     if (auditHeader.isMissingNode() || urnNode.isMissingNode() || deployment.isMissingNode() || !deployment.isArray()) {
       throw new IllegalArgumentException(
@@ -226,7 +231,7 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    // om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     for (final JsonNode deploymentInfo : deployment) {
       DatasetDeploymentRecord record = om.convertValue(deploymentInfo, DatasetDeploymentRecord.class);
@@ -256,7 +261,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetCapacity(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode capacity = root.path("capacity");
 
@@ -271,7 +276,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     for (final JsonNode capacityInfo : capacity) {
       DatasetCapacityRecord record = om.convertValue(capacityInfo, DatasetCapacityRecord.class);
@@ -301,7 +305,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetTags(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode tags = root.path("tags");
 
@@ -344,9 +348,9 @@ public class DatasetInfoDao {
 
   public static void updateDatasetCaseSensitivity(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
-    final JsonNode caseSensitivity = root.path("case_sensitivity");
+    final JsonNode caseSensitivity = root.path("caseSensitivity");
 
     if (auditHeader.isMissingNode() || urnNode.isMissingNode() || caseSensitivity.isMissingNode()) {
       throw new IllegalArgumentException(
@@ -359,7 +363,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     DatasetCaseSensitiveRecord record = om.convertValue(caseSensitivity, DatasetCaseSensitiveRecord.class);
     record.setDataset(datasetId, urn);
@@ -393,7 +396,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetReference(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode references = root.path("references");
 
@@ -408,7 +411,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     for (final JsonNode reference : references) {
       DatasetReferenceRecord record = om.convertValue(reference, DatasetReferenceRecord.class);
@@ -438,9 +440,9 @@ public class DatasetInfoDao {
 
   public static void updateDatasetPartition(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
-    final JsonNode partition = root.path("partition_spec");
+    final JsonNode partition = root.path("partitionSpec");
 
     if (auditHeader.isMissingNode() || urnNode.isMissingNode() || partition.isMissingNode()) {
       throw new IllegalArgumentException(
@@ -453,7 +455,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     DatasetPartitionRecord record = om.convertValue(partition, DatasetPartitionRecord.class);
     record.setDataset(datasetId, urn);
@@ -471,11 +472,13 @@ public class DatasetInfoDao {
     }
 
     // update dataset field partitioned
-    for (DatasetPartitionKeyRecord partitionKey : record.getPartitionKeys()) {
-      List<String> fieldNames = partitionKey.getFieldNames();
-      for (String fieldName : fieldNames) {
-        FIELD_DETAIL_WRITER.execute(UPDATE_DATASET_FIELD_PARTITIONED_BY_FIELDNAME,
-            new Object[]{"Y", datasetId, fieldName});
+    if (record.getPartitionKeys() != null) {
+      for (DatasetPartitionKeyRecord partitionKey : record.getPartitionKeys()) {
+        List<String> fieldNames = partitionKey.getFieldNames();
+        for (String fieldName : fieldNames) {
+          FIELD_DETAIL_WRITER.execute(UPDATE_DATASET_FIELD_PARTITIONED_BY_FIELDNAME,
+              new Object[]{"Y", datasetId, fieldName});
+        }
       }
     }
   }
@@ -496,9 +499,9 @@ public class DatasetInfoDao {
 
   public static void updateDatasetSecurity(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
-    final JsonNode security = root.path("security_spec");
+    final JsonNode security = root.path("securitySpec");
 
     if (auditHeader.isMissingNode() || urnNode.isMissingNode() || security.isMissingNode()) {
       throw new IllegalArgumentException(
@@ -511,7 +514,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     DatasetSecurityRecord record = om.convertValue(security, DatasetSecurityRecord.class);
     record.setDataset(datasetId, urn);
@@ -545,7 +547,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetOwner(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode owners = root.path("owners");
 
@@ -565,7 +567,6 @@ public class DatasetInfoDao {
     }
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     List<DatasetOwnerRecord> ownerList = new ArrayList<>();
     int sortId = 0;
@@ -618,8 +619,7 @@ public class DatasetInfoDao {
           rec.setCreatedTime(StringUtil.toLong(old.get("created_time")));
 
           // take the higher priority owner category
-          rec.setOwnerCategory(
-              OwnerType.chooseOwnerType(rec.getOwnerCategory(), (String) old.get("owner_type")));
+          rec.setOwnerCategory(OwnerType.chooseOwnerType(rec.getOwnerCategory(), (String) old.get("owner_type")));
 
           // merge owner source as comma separated list
           rec.setOwnerSource(mergeOwnerSource(rec.getOwnerSource(), (String) old.get("owner_source")));
@@ -695,7 +695,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetConstraint(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode constraints = root.path("constraints");
 
@@ -711,7 +711,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     for (final JsonNode constraint : constraints) {
       DatasetConstraintRecord record = om.convertValue(constraint, DatasetConstraintRecord.class);
@@ -741,7 +740,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetIndex(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode indices = root.path("indices");
 
@@ -756,7 +755,6 @@ public class DatasetInfoDao {
     final Integer datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     for (final JsonNode index : indices) {
       DatasetIndexRecord record = om.convertValue(index, DatasetIndexRecord.class);
@@ -794,7 +792,7 @@ public class DatasetInfoDao {
 
   public static void updateDatasetSchema(JsonNode root)
       throws Exception {
-    final JsonNode auditHeader = root.path("audit_header");
+    final JsonNode auditHeader = root.path("auditHeader");
     final JsonNode urnNode = root.path("urn");
     final JsonNode schemas = root.path("schemas");
 
@@ -813,7 +811,6 @@ public class DatasetInfoDao {
     }
 
     ObjectMapper om = new ObjectMapper();
-    om.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
 
     DatasetSchemaInfoRecord rec = om.convertValue(schemas, DatasetSchemaInfoRecord.class);
     rec.setDataset(datasetId, urn);
@@ -823,7 +820,7 @@ public class DatasetInfoDao {
     if (datasetId == 0) {
       DatasetRecord record = new DatasetRecord();
       record.setUrn(urn);
-      record.setSourceCreatedTime(rec.getCreateTime().toString());
+      record.setSourceCreatedTime("" + rec.getCreateTime() / 1000);
       record.setSchema(rec.getOriginalSchema());
       record.setSchemaType(rec.getFormat());
       record.setFields(rec.getFieldSchema().toString());
@@ -834,11 +831,15 @@ public class DatasetInfoDao {
       String[] urnPaths = urnType.abstractObjectName.split("/");
       record.setName(urnPaths[urnPaths.length - 1]);
 
-      DatabaseWriter dw = new DatabaseWriter(JdbcUtil.wherehowsJdbcTemplate, "dict_dataset");
-      dw.append(record);
-      dw.close();
+      DICT_DATASET_WRITER.append(record);
+      DICT_DATASET_WRITER.close();
 
       datasetId = Integer.valueOf(DatasetDao.getDatasetByUrn(urn).get("id").toString());
+    }
+    // if dataset already exist in dict_dataset, update info
+    else {
+      DICT_DATASET_WRITER.execute(UPDATE_DICT_DATASET_WITH_SCHEMA_CHANGE,
+          new Object[]{rec.getOriginalSchema(), rec.getFormat(), rec.getFieldSchema().toString(), "API", eventTime, datasetId});
     }
 
     // get old dataset fields info
@@ -870,12 +871,15 @@ public class DatasetInfoDao {
     }
     // remove old info then insert new info
     FIELD_DETAIL_WRITER.execute(DELETE_DATASET_FIELDS_BY_DATASET_ID, new Object[]{datasetId});
-    String sql = PreparedStatementUtil.prepareInsertTemplateWithColumn(DATASET_FIELD_DETAIL_TABLE,
-        rec.getFieldSchema().get(0).getFieldDetailColumns());
-    for (DatasetFieldSchemaRecord field : rec.getFieldSchema()) {
-      FIELD_DETAIL_WRITER.execute(sql, field.getFieldDetailValues());
+    if (rec.getFieldSchema().size() > 0) {
+      String sql = PreparedStatementUtil.prepareInsertTemplateWithColumn(DATASET_FIELD_DETAIL_TABLE,
+          rec.getFieldSchema().get(0).getFieldDetailColumns());
+      for (DatasetFieldSchemaRecord field : rec.getFieldSchema()) {
+        FIELD_DETAIL_WRITER.execute(sql, field.getFieldDetailValues());
+      }
     }
 
+    // insert/update new schema info
     try {
       Map<String, Object> result = getDatasetSchemaByDatasetUrn(urn);
       String[] columns = rec.getDbColumnNames();

--- a/backend-service/app/utils/MetadataChangeProcessor.java
+++ b/backend-service/app/utils/MetadataChangeProcessor.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import models.daos.DatasetInfoDao;
+import org.apache.avro.generic.GenericData;
+import play.Logger;
+import wherehows.common.schemas.Record;
+
+
+public class MetadataChangeProcessor {
+
+  /**
+   * Process a MetadataChangeEvent record
+   * @param record GenericData.Record
+   * @param topic String
+   * @throws Exception
+   * @return null
+   */
+  public Record process(GenericData.Record record, String topic)
+      throws Exception {
+    if (record != null) {
+      // Logger.info("Processing Metadata Change Event record. ");
+
+      final GenericData.Record auditHeader = (GenericData.Record) record.get("auditHeader");
+      final GenericData.Array<GenericData.Record> changedItems =
+          (GenericData.Array<GenericData.Record>) record.get("changedItems");
+
+      if (auditHeader == null || auditHeader.get("time") == null) {
+        Logger.info("MetadataChangeEvent without auditHeader, abort process. " + record.toString());
+        return null;
+      }
+
+      // list change items, schema first
+      List<String> changes = new ArrayList<>();
+      for (GenericData.Record item : changedItems) {
+        switch (item.get("changeScope").toString().toLowerCase()) { // can't be null
+          case "*":
+            Collections.addAll(changes, "schemas", "owners", "references", "partitionSpec", "deploymentInfo",
+                "caseSensitivity", "tags", "constraints", "indices", "capacity", "securitySpec");
+            break;
+          case "schema":
+            if (!changes.contains("schemas")) {
+              changes.add(0, "schemas"); // add to front
+            }
+            break;
+          case "owner":
+            if (!changes.contains("owners")) {
+              changes.add("owners");
+            }
+            break;
+          case "reference":
+            if (!changes.contains("references")) {
+              changes.add("references");
+            }
+            break;
+          case "partition":
+            if (!changes.contains("partitionSpec")) {
+              changes.add("partitionSpec");
+            }
+            break;
+          case "deployment":
+            if (!changes.contains("deploymentInfo")) {
+              changes.add("deploymentInfo");
+            }
+            break;
+          case "casesensitivity":
+            if (!changes.contains("caseSensitivity")) {
+              changes.add("caseSensitivity");
+            }
+            break;
+          case "tag":
+            if (!changes.contains("tags")) {
+              changes.add("tags");
+            }
+            break;
+          case "constraint":
+            if (!changes.contains("constraints")) {
+              changes.add("constraints");
+            }
+            break;
+          case "index":
+            if (!changes.contains("indices")) {
+              changes.add("indices");
+            }
+            break;
+          case "capacity":
+            if (!changes.contains("capacity")) {
+              changes.add("capacity");
+            }
+            break;
+          case "security":
+            if (!changes.contains("securitySpec")) {
+              changes.add("securitySpec");
+            }
+            break;
+          default:
+            break;
+        }
+      }
+      Logger.debug("Updating dataset " + changedItems.toString());
+
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode rootNode = mapper.readTree(record.toString());
+
+      for (String itemName : changes) {
+        // check if the corresponding change field has content
+        if (record.get(itemName) == null) {
+          continue;
+        }
+
+        switch (itemName) {
+          case "schemas":
+            try {
+              DatasetInfoDao.updateDatasetSchema(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: schema ", ex);
+            }
+            break;
+          case "owners":
+            try {
+              DatasetInfoDao.updateDatasetOwner(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: owner ", ex);
+            }
+            break;
+          case "references":
+            try {
+              DatasetInfoDao.updateDatasetReference(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: reference ", ex);
+            }
+            break;
+          case "partitionSpec":
+            try {
+              DatasetInfoDao.updateDatasetPartition(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: partition ", ex);
+            }
+            break;
+          case "deploymentInfo":
+            try {
+              DatasetInfoDao.updateDatasetDeployment(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: deployment ", ex);
+            }
+            break;
+          case "caseSensitivity":
+            try {
+              DatasetInfoDao.updateDatasetCaseSensitivity(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: case sensitivity ", ex);
+            }
+            break;
+          case "tags":
+            try {
+              DatasetInfoDao.updateDatasetTags(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: tag ", ex);
+            }
+            break;
+          case "constraints":
+            try {
+              DatasetInfoDao.updateDatasetConstraint(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: constraint ", ex);
+            }
+            break;
+          case "indices":
+            try {
+              DatasetInfoDao.updateDatasetIndex(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: index ", ex);
+            }
+            break;
+          case "capacity":
+            try {
+              DatasetInfoDao.updateDatasetCapacity(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: capacity ", ex);
+            }
+            break;
+          case "securitySpec":
+            try {
+              DatasetInfoDao.updateDatasetSecurity(rootNode);
+            } catch (Exception ex) {
+              Logger.debug("Metadata change exception: security ", ex);
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
+++ b/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
@@ -78,7 +78,7 @@ CREATE TABLE dataset_reference (
   `dataset_urn`      VARCHAR(200)       NOT NULL,
   `reference_type`   VARCHAR(20)        NOT NULL,
   `reference_format` VARCHAR(50)        NOT NULL,
-  `reference_list`   TEXT CHAR SET utf8 NOT NULL,
+  `reference_list`   TEXT CHAR SET utf8 DEFAULT NULL,
   `modified_time`    INT UNSIGNED DEFAULT NULL
   COMMENT 'the modified time in epoch',
   PRIMARY KEY (`dataset_id`, `reference_type`, `reference_format`),
@@ -126,15 +126,15 @@ CREATE TABLE dataset_constraint (
   `dataset_urn`           VARCHAR(200) NOT NULL,
   `constraint_type`       VARCHAR(20)  NOT NULL,
   `constraint_sub_type`   VARCHAR(20)  NOT NULL,
-  `constraint_name`       VARCHAR(50)  NOT NULL,
-  `constraint_expression` TEXT CHAR SET utf8 DEFAULT NULL,
+  `constraint_name`       VARCHAR(50)        DEFAULT NULL,
+  `constraint_expression` VARCHAR(200) NOT NULL,
   `enabled`               BOOLEAN      NOT NULL,
   `referred_fields`       TEXT               DEFAULT NULL,
   `additional_reference`  TEXT CHAR SET utf8 DEFAULT NULL,
   `modified_time`         INT UNSIGNED       DEFAULT NULL
   COMMENT 'the modified time in epoch',
-  PRIMARY KEY (`dataset_id`, `constraint_type`, `constraint_sub_type`, `constraint_name`),
-  UNIQUE KEY (`dataset_urn`, `constraint_type`, `constraint_sub_type`, `constraint_name`)
+  PRIMARY KEY (`dataset_id`, `constraint_type`, `constraint_sub_type`, `constraint_expression`),
+  UNIQUE KEY (`dataset_urn`, `constraint_type`, `constraint_sub_type`, `constraint_expression`)
 )
   ENGINE = InnoDB
   DEFAULT CHARSET = latin1;

--- a/data-model/DDL/ETL_DDL/dataset_metadata.sql
+++ b/data-model/DDL/ETL_DDL/dataset_metadata.sql
@@ -181,7 +181,7 @@ CREATE TABLE `dict_field_detail` (
   `is_distributed`     TINYINT(4)                    NULL
   COMMENT 'only in RDBMS',
   `is_recursive`       CHAR(1)                       NULL,
-  `confidential_flag`  VARCHAR(200)                  NULL,
+  `confidential_flags` VARCHAR(200)                  NULL,
   `default_value`      VARCHAR(200)                  NULL,
   `namespace`          VARCHAR(200)                  NULL,
   `java_data_type`     VARCHAR(50)                   NULL

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetConstraintRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetConstraintRecord.java
@@ -27,7 +27,7 @@ public class DatasetConstraintRecord extends AbstractRecord {
   String constraintExpression;
   Boolean enabled;
   List<DatasetFieldIndexRecord> referredFields;
-  Map<String, String> additionalReference;
+  Map<String, String> additionalReferences;
   Long modifiedTime;
 
   @Override
@@ -97,12 +97,12 @@ public class DatasetConstraintRecord extends AbstractRecord {
     this.referredFields = referredFields;
   }
 
-  public Map<String, String> getAdditionalReference() {
-    return additionalReference;
+  public Map<String, String> getAdditionalReferences() {
+    return additionalReferences;
   }
 
-  public void setAdditionalReference(Map<String, String> additionalReference) {
-    this.additionalReference = additionalReference;
+  public void setAdditionalReferences(Map<String, String> additionalReferences) {
+    this.additionalReferences = this.additionalReferences;
   }
 
   public Long getModifiedTime() {

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldIndexRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldIndexRecord.java
@@ -13,10 +13,11 @@
  */
 package wherehows.common.schemas;
 
-import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
-public class DatasetFieldIndexRecord extends AbstractRecord {
+public class DatasetFieldIndexRecord {
 
   Integer position;
   String fieldPath;
@@ -24,24 +25,14 @@ public class DatasetFieldIndexRecord extends AbstractRecord {
   Integer prefixLength;
   String filter;
 
-  @Override
-  public String[] getDbColumnNames() {
-    return new String[]{"position", "field_path", "descend", "prefix_length", "filter"};
-  }
-
-  @Override
-  public List<Object> fillAllFields() {
-    return null;
-  }
-
   public DatasetFieldIndexRecord() {
   }
 
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException ex) {
       return null;
     }
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldPathRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldPathRecord.java
@@ -13,23 +13,14 @@
  */
 package wherehows.common.schemas;
 
-import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
-public class DatasetFieldPathRecord extends AbstractRecord {
+public class DatasetFieldPathRecord {
 
   String fieldPath;
   String role;
-
-  @Override
-  public String[] getDbColumnNames() {
-    return new String[]{"field_path", "role"};
-  }
-
-  @Override
-  public List<Object> fillAllFields() {
-    return null;
-  }
 
   public DatasetFieldPathRecord() {
   }
@@ -37,8 +28,8 @@ public class DatasetFieldPathRecord extends AbstractRecord {
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException ex) {
       return null;
     }
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldSchemaRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldSchemaRecord.java
@@ -13,6 +13,8 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 
 
@@ -80,8 +82,8 @@ public class DatasetFieldSchemaRecord extends AbstractRecord {
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      return new ObjectMapper().writeValueAsString(this.getFieldValueMap());
+    } catch (Exception ex) {
       return null;
     }
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetGeographicAffinityRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetGeographicAffinityRecord.java
@@ -13,7 +13,11 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class DatasetGeographicAffinityRecord extends AbstractRecord {
@@ -37,8 +41,11 @@ public class DatasetGeographicAffinityRecord extends AbstractRecord {
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      Map<String, String> valueMap = new HashMap<>();
+      valueMap.put("affinity", affinity);
+      valueMap.put("locations", locations.toString());
+      return new ObjectMapper().writeValueAsString(valueMap);
+    } catch (JsonProcessingException ex) {
       return null;
     }
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetLocaleRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetLocaleRecord.java
@@ -13,24 +13,15 @@
  */
 package wherehows.common.schemas;
 
-import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
-public class DatasetLocaleRecord extends AbstractRecord {
+public class DatasetLocaleRecord {
 
   String language;
   String country;
   String variant;
-
-  @Override
-  public String[] getDbColumnNames() {
-    return new String[]{"language", "country", "variant"};
-  }
-
-  @Override
-  public List<Object> fillAllFields() {
-    return null;
-  }
 
   public DatasetLocaleRecord() {
   }
@@ -38,8 +29,8 @@ public class DatasetLocaleRecord extends AbstractRecord {
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException ex) {
       return null;
     }
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionKeyRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionKeyRecord.java
@@ -13,28 +13,20 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 
 
-public class DatasetPartitionKeyRecord extends AbstractRecord {
+public class DatasetPartitionKeyRecord {
 
   String partitionLevel;
   String partitionType;
   String timeFormat;
   String granularity;
   List<String> fieldNames;
+  List<String> partitionValues;
   Integer numberOfHashBuckets;
-
-  @Override
-  public String[] getDbColumnNames() {
-    return new String[]{"partition_level", "partition_type", "time_format", "granularity", "field_names",
-        "number_of_hash_buckets"};
-  }
-
-  @Override
-  public List<Object> fillAllFields() {
-    return null;
-  }
 
   public DatasetPartitionKeyRecord() {
   }
@@ -42,8 +34,8 @@ public class DatasetPartitionKeyRecord extends AbstractRecord {
   @Override
   public String toString() {
     try {
-      return this.getFieldValueMap().toString();
-    } catch (IllegalAccessException ex) {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException ex) {
       return null;
     }
   }
@@ -86,6 +78,14 @@ public class DatasetPartitionKeyRecord extends AbstractRecord {
 
   public void setFieldNames(List<String> fieldNames) {
     this.fieldNames = fieldNames;
+  }
+
+  public List<String> getPartitionValues() {
+    return partitionValues;
+  }
+
+  public void setPartitionValues(List<String> partitionValues) {
+    this.partitionValues = partitionValues;
   }
 
   public Integer getNumberOfHashBuckets() {


### PR DESCRIPTION
The MatadataChangeEvent processor checks for the changed items and calls the corresponding APIs with the Event avro record transferred JSON. 
If there are several change event including schema change, the schema change will be called first, since it can possibly insert new dataset so the other changes can use this dataset id. 