### PR TITLE
Modify HdfsLoad to improve speed, Add process_id and hostname to wh_etl_job_execution

### DIFF
--- a/backend-service/app/actors/EtlJobActor.java
+++ b/backend-service/app/actors/EtlJobActor.java
@@ -14,6 +14,7 @@
 package actors;
 
 import akka.actor.UntypedActor;
+import java.net.UnknownHostException;
 import metadata.etl.models.EtlJobStatus;
 import models.daos.EtlJobDao;
 import models.daos.EtlJobPropertyDao;
@@ -52,6 +53,9 @@ public class EtlJobActor extends UntypedActor {
 
         ConfigUtil.generateProperties(msg.getEtlJobName(), msg.getRefId(), msg.getWhEtlExecId(), props);
         process = Runtime.getRuntime().exec(cmd);
+
+        // update process id and hostname for started job
+        EtlJobDao.updateJobProcessInfo(msg.getWhEtlExecId(), getPid(process), getHostname());
 
         InputStream stdout = process.getInputStream();
         InputStreamReader isr = new InputStreamReader(stdout);
@@ -116,6 +120,18 @@ public class EtlJobActor extends UntypedActor {
       return fPid.getInt(process);
     } catch (Exception e) {
       return -1;
+    }
+  }
+
+  /**
+   * Return the hostname of the machine
+   * @return hostname, null if unknown
+   */
+  private static String getHostname() {
+    try {
+      return java.net.InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException ex) {
+      return null;
     }
   }
 }

--- a/backend-service/app/models/daos/EtlJobDao.java
+++ b/backend-service/app/models/daos/EtlJobDao.java
@@ -15,15 +15,21 @@ package models.daos;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import metadata.etl.models.EtlJobName;
 import metadata.etl.models.EtlJobStatus;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.support.KeyHolder;
 import play.libs.Time;
 import utils.JdbcUtil;
 import utils.JsonUtil;
 
 import java.sql.SQLException;
-import java.util.*;
 
 
 /**
@@ -53,6 +59,9 @@ public class EtlJobDao {
 
   public static final String END_RUN =
     "UPDATE wh_etl_job_execution set status = :status, message = :message, end_time = :endTime where wh_etl_exec_id = :whEtlExecId";
+
+  public static final String UPDATE_JOB_PROCESS_ID_AND_HOSTNAME =
+    "UPDATE wh_etl_job_execution SET process_id=?, host_name=? WHERE wh_etl_exec_id =?";
 
   public static final String UPDATE_JOB_STATUS =
     "UPDATE wh_etl_job SET is_active = :isActive WHERE wh_etl_job_name = :whEtlJobName and ref_id = :refId";
@@ -228,5 +237,10 @@ public class EtlJobDao {
     params.put("endTime", System.currentTimeMillis() / 1000);
     params.put("message", message);
     JdbcUtil.wherehowsNamedJdbcTemplate.update(END_RUN, params);
+  }
+
+  public static void updateJobProcessInfo(long whEtlExecId, int processId, String hostname)
+      throws DataAccessException {
+    JdbcUtil.wherehowsJdbcTemplate.update(UPDATE_JOB_PROCESS_ID_AND_HOSTNAME, processId, hostname, whEtlExecId);
   }
 }

--- a/data-model/DDL/ETL_DDL/etl_configure_tables.sql
+++ b/data-model/DDL/ETL_DDL/etl_configure_tables.sql
@@ -50,7 +50,7 @@ CREATE TABLE `wh_etl_job_execution` (
   COMMENT 'id of the etl job',
   `status`         VARCHAR(31)                  DEFAULT NULL
   COMMENT 'status of etl job execution',
-  `request_time`     INT(10) UNSIGNED             DEFAULT NULL
+  `request_time`   INT(10) UNSIGNED             DEFAULT NULL
   COMMENT 'request time of the execution',
   `start_time`     INT(10) UNSIGNED             DEFAULT NULL
   COMMENT 'start time of the execution',
@@ -58,6 +58,10 @@ CREATE TABLE `wh_etl_job_execution` (
   COMMENT 'end time of the execution',
   `message`        VARCHAR(1024)                DEFAULT NULL
   COMMENT 'debug information message',
+  `host_name`      VARCHAR(200)                 DEFAULT NULL
+  COMMENT 'host machine name of the job execution',
+  `process_id`     INT UNSIGNED                 DEFAULT NULL
+  COMMENT 'job execution process id',
   PRIMARY KEY (`wh_etl_exec_id`)
 )
   ENGINE = InnoDB
@@ -120,10 +124,10 @@ CREATE TABLE `cfg_application` (
   ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-CREATE TABLE cfg_database  ( 
+CREATE TABLE cfg_database  (
 	db_id                  	smallint(6) UNSIGNED NOT NULL,
 	db_code                	varchar(30) COMMENT 'Unique string without space'  NOT NULL,
-	primary_dataset_type    varchar(30) COMMENT 'What type of dataset this DB supports' NOT NULL DEFAULT '*', 
+	primary_dataset_type    varchar(30) COMMENT 'What type of dataset this DB supports' NOT NULL DEFAULT '*',
 	description            	varchar(128) NOT NULL,
 	is_logical             	char(1) COMMENT 'Is a group, which contains multiple physical DB(s)'  NOT NULL DEFAULT 'N',
 	deployment_tier        	varchar(20) COMMENT 'Lifecycle/FabricGroup: local,dev,sit,ei,qa,canary,preprod,pr'  NULL DEFAULT 'prod',
@@ -146,7 +150,7 @@ ENGINE = InnoDB
 DEFAULT CHARSET = utf8
 COMMENT = 'Abstract different storage instances as databases' ;
 
-CREATE TABLE stg_cfg_object_name_map  ( 
+CREATE TABLE stg_cfg_object_name_map  (
 	object_type             	varchar(100) NOT NULL,
 	object_sub_type         	varchar(100) NULL,
 	object_name             	varchar(350) NOT NULL,
@@ -168,10 +172,10 @@ CHARACTER SET latin1
 COLLATE latin1_swedish_ci
 COMMENT = 'Map alias (when is_identical_map=Y) and view dependency' ;
 
-CREATE INDEX idx_stg_cfg_object_name_map__mappedobjectname USING BTREE 
+CREATE INDEX idx_stg_cfg_object_name_map__mappedobjectname USING BTREE
 	ON stg_cfg_object_name_map(mapped_object_name);
 
-CREATE TABLE cfg_object_name_map  ( 
+CREATE TABLE cfg_object_name_map  (
   obj_name_map_id         int(11) AUTO_INCREMENT NOT NULL,
   object_type             varchar(100) NOT NULL,
   object_sub_type         varchar(100) NULL,
@@ -196,11 +200,11 @@ ALTER TABLE cfg_object_name_map
   ADD CONSTRAINT uix_cfg_object_name_map__objectname_mappedobjectname
   UNIQUE (object_name, mapped_object_name);
 
-CREATE INDEX idx_cfg_object_name_map__mappedobjectname USING BTREE 
+CREATE INDEX idx_cfg_object_name_map__mappedobjectname USING BTREE
   ON cfg_object_name_map(mapped_object_name);
 
 
-CREATE TABLE cfg_deployment_tier  ( 
+CREATE TABLE cfg_deployment_tier  (
   tier_id      	tinyint(4) NOT NULL,
   tier_code    	varchar(25) COMMENT 'local,dev,test,qa,stg,prod' NOT NULL,
   tier_label    varchar(50) COMMENT 'display full name' NULL,
@@ -215,7 +219,7 @@ COMMENT = 'http://en.wikipedia.org/wiki/Deployment_environment';
 CREATE UNIQUE INDEX uix_cfg_deployment_tier__tiercode
 	ON cfg_deployment_tier(tier_code);
 
-CREATE TABLE cfg_data_center  ( 
+CREATE TABLE cfg_data_center  (
 	data_center_id    	smallint(6) NOT NULL DEFAULT '0',
 	data_center_code  	varchar(30) NOT NULL,
 	data_center_name  	varchar(50) NOT NULL,
@@ -237,7 +241,7 @@ CREATE UNIQUE INDEX uix_cfg_data_center__datacentercode
 	ON cfg_data_center(data_center_code);
 
 
-CREATE TABLE cfg_cluster  ( 
+CREATE TABLE cfg_cluster  (
 	cluster_id    	        smallint(6) NOT NULL DEFAULT '0',
 	cluster_code  	        varchar(80) NOT NULL,
 	cluster_short_name      varchar(50) NOT NULL,

--- a/metadata-etl/src/main/java/metadata/etl/dataset/hdfs/HdfsMetadataEtl.java
+++ b/metadata-etl/src/main/java/metadata/etl/dataset/hdfs/HdfsMetadataEtl.java
@@ -68,7 +68,7 @@ public class HdfsMetadataEtl extends EtlJob {
   @Override
   public void extract()
     throws Exception {
-    logger.info("Begin hdfs metadata extract!");
+    logger.info("Begin hdfs metadata extract! - " + prop.getProperty(Constant.WH_EXEC_ID_KEY));
     boolean isRemote = Boolean.valueOf(prop.getProperty(Constant.HDFS_REMOTE, "false"));
     if (isRemote) {
       extractRemote();
@@ -246,7 +246,7 @@ public class HdfsMetadataEtl extends EtlJob {
   @Override
   public void transform()
     throws Exception {
-    logger.info("hdfs metadata transform");
+    logger.info("Begin hdfs metadata transform : " + prop.getProperty(Constant.WH_EXEC_ID_KEY));
     // call a python script to do the transformation
     InputStream inputStream = classLoader.getResourceAsStream("jython/HdfsTransform.py");
     interpreter.execfile(inputStream);
@@ -256,11 +256,11 @@ public class HdfsMetadataEtl extends EtlJob {
   @Override
   public void load()
     throws Exception {
-    logger.info("hdfs metadata load");
+    logger.info("Begin hdfs metadata load : " + prop.getProperty(Constant.WH_EXEC_ID_KEY));
     // load into mysql
     InputStream inputStream = classLoader.getResourceAsStream("jython/HdfsLoad.py");
     interpreter.execfile(inputStream);
     inputStream.close();
-    logger.info("hdfs metadata load finished");
+    logger.info("hdfs metadata load finished : " + prop.getProperty(Constant.WH_EXEC_ID_KEY));
   }
 }


### PR DESCRIPTION
1. Modify HdfsLoad job to improve speed on some tasks
2. Add exec_id info in HdfsLoad job logging
3. Add host_name and process_id in wh_etl_job_execution table to provide better execution tracking of ETL jobs.