### PR TITLE
Add Database to create_tables readme

### DIFF
--- a/data-model/DDL/readme.MD
+++ b/data-model/DDL/readme.MD
@@ -1,7 +1,7 @@
 It is pretty easy to create all metadata tables in mysql client.
 ```
 cd WhereHows/data-model/DDL
-mysql -hlocalhost -uwherehows -pwherehows wherehows < create_all_tables_wrapper.sql
+mysql -hlocalhost -uwherehows -pwherehows -Dwherehows < create_all_tables_wrapper.sql
 ```
 
 It is also fine to load each DDL files into a GUI client such as [DBeaver][DBV] or [Aqua Data Studio][ADS]

--- a/data-model/DDL/readme.MD
+++ b/data-model/DDL/readme.MD
@@ -1,7 +1,7 @@
 It is pretty easy to create all metadata tables in mysql client.
 ```
 cd WhereHows/data-model/DDL
-mysql -hlocalhost -uwherehows -pwherehows < create_all_tables_wrapper.sql
+mysql -hlocalhost -uwherehows -pwherehows wherehows < create_all_tables_wrapper.sql
 ```
 
 It is also fine to load each DDL files into a GUI client such as [DBeaver][DBV] or [Aqua Data Studio][ADS]


### PR DESCRIPTION
Currently, when copying the recommended command from the README, MySQL throws a missing database error.