### PR TITLE
Update backend APIs to cast SQL results back to Java record then to Json

### DIFF
--- a/backend-service/app/controllers/DatasetInfoController.java
+++ b/backend-service/app/controllers/DatasetInfoController.java
@@ -13,11 +13,8 @@
  */
 package controllers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -29,10 +26,17 @@ import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Controller;
 import play.mvc.Result;
-import wherehows.common.schemas.DatasetGeographicAffinityRecord;
-import wherehows.common.schemas.DatasetRetentionRecord;
+import wherehows.common.schemas.DatasetCapacityRecord;
+import wherehows.common.schemas.DatasetCaseSensitiveRecord;
+import wherehows.common.schemas.DatasetConstraintRecord;
+import wherehows.common.schemas.DatasetDeploymentRecord;
+import wherehows.common.schemas.DatasetIndexRecord;
+import wherehows.common.schemas.DatasetOwnerRecord;
+import wherehows.common.schemas.DatasetPartitionRecord;
+import wherehows.common.schemas.DatasetReferenceRecord;
+import wherehows.common.schemas.DatasetSchemaInfoRecord;
 import wherehows.common.schemas.DatasetSecurityRecord;
-import wherehows.common.utils.StringUtil;
+import wherehows.common.schemas.DatasetTagRecord;
 
 
 public class DatasetInfoController extends Controller {
@@ -45,9 +49,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> deployments = DatasetInfoDao.getDatasetDeploymentByDatasetId(datasetId);
+        List<DatasetDeploymentRecord> records = DatasetInfoDao.getDatasetDeploymentByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_deployment_info", Json.toJson(deployments));
+        resultJson.set("deploymentInfo", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -64,9 +68,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> deployments = DatasetInfoDao.getDatasetDeploymentByDatasetUrn(urn);
+        List<DatasetDeploymentRecord> records = DatasetInfoDao.getDatasetDeploymentByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_deployment_info", Json.toJson(deployments));
+        resultJson.set("deploymentInfo", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -105,9 +109,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> capacity = DatasetInfoDao.getDatasetCapacityByDatasetId(datasetId);
+        List<DatasetCapacityRecord> records = DatasetInfoDao.getDatasetCapacityByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_capacity_info", Json.toJson(capacity));
+        resultJson.set("capacity", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -124,9 +128,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> capacity = DatasetInfoDao.getDatasetCapacityByDatasetUrn(urn);
+        List<DatasetCapacityRecord> records = DatasetInfoDao.getDatasetCapacityByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_capacity_info", Json.toJson(capacity));
+        resultJson.set("capacity", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -165,9 +169,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> tags = DatasetInfoDao.getDatasetTagByDatasetId(datasetId);
+        List<DatasetTagRecord> records = DatasetInfoDao.getDatasetTagByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_tags", Json.toJson(tags));
+        resultJson.set("capacity", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -184,9 +188,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> tags = DatasetInfoDao.getDatasetTagByDatasetUrn(urn);
+        List<DatasetTagRecord> records = DatasetInfoDao.getDatasetTagByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_tags", Json.toJson(tags));
+        resultJson.set("capacity", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -225,9 +229,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        Map<String, Object> caseSensitive = DatasetInfoDao.getDatasetCaseSensitivityByDatasetId(datasetId);
+        DatasetCaseSensitiveRecord record = DatasetInfoDao.getDatasetCaseSensitivityByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_case_sensitive", Json.toJson(caseSensitive));
+        resultJson.set("caseSensitivity", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -244,9 +248,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        Map<String, Object> caseSensitive = DatasetInfoDao.getDatasetCaseSensitivityByDatasetUrn(urn);
+        DatasetCaseSensitiveRecord record = DatasetInfoDao.getDatasetCaseSensitivityByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_case_sensitive", Json.toJson(caseSensitive));
+        resultJson.set("caseSensitivity", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -285,9 +289,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> reference = DatasetInfoDao.getDatasetReferenceByDatasetId(datasetId);
+        List<DatasetReferenceRecord> records = DatasetInfoDao.getDatasetReferenceByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_reference", Json.toJson(reference));
+        resultJson.set("references", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -304,9 +308,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> reference = DatasetInfoDao.getDatasetReferenceByDatasetUrn(urn);
+        List<DatasetReferenceRecord> records = DatasetInfoDao.getDatasetReferenceByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_reference", Json.toJson(reference));
+        resultJson.set("references", Json.toJson(records));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -345,9 +349,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        Map<String, Object> partition = DatasetInfoDao.getDatasetPartitionByDatasetId(datasetId);
+        DatasetPartitionRecord record = DatasetInfoDao.getDatasetPartitionByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_partition", Json.toJson(partition));
+        resultJson.set("partitionSpec", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -364,9 +368,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        Map<String, Object> partition = DatasetInfoDao.getDatasetPartitionByDatasetUrn(urn);
+        DatasetPartitionRecord record = DatasetInfoDao.getDatasetPartitionByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_partition", Json.toJson(partition));
+        resultJson.set("partitionSpec", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -405,10 +409,8 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        Map<String, Object> security = DatasetInfoDao.getDatasetSecurityByDatasetId(datasetId);
-        DatasetSecurityRecord record = convertToDatasetSecurityRecord(security);
+        DatasetSecurityRecord record = DatasetInfoDao.getDatasetSecurityByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.put("datasetId", record.getDatasetId());
         resultJson.set("securitySpec", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
@@ -426,10 +428,8 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        Map<String, Object> security = DatasetInfoDao.getDatasetSecurityByDatasetUrn(urn);
-        DatasetSecurityRecord record = convertToDatasetSecurityRecord(security);
+        DatasetSecurityRecord record = DatasetInfoDao.getDatasetSecurityByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.put("datasetId", record.getDatasetId());
         resultJson.set("securitySpec", Json.toJson(record));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
@@ -443,32 +443,6 @@ public class DatasetInfoController extends Controller {
     resultJson.put("return_code", 400);
     resultJson.put("error_message", "No parameter provided");
     return ok(resultJson);
-  }
-
-  private static DatasetSecurityRecord convertToDatasetSecurityRecord(Map<String, Object> map) {
-    DatasetSecurityRecord record = new DatasetSecurityRecord();
-    ObjectMapper om = new ObjectMapper();
-    try {
-      record.setDatasetId(StringUtil.toInt(map.get("dataset_id")));
-      record.setDatasetUrn((String) map.get("dataset_urn"));
-      record.setClassification(
-          om.readValue((String) map.get("classification"), new TypeReference<Map<String, Integer>>() {
-          }));
-      record.setRecordOwnerType((String) map.get("record_owner_type"));
-      record.setRecordOwner(om.readValue((String) map.get("record_owner"), new TypeReference<List<String>>() {
-      }));
-      record.setComplianceType((String) map.get("compliance_type"));
-      record.setRetentionPolicy(
-          om.readValue((String) map.get("retention_policy"), new TypeReference<DatasetRetentionRecord>() {
-          }));
-      record.setGeographicAffinity(
-          om.readValue((String) map.get("geographic_affinity"), new TypeReference<DatasetGeographicAffinityRecord>() {
-          }));
-      record.setModifiedTime((Long) map.get("modified_time"));
-    } catch (IOException ex) {
-      Logger.debug("Can't serialize DB results: security " + map.toString(), ex);
-    }
-    return record;
   }
 
   @BodyParser.Of(BodyParser.Json.class)
@@ -495,9 +469,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> owners = DatasetInfoDao.getDatasetOwnerByDatasetId(datasetId);
+        List<DatasetOwnerRecord> owners = DatasetInfoDao.getDatasetOwnerByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_owner", Json.toJson(owners));
+        resultJson.set("owners", Json.toJson(owners));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -514,9 +488,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> owners = DatasetInfoDao.getDatasetOwnerByDatasetUrn(urn);
+        List<DatasetOwnerRecord> owners = DatasetInfoDao.getDatasetOwnerByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_owner", Json.toJson(owners));
+        resultJson.set("owners", Json.toJson(owners));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -555,9 +529,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> constraints = DatasetInfoDao.getDatasetConstraintByDatasetId(datasetId);
+        List<DatasetConstraintRecord> constraints = DatasetInfoDao.getDatasetConstraintByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_constraints", Json.toJson(constraints));
+        resultJson.set("constraints", Json.toJson(constraints));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -574,9 +548,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> constraints = DatasetInfoDao.getDatasetConstraintByDatasetUrn(urn);
+        List<DatasetConstraintRecord> constraints = DatasetInfoDao.getDatasetConstraintByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_constraints", Json.toJson(constraints));
+        resultJson.set("constraints", Json.toJson(constraints));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -615,9 +589,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        List<Map<String, Object>> indices = DatasetInfoDao.getDatasetIndexByDatasetId(datasetId);
+        List<DatasetIndexRecord> indices = DatasetInfoDao.getDatasetIndexByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_indices", Json.toJson(indices));
+        resultJson.set("indices", Json.toJson(indices));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -634,9 +608,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        List<Map<String, Object>> indices = DatasetInfoDao.getDatasetIndexByDatasetUrn(urn);
+        List<DatasetIndexRecord> indices = DatasetInfoDao.getDatasetIndexByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_indices", Json.toJson(indices));
+        resultJson.set("indices", Json.toJson(indices));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -675,9 +649,9 @@ public class DatasetInfoController extends Controller {
       int datasetId = Integer.parseInt(datasetIdString);
 
       try {
-        Map<String, Object> schema = DatasetInfoDao.getDatasetSchemaByDatasetId(datasetId);
+        DatasetSchemaInfoRecord schema = DatasetInfoDao.getDatasetSchemaByDatasetId(datasetId);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_schema", Json.toJson(schema));
+        resultJson.set("schemas", Json.toJson(schema));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException dataset id: " + datasetId, e);
         resultJson.put("return_code", 404);
@@ -694,9 +668,9 @@ public class DatasetInfoController extends Controller {
         return ok(resultJson);
       }
       try {
-        Map<String, Object> schema = DatasetInfoDao.getDatasetSchemaByDatasetUrn(urn);
+        DatasetSchemaInfoRecord schema = DatasetInfoDao.getDatasetSchemaByDatasetUrn(urn);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_schema", Json.toJson(schema));
+        resultJson.set("schemas", Json.toJson(schema));
       } catch (EmptyResultDataAccessException e) {
         Logger.debug("DataAccessException urn: " + urn, e);
         resultJson.put("return_code", 404);
@@ -745,12 +719,11 @@ public class DatasetInfoController extends Controller {
         List<Map<String, Object>> items =
             DatasetInfoDao.getDatasetInventoryItems(dataPlatform, nativeName, dataOrigin, limit);
         resultJson.put("return_code", 200);
-        resultJson.set("dataset_inventory_items", Json.toJson(items));
+        resultJson.set("datasetList", Json.toJson(items));
       } catch (EmptyResultDataAccessException e) {
-        Logger.debug("DataAccessException nativeName: " + nativeName + " , dataOrigin: " + dataOrigin, e);
         resultJson.put("return_code", 404);
         resultJson.put("error_message",
-            "dataset inventory for " + nativeName + " at " + dataOrigin + " cannot be found!");
+            "dataset inventory for " + dataPlatform + " - " + nativeName + " - " + dataOrigin + " cannot be found!");
       }
       return ok(resultJson);
     }

--- a/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
+++ b/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
@@ -158,7 +158,7 @@ CREATE TABLE dataset_schema_info (
   `dataset_id`                   INT UNSIGNED NOT NULL,
   `dataset_urn`                  VARCHAR(200) NOT NULL,
   `is_latest_revision`           BOOLEAN      NOT NULL,
-  `create_time`                  LONG         NOT NULL,
+  `create_time`                  BIGINT       NOT NULL,
   `revision`                     INT UNSIGNED             DEFAULT NULL,
   `version`                      VARCHAR(20)              DEFAULT NULL,
   `name`                         VARCHAR(100)             DEFAULT NULL,

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetCapacityRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetCapacityRecord.java
@@ -23,8 +23,8 @@ public class DatasetCapacityRecord extends AbstractRecord {
   String capacityName;
   String capacityType;
   String capacityUnit;
-  String capacityLow;
-  String capacityHigh;
+  Long capacityLow;
+  Long capacityHigh;
   Long modifiedTime;
 
   @Override
@@ -41,8 +41,19 @@ public class DatasetCapacityRecord extends AbstractRecord {
   public DatasetCapacityRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 
@@ -70,19 +81,19 @@ public class DatasetCapacityRecord extends AbstractRecord {
     this.capacityUnit = capacityUnit;
   }
 
-  public String getCapacityLow() {
+  public Long getCapacityLow() {
     return capacityLow;
   }
 
-  public void setCapacityLow(String capacityLow) {
+  public void setCapacityLow(Long capacityLow) {
     this.capacityLow = capacityLow;
   }
 
-  public String getCapacityHigh() {
+  public Long getCapacityHigh() {
     return capacityHigh;
   }
 
-  public void setCapacityHigh(String capacityHigh) {
+  public void setCapacityHigh(Long capacityHigh) {
     this.capacityHigh = capacityHigh;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetCaseSensitiveRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetCaseSensitiveRecord.java
@@ -42,21 +42,19 @@ public class DatasetCaseSensitiveRecord extends AbstractRecord {
   public DatasetCaseSensitiveRecord() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      Map<String, Object> valueMap = new HashMap<>();
-      valueMap.put("datasetName", datasetName);
-      valueMap.put("fieldName", fieldName);
-      valueMap.put("dataContent", dataContent);
-      return new ObjectMapper().writeValueAsString(valueMap);
-    } catch (Exception ex) {
-      return null;
-    }
+  public Integer getDatasetId() {
+    return datasetId;
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetChangeAuditStamp.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetChangeAuditStamp.java
@@ -27,15 +27,6 @@ public class DatasetChangeAuditStamp {
   public DatasetChangeAuditStamp() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException ex) {
-      return null;
-    }
-  }
-
   public String getActorUrn() {
     return actorUrn;
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetConstraintRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetConstraintRecord.java
@@ -44,8 +44,19 @@ public class DatasetConstraintRecord extends AbstractRecord {
   public DatasetConstraintRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetDeploymentRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetDeploymentRecord.java
@@ -44,8 +44,19 @@ public class DatasetDeploymentRecord extends AbstractRecord {
   public DatasetDeploymentRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldIndexRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldIndexRecord.java
@@ -28,15 +28,6 @@ public class DatasetFieldIndexRecord {
   public DatasetFieldIndexRecord() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException ex) {
-      return null;
-    }
-  }
-
   public Integer getPosition() {
     return position;
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldPathRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldPathRecord.java
@@ -25,15 +25,6 @@ public class DatasetFieldPathRecord {
   public DatasetFieldPathRecord() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException ex) {
-      return null;
-    }
-  }
-
   public String getFieldPath() {
     return fieldPath;
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldSchemaRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetFieldSchemaRecord.java
@@ -13,6 +13,7 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -62,6 +63,7 @@ public class DatasetFieldSchemaRecord extends AbstractRecord {
     return null;
   }
 
+  @JsonIgnore
   public String[] getFieldDetailColumns() {
     return new String[]{"dataset_id", "sort_id", "parent_sort_id", "parent_path", "field_name", "fields_layout_id",
         "field_label", "data_type", "data_size", "data_precision", "data_fraction", "is_nullable", "is_indexed",
@@ -69,6 +71,7 @@ public class DatasetFieldSchemaRecord extends AbstractRecord {
         "comment_ids"};
   }
 
+  @JsonIgnore
   public Object[] getFieldDetailValues() {
     return new Object[]{datasetId, position, parentFieldPosition, parentPath, fieldName, 0, label, type, maxCharLength,
         precision, scale, nullable != null && nullable ? "Y" : "N", indexed != null && indexed ? "Y" : "N",
@@ -77,15 +80,6 @@ public class DatasetFieldSchemaRecord extends AbstractRecord {
   }
 
   public DatasetFieldSchemaRecord() {
-  }
-
-  @Override
-  public String toString() {
-    try {
-      return new ObjectMapper().writeValueAsString(this.getFieldValueMap());
-    } catch (Exception ex) {
-      return null;
-    }
   }
 
   public Integer getDatasetId() {

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetIndexRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetIndexRecord.java
@@ -40,8 +40,19 @@ public class DatasetIndexRecord extends AbstractRecord {
   public DatasetIndexRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetInventoryItemRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetInventoryItemRecord.java
@@ -13,6 +13,7 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 
@@ -34,12 +35,14 @@ public class DatasetInventoryItemRecord extends AbstractRecord {
     return null;
   }
 
+  @JsonIgnore
   public static String[] getInventoryItemColumns() {
     return new String[]{"native_name", "data_origin", "data_platform", "event_date", "change_actor_urn", "change_type",
         "change_time", "change_note", "native_type", "uri", "dataset_name_case_sensitivity",
         "field_name_case_sensitivity", "data_content_case_sensitivity"};
   }
 
+  @JsonIgnore
   public Object[] getInventoryItemValues() {
     if (datasetProperties == null) {
       return new Object[]{nativeName, dataOrigin, dataPlatformUrn, eventDate, null, null, null, null, null, null, null,

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetInventoryPropertiesRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetInventoryPropertiesRecord.java
@@ -40,20 +40,6 @@ public class DatasetInventoryPropertiesRecord extends AbstractRecord {
   public DatasetInventoryPropertiesRecord() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      Map<String, String> valueMap = new HashMap<>();
-      valueMap.put("changeAuditStamp", changeAuditStamp.toString());
-      valueMap.put("nativeType", nativeType);
-      valueMap.put("uri", uri);
-      valueMap.put("caseSensitivity", caseSensitivity.toString());
-      return new ObjectMapper().writeValueAsString(valueMap);
-    } catch (JsonProcessingException ex) {
-      return null;
-    }
-  }
-
   public DatasetChangeAuditStamp getChangeAuditStamp() {
     return changeAuditStamp;
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetOwnerRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetOwnerRecord.java
@@ -13,6 +13,7 @@
  */
 package wherehows.common.schemas;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,11 +56,13 @@ public class DatasetOwnerRecord extends AbstractRecord {
     return allFields;
   }
 
+  @JsonIgnore
   public String[] getDbColumnForUnmatchedOwner() {
     return new String[]{"dataset_urn", "app_id", "owner_type", "owner_sub_type", "owner_id", "owner_id_type",
         "is_group", "is_active", "sort_id", "namespace", "owner_source", "db_name", "db_id", "source_time"};
   }
 
+  @JsonIgnore
   public Object[] getValuesForUnmatchedOwner() {
     return new Object[]{datasetUrn, appId, ownerCategory, ownerSubCategory, owner, ownerType, isGroup,
         isActive, sortId, namespace, ownerSource, "N/A", dbIds, sourceTime};

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionKeyRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionKeyRecord.java
@@ -31,15 +31,6 @@ public class DatasetPartitionKeyRecord {
   public DatasetPartitionKeyRecord() {
   }
 
-  @Override
-  public String toString() {
-    try {
-      return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException ex) {
-      return null;
-    }
-  }
-
   public String getPartitionLevel() {
     return partitionLevel;
   }

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetPartitionRecord.java
@@ -42,8 +42,19 @@ public class DatasetPartitionRecord extends AbstractRecord {
   public DatasetPartitionRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetReferenceRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetReferenceRecord.java
@@ -39,8 +39,19 @@ public class DatasetReferenceRecord extends AbstractRecord {
   public DatasetReferenceRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetSchemaInfoRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetSchemaInfoRecord.java
@@ -55,8 +55,19 @@ public class DatasetSchemaInfoRecord extends AbstractRecord {
   public DatasetSchemaInfoRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/schemas/DatasetTagRecord.java
+++ b/wherehows-common/src/main/java/wherehows/common/schemas/DatasetTagRecord.java
@@ -36,8 +36,19 @@ public class DatasetTagRecord extends AbstractRecord {
   public DatasetTagRecord() {
   }
 
-  public void setDataset(Integer datasetId, String datasetUrn) {
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
+  }
+
+  public String getDatasetUrn() {
+    return datasetUrn;
+  }
+
+  public void setDatasetUrn(String datasetUrn) {
     this.datasetUrn = datasetUrn;
   }
 

--- a/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
+++ b/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
@@ -50,15 +50,6 @@ public class StringUtil {
     }
   }
 
-  public static Object objectToString(Object obj) {
-    if (obj instanceof Collection || obj instanceof Map || obj instanceof Record) {
-      return obj.toString();
-    } else if (obj instanceof Object[]) {
-      return Arrays.toString((Object[]) obj);
-    }
-    return obj;
-  }
-
   public static Object objectToJsonString(Object obj) {
     if (obj instanceof Collection || obj instanceof Map || obj instanceof Object[] || obj instanceof Record) {
       try {


### PR DESCRIPTION
backend APIs related to MetadataChangeEvent will cast the Mysql query results Map<String, Object> to corresponding Java Record, then serialize the record to Json and send to REST reply. This way, the post and get Json format is consistent. 
This is for better debugging and easier frontend usage. 
Also correct the multiple escape characters in return Json string issue.