### PR TITLE
Update Kafka consumer actors to reduce memory usage

### DIFF
--- a/backend-service/app/actors/KafkaConsumerMaster.java
+++ b/backend-service/app/actors/KafkaConsumerMaster.java
@@ -29,11 +29,11 @@ import metadata.etl.models.EtlJobName;
 import models.daos.ClusterDao;
 import models.daos.EtlJobDao;
 
-import msgs.KafkaResponseMsg;
+import msgs.KafkaCommMsg;
 import play.Logger;
 import play.Play;
-import utils.KafkaConfig;
-import utils.KafkaConfig.Topic;
+import models.kafka.KafkaConfig;
+import models.kafka.KafkaConfig.Topic;
 import wherehows.common.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import wherehows.common.kafka.schemaregistry.client.SchemaRegistryClient;
 import wherehows.common.utils.ClusterUtil;
@@ -132,9 +132,9 @@ public class KafkaConsumerMaster extends UntypedActor {
   @Override
   public void onReceive(Object message)
       throws Exception {
-    if (message instanceof KafkaResponseMsg) {
-      final KafkaResponseMsg kafkaMsg = (KafkaResponseMsg) message;
-      Logger.debug("Got kafka response message: " + kafkaMsg.toString());
+    if (message instanceof KafkaCommMsg) {
+      final KafkaCommMsg kafkaCommMsg = (KafkaCommMsg) message;
+      Logger.debug(kafkaCommMsg.toString());
     } else {
       unhandled(message);
     }

--- a/backend-service/app/actors/KafkaConsumerWorker.java
+++ b/backend-service/app/actors/KafkaConsumerWorker.java
@@ -24,7 +24,7 @@ import kafka.consumer.KafkaStream;
 import kafka.message.MessageAndMetadata;
 
 import akka.actor.UntypedActor;
-import msgs.KafkaResponseMsg;
+import msgs.KafkaCommMsg;
 import play.Logger;
 import wherehows.common.kafka.schemaregistry.client.SchemaRegistryClient;
 import wherehows.common.kafka.serializers.KafkaAvroDeserializer;

--- a/backend-service/app/actors/KafkaConsumerWorker.java
+++ b/backend-service/app/actors/KafkaConsumerWorker.java
@@ -13,8 +13,10 @@
  */
 package actors;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 import org.apache.avro.generic.GenericData;
 import org.apache.kafka.common.serialization.Deserializer;
 import kafka.consumer.ConsumerIterator;
@@ -27,6 +29,7 @@ import play.Logger;
 import wherehows.common.kafka.schemaregistry.client.SchemaRegistryClient;
 import wherehows.common.kafka.serializers.KafkaAvroDeserializer;
 import wherehows.common.schemas.AbstractRecord;
+import wherehows.common.writers.DatabaseWriter;
 
 
 /**
@@ -39,16 +42,22 @@ public class KafkaConsumerWorker extends UntypedActor {
   private final SchemaRegistryClient _schemaRegistryRestfulClient;
   private final Object _processorClass;
   private final Method _processorMethod;
+  private final DatabaseWriter _dbWriter;
+  private int _receivedRecordCount;
+  private int _processedRecordCount;
 
   public KafkaConsumerWorker(String topic, int threadNumber,
       KafkaStream<byte[], byte[]> stream, SchemaRegistryClient schemaRegistryRestfulClient,
-      Object processorClass, Method processorMethod) {
+      Object processorClass, Method processorMethod, DatabaseWriter dbWriter) {
     this._topic = topic;
     this._threadId = threadNumber;
     this._kafkaStream = stream;
     this._schemaRegistryRestfulClient = schemaRegistryRestfulClient;
     this._processorClass = processorClass;
     this._processorMethod = processorMethod;
+    this._dbWriter = dbWriter;
+    this._receivedRecordCount = 0;  // number of received kafka messages
+    this._processedRecordCount = 0; // number of processed records
   }
 
   @Override
@@ -59,22 +68,35 @@ public class KafkaConsumerWorker extends UntypedActor {
       final Deserializer<Object> avroDeserializer = new KafkaAvroDeserializer(_schemaRegistryRestfulClient);
 
       while (it.hasNext()) { // block for next input
+        _receivedRecordCount++;
+
         try {
           MessageAndMetadata<byte[], byte[]> msg = it.next();
           GenericData.Record kafkaMsgRecord = (GenericData.Record) avroDeserializer.deserialize(_topic, msg.message());
           // Logger.debug("Kafka worker ThreadId " + _threadId + " Topic " + _topic + " record: " + rec);
 
+          // invoke processor
           final AbstractRecord record = (AbstractRecord) _processorMethod.invoke(
               _processorClass, kafkaMsgRecord, _topic);
-          // send processed record to master
+
+          // save record to database
           if (record != null) {
-            getSender().tell(new KafkaResponseMsg(record, _topic), getSelf());
+            _dbWriter.append(record);
+            // _dbWriter.close();
+            _dbWriter.insert();
+            _processedRecordCount++;
           }
         } catch (InvocationTargetException ite) {
           Logger.error("Processing topic " + _topic + " record error: " + ite.getCause()
               + " - " + ite.getTargetException());
+        } catch (SQLException | IOException e) {
+          Logger.error("Error while inserting event record: ", e);
         } catch (Throwable ex) {
           Logger.error("Error in notify order. ", ex);
+        }
+
+        if (_receivedRecordCount % 1000 == 0) {
+          Logger.debug(_topic + " received " + _receivedRecordCount + " processed " + _processedRecordCount);
         }
       }
       Logger.info("Shutting down Thread: " + _threadId + " for topic: " + _topic);

--- a/backend-service/app/controllers/DatasetController.java
+++ b/backend-service/app/controllers/DatasetController.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.List;
 import models.daos.DatasetDao;
 import models.daos.UserDao;
-import models.utils.Urn;
+import utils.Urn;
 import org.springframework.dao.EmptyResultDataAccessException;
 import play.Logger;
 import play.libs.Json;

--- a/backend-service/app/controllers/DatasetInfoController.java
+++ b/backend-service/app/controllers/DatasetInfoController.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import models.daos.DatasetInfoDao;
-import models.utils.Urn;
+import utils.Urn;
 import org.springframework.dao.EmptyResultDataAccessException;
 import play.Logger;
 import play.libs.Json;

--- a/backend-service/app/controllers/LineageController.java
+++ b/backend-service/app/controllers/LineageController.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import models.daos.LineageDao;
-import models.utils.Urn;
+import utils.Urn;
 import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Controller;

--- a/backend-service/app/models/daos/DatasetInfoDao.java
+++ b/backend-service/app/models/daos/DatasetInfoDao.java
@@ -22,7 +22,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import models.utils.Urn;
+import utils.Urn;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import play.Logger;

--- a/backend-service/app/models/daos/LineageDao.java
+++ b/backend-service/app/models/daos/LineageDao.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import models.utils.Urn;
+import utils.Urn;
 import utils.JdbcUtil;
 import wherehows.common.schemas.LineageRecord;
 import wherehows.common.utils.PartitionPatternMatcher;

--- a/backend-service/app/models/kafka/GobblinTrackingAuditProcessor.java
+++ b/backend-service/app/models/kafka/GobblinTrackingAuditProcessor.java
@@ -41,8 +41,8 @@ public class GobblinTrackingAuditProcessor extends KafkaConsumerProcessor {
   public Record process(GenericData.Record record, String topic)
       throws Exception {
 
-    if (record != null) {
-      String name = (String) record.get("name");
+    if (record != null && record.get("name") != null) {
+      final String name = record.get("name").toString();
       // only handle "DaliLimitedRetentionAuditor","DaliAutoPurgeAuditor" and "DsIgnoreIDPCAuditor"
       if (name.equals(DALI_LIMITED_RETENTION_AUDITOR)
           || name.equals(DALI_AUTOPURGED_AUDITOR)
@@ -52,10 +52,10 @@ public class GobblinTrackingAuditProcessor extends KafkaConsumerProcessor {
 
         String hasError = metadata.get("HasError");
         if (!hasError.equalsIgnoreCase("true")) {
-          String datasetUrn = metadata.get("DatasetPath");
+          String datasetPath = metadata.get("DatasetPath");
+          String datasetUrn = DATASET_URN_PREFIX + (datasetPath.startsWith("/") ? "" : "/") + datasetPath;
           String ownerUrns = metadata.get("OwnerURNs");
-          DatasetInfoDao.updateKafkaDatasetOwner(DATASET_URN_PREFIX + datasetUrn, ownerUrns, DATASET_OWNER_SOURCE,
-              timestamp);
+          DatasetInfoDao.updateKafkaDatasetOwner(datasetUrn, ownerUrns, DATASET_OWNER_SOURCE, timestamp);
         }
       }
     }

--- a/backend-service/app/models/kafka/GobblinTrackingCompactionProcessor.java
+++ b/backend-service/app/models/kafka/GobblinTrackingCompactionProcessor.java
@@ -11,14 +11,12 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package metadata.etl.kafka;
+package models.kafka;
 
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.avro.generic.GenericData;
-import wherehows.common.schemas.ClusterInfo;
 import wherehows.common.schemas.GobblinTrackingCompactionRecord;
 import wherehows.common.schemas.Record;
 import wherehows.common.utils.ClusterUtil;
@@ -39,6 +37,7 @@ public class GobblinTrackingCompactionProcessor extends KafkaConsumerProcessor {
    * Process a Gobblin tracking event compaction record
    * @param record
    * @param topic
+   * @return Record
    * @throws Exception
    */
   @Override
@@ -78,7 +77,7 @@ public class GobblinTrackingCompactionProcessor extends KafkaConsumerProcessor {
         if (name.equals("CompactionCompleted")) {
           dataset = metadata.get("datasetUrn");
           partitionName = metadata.get("partition");
-          recordCount = parseLong(metadata.get("recordCount"));
+          recordCount = StringUtil.parseLong(metadata.get("recordCount"));
         }
         // name = "CompactionRecordCounts"
         else {
@@ -89,8 +88,8 @@ public class GobblinTrackingCompactionProcessor extends KafkaConsumerProcessor {
             partitionName = m.group(3);
           }
 
-          recordCount = parseLong(metadata.get("RegularRecordCount"));
-          lateRecordCount = parseLong(metadata.get("LateRecordCount"));
+          recordCount = StringUtil.parseLong(metadata.get("RegularRecordCount"));
+          lateRecordCount = StringUtil.parseLong(metadata.get("LateRecordCount"));
         }
 
         eventRecord =

--- a/backend-service/app/models/kafka/GobblinTrackingDistcpNgProcessor.java
+++ b/backend-service/app/models/kafka/GobblinTrackingDistcpNgProcessor.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package metadata.etl.kafka;
+package models.kafka;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -35,8 +35,9 @@ public class GobblinTrackingDistcpNgProcessor extends KafkaConsumerProcessor {
 
   /**
    * Process a Gobblin tracking event distcp_ng event record
-   * @param record
+   * @param record GenericData.Record
    * @param topic
+   * @return Record
    * @throws Exception
    */
   @Override
@@ -59,12 +60,12 @@ public class GobblinTrackingDistcpNgProcessor extends KafkaConsumerProcessor {
         final String projectName = metadata.get("azkabanProjectName");
         final String flowId = metadata.get("azkabanFlowId");
         final String jobId = metadata.get("azkabanJobId");
-        final int execId = parseInteger(metadata.get("azkabanExecId"));
+        final int execId = StringUtil.parseInteger(metadata.get("azkabanExecId"));
         // final String metricContextId = metadata.get("metricContextID");
         // final String metricContextName = metadata.get("metricContextName");
 
-        final long upstreamTimestamp = parseLong(metadata.get("upstreamTimestamp"));
-        final long originTimestamp = parseLong(metadata.get("originTimestamp"));
+        final long upstreamTimestamp = StringUtil.parseLong(metadata.get("upstreamTimestamp"));
+        final long originTimestamp = StringUtil.parseLong(metadata.get("originTimestamp"));
         final String sourcePath = metadata.get("SourcePath");
         final String targetPath = metadata.get("TargetPath");
 

--- a/backend-service/app/models/kafka/GobblinTrackingLumosProcessor.java
+++ b/backend-service/app/models/kafka/GobblinTrackingLumosProcessor.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package metadata.etl.kafka;
+package models.kafka;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -45,6 +45,7 @@ public class GobblinTrackingLumosProcessor extends KafkaConsumerProcessor {
    * Process a Gobblin tracking event lumos record
    * @param record
    * @param topic
+   * @return Record
    * @throws Exception
    */
   @Override
@@ -86,7 +87,7 @@ public class GobblinTrackingLumosProcessor extends KafkaConsumerProcessor {
           datacenter = datasourceColo;
         }
 
-        final long recordCount = parseLong(metadata.get("recordCount"));
+        final long recordCount = StringUtil.parseLong(metadata.get("recordCount"));
 
         final String partitionType = "snapshot";
         final String partition = metadata.get("partition");
@@ -94,18 +95,18 @@ public class GobblinTrackingLumosProcessor extends KafkaConsumerProcessor {
         String subpartitionType = null;
         String subpartitionName = null;
 
-        final long dropdate = parseLong(metadata.get("Dropdate"));
+        final long dropdate = StringUtil.parseLong(metadata.get("Dropdate"));
         long maxDataDateEpoch3 = dropdate;
         long maxDataKey = 0; // if field is null, default value 0
         if (!isPartitionRegular(partition)) {
-          maxDataKey = parseLong(getPartitionEpoch(partition));
+          maxDataKey = StringUtil.parseLong(getPartitionEpoch(partition));
         }
 
         // handle name 'SnapshotPublished'
         if (name.equals("SnapshotPublished")) {
           partitionName = partition;
           if (dropdate < 1460000000000L) {
-            maxDataDateEpoch3 = parseLong(getPartitionEpoch(targetDirectory));
+            maxDataDateEpoch3 = StringUtil.parseLong(getPartitionEpoch(targetDirectory));
           }
         }
         // handle name 'DeltaPublished'
@@ -114,7 +115,7 @@ public class GobblinTrackingLumosProcessor extends KafkaConsumerProcessor {
           subpartitionType = "_delta";
           subpartitionName = partition;
           if (dropdate < 1460000000000L) {
-            maxDataDateEpoch3 = parseLong(getPartitionEpoch(subpartitionName));
+            maxDataDateEpoch3 = StringUtil.parseLong(getPartitionEpoch(subpartitionName));
           }
         }
 

--- a/backend-service/app/models/kafka/KafkaConfig.java
+++ b/backend-service/app/models/kafka/KafkaConfig.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package utils;
+package models.kafka;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -22,6 +22,7 @@ import metadata.etl.models.EtlJobName;
 import models.daos.EtlJobPropertyDao;
 import org.apache.avro.generic.GenericData;
 import play.Logger;
+import utils.JdbcUtil;
 import wherehows.common.kafka.schemaregistry.client.SchemaRegistryClient;
 import wherehows.common.writers.DatabaseWriter;
 

--- a/backend-service/app/models/kafka/KafkaConsumerProcessor.java
+++ b/backend-service/app/models/kafka/KafkaConsumerProcessor.java
@@ -11,10 +11,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package metadata.etl.kafka;
+package models.kafka;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.avro.generic.GenericData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,36 +30,11 @@ public abstract class KafkaConsumerProcessor {
   /**
    * Abstract method 'process' to be implemented by specific processor
    * input Kafka record, process information and write to DB.
-   * @param record
+   * @param record GenericData.Record
    * @param topic
+   * @return wherehows.common.schemas.Record
    * @throws Exception
    */
   public abstract Record process(GenericData.Record record, String topic) throws Exception;
 
-
-  /**
-   * Parse Long value from a String, if null or exception, return 0
-   * @param text String
-   * @return long
-   */
-  protected long parseLong(String text) {
-    try {
-      return Long.parseLong(text);
-    } catch (NumberFormatException e) {
-      return 0;
-    }
-  }
-
-  /**
-   * Parse Integer value from a String, if null or exception, return 0
-   * @param text String
-   * @return int
-   */
-  protected int parseInteger(String text) {
-    try {
-      return Integer.parseInt(text);
-    } catch (NumberFormatException e) {
-      return 0;
-    }
-  }
 }

--- a/backend-service/app/models/kafka/MetadataChangeProcessor.java
+++ b/backend-service/app/models/kafka/MetadataChangeProcessor.java
@@ -11,13 +11,10 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package utils;
+package models.kafka;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import models.daos.DatasetInfoDao;
 import org.apache.avro.generic.GenericData;
 import play.Logger;

--- a/backend-service/app/models/kafka/MetadataInventoryProcessor.java
+++ b/backend-service/app/models/kafka/MetadataInventoryProcessor.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package utils;
+package models.kafka;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,7 +20,7 @@ import org.apache.avro.generic.GenericData;
 import wherehows.common.schemas.Record;
 
 
-public class MetadataInventoryProcessor {
+public class MetadataInventoryProcessor extends KafkaConsumerProcessor {
 
   /**
    * Process a MetadataInventoryEvent record

--- a/backend-service/app/models/kafka/MetastoreAuditProcessor.java
+++ b/backend-service/app/models/kafka/MetastoreAuditProcessor.java
@@ -86,8 +86,8 @@ public class MetastoreAuditProcessor extends KafkaConsumerProcessor {
       eventRecord = new MetastoreAuditRecord(server, instance, appName, eventName, eventType, timestamp);
       eventRecord.setEventInfo(metastoreThriftUri, metastoreVersion, isSuccessful, isDataDeleted);
       eventRecord.setTableInfo(dbName, tableName, partition, location, owner, createTime, lastAccessTime);
-      eventRecord.setOldInfo(StringUtil.toStringReplaceNull(oldInfo, null));
-      eventRecord.setNewInfo(StringUtil.toStringReplaceNull(newInfo, null));
+      // eventRecord.setOldInfo(StringUtil.toStringReplaceNull(oldInfo, null));
+      // eventRecord.setNewInfo(StringUtil.toStringReplaceNull(newInfo, null));
     }
     return eventRecord;
   }

--- a/backend-service/app/msgs/KafkaCommMsg.java
+++ b/backend-service/app/msgs/KafkaCommMsg.java
@@ -20,15 +20,21 @@ import java.util.Map;
 /**
  * Generic communication message between KafkaConsumerMaster and KafkaConsumerWorker
  */
-public class KafkaResponseMsg {
+public class KafkaCommMsg {
 
+  // Message type: AUDIT, AUDIT_RESPONSE, FLUSH, FLUSH_RESPONSE, HEARTBEAT, etc
   private String msgType;
+  // Kafka topic of the worker
   private String topic;
+  // Kafka worker thread number
+  private int thread;
+  // Message content
   private Map<String, Object> content;
 
-  public KafkaResponseMsg(String msgType, String topic) {
+  public KafkaCommMsg(String msgType, String topic, int thread) {
     this.msgType = msgType;
     this.topic = topic;
+    this.thread = thread;
     this.content = new HashMap<>();
   }
 
@@ -48,6 +54,14 @@ public class KafkaResponseMsg {
     this.topic = topic;
   }
 
+  public int getThread() {
+    return thread;
+  }
+
+  public void setThread(int thread) {
+    this.thread = thread;
+  }
+
   public Map<String, Object> getContent() {
     return content;
   }
@@ -56,8 +70,13 @@ public class KafkaResponseMsg {
     this.content = content;
   }
 
+  public void putContent(String key, Object value) {
+    this.content.put(key, value);
+  }
+
   @Override
   public String toString() {
-    return "KafkaResponseMsg [type=" + msgType + ", topic=" + topic + ", " + content.toString() + "]";
+    return "KafkaCommMsg [type=" + msgType + ", topic=" + topic + ", thread=" + thread + ", content="
+        + content.toString() + "]";
   }
 }

--- a/backend-service/app/msgs/KafkaResponseMsg.java
+++ b/backend-service/app/msgs/KafkaResponseMsg.java
@@ -13,27 +13,31 @@
  */
 package msgs;
 
-import wherehows.common.schemas.AbstractRecord;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
- * Message wrapper for communication between KafkaConsumerMaster and KafkaConsumerWorker
+ * Generic communication message between KafkaConsumerMaster and KafkaConsumerWorker
  */
 public class KafkaResponseMsg {
-  private AbstractRecord record;
+
+  private String msgType;
   private String topic;
+  private Map<String, Object> content;
 
-  public KafkaResponseMsg(AbstractRecord record, String topic) {
-    this.record = record;
+  public KafkaResponseMsg(String msgType, String topic) {
+    this.msgType = msgType;
     this.topic = topic;
+    this.content = new HashMap<>();
   }
 
-  public AbstractRecord getRecord() {
-    return record;
+  public String getMsgType() {
+    return msgType;
   }
 
-  public void setRecord(AbstractRecord record) {
-    this.record = record;
+  public void setMsgType(String msgType) {
+    this.msgType = msgType;
   }
 
   public String getTopic() {
@@ -44,9 +48,16 @@ public class KafkaResponseMsg {
     this.topic = topic;
   }
 
-  @Override
-  public String toString() {
-    return "KafkaResponseMsg [record=" + record + ", topic=" + topic + "]";
+  public Map<String, Object> getContent() {
+    return content;
   }
 
+  public void setContent(Map<String, Object> content) {
+    this.content = content;
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaResponseMsg [type=" + msgType + ", topic=" + topic + ", " + content.toString() + "]";
+  }
 }

--- a/backend-service/app/utils/Urn.java
+++ b/backend-service/app/utils/Urn.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-package models.utils;
+package utils;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -19,7 +19,7 @@ import play.Logger;
 
 
 /**
- * Urn class used for urn convertion
+ * Urn class used for urn conversion
  * Created by zsun on 1/15/15.
  */
 public class Urn {

--- a/build.gradle
+++ b/build.gradle
@@ -107,9 +107,9 @@ subprojects {
                             "play_java_jdbc"     : "com.typesafe.play:play-java-jdbc_2.10:2.2.4",
                             "play_cache"         : "com.typesafe.play:play-cache_2.10:2.2.4",
 
-                            "kafka"              : "org.apache.kafka:kafka_2.10:0.10.0.0",
-                            "kafka_clients"      : "org.apache.kafka:kafka-clients:0.10.0.0",
-                            "confluent_common_cfg" : "io.confluent:common-config:3.0.0"
+                            "kafka"              : "org.apache.kafka:kafka_2.10:0.10.0.1",
+                            "kafka_clients"      : "org.apache.kafka:kafka-clients:0.10.0.1",
+                            "confluent_common_cfg" : "io.confluent:common-config:3.0.1"
   ]
 
   task buildWithWarning(type: JavaCompile, dependsOn: build) {

--- a/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
+++ b/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
@@ -15,7 +15,6 @@ package wherehows.common.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,6 +50,11 @@ public class StringUtil {
     }
   }
 
+  /**
+   * Convert objects of type Collection, Map, Array and AbstractRecord to Json string
+   * @param obj
+   * @return
+   */
   public static Object objectToJsonString(Object obj) {
     if (obj instanceof Collection || obj instanceof Map || obj instanceof Object[] || obj instanceof Record) {
       try {
@@ -60,10 +64,6 @@ public class StringUtil {
       }
     }
     return obj;
-  }
-
-  public static String toStr(Object obj) {
-    return obj != null ? obj.toString() : null;
   }
 
   public static Long toLong(Object obj) {
@@ -90,5 +90,41 @@ public class StringUtil {
       metadata.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
     }
     return metadata;
+  }
+
+  /**
+   * Parse Long value from a String, if null or exception, return 0
+   * @param text String
+   * @return long
+   */
+  public static long parseLong(String text) {
+    try {
+      return Long.parseLong(text);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  /**
+   * Parse Integer value from a String, if null or exception, return 0
+   * @param text String
+   * @return int
+   */
+  public static int parseInteger(String text) {
+    try {
+      return Integer.parseInt(text);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  /**
+   * Object to string, replace null/"null" with replacement string
+   * @param obj Object
+   * @return String
+   */
+  public static String toStringReplaceNull(Object obj, String replacement) {
+    String string = String.valueOf(obj);
+    return string == null || string.equals("null") ? replacement : string;
   }
 }


### PR DESCRIPTION
1. Move database writing from KafkaConsumerMaster to KafkaConsumerWorker. Eliminate record passing from worker to master, increase database writing speed (each worker writing independently to different table), and resolved the Out-of-memory exception at Kafka system start-up. The reason being that the workers will process another message after a DB writing, instead of keeping processing and throwing records into Master message queue, which, at start-up, can eat up memory rapidly. 
2. Refactor/move some Kafka processors to the same models.kafka package under backend-service.
3. Turned off the population of OldInfo and NewInfo in MetastoreAuditProcessor due to storage concern.
4. Create generic KafkaCommMsg for communication between Kafka Master and Worker in futurn use.
5. Move some string utilities to wherehows.commons, other code refactoring.