### PR TITLE
Add get_schema_literal_from_url() to fetch schema literal based on schema url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
                             "hadoop_common"       : "org.apache.hadoop:hadoop-common:2.7.3",
                             "hadoop_client"       : "org.apache.hadoop:hadoop-mapreduce-client-core:2.7.3",
                             "hadoop_auth"         : "org.apache.hadoop:hadoop-auth:2.7.3",
-                            "hadoop_hdfs"        : "org.apache.hadoop:hadoop-hdfs:2.7.1",
+                            "hadoop_hdfs"         : "org.apache.hadoop:hadoop-hdfs:2.7.1",
                             "pig"                 : "org.apache.pig:pig:0.15.0",
                             "hive_exec"           : "org.apache.hive:hive-exec:1.2.1",
                             "avro"                : "org.apache.avro:avro:1.7.7",

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects {
                             "hadoop_common"       : "org.apache.hadoop:hadoop-common:2.7.3",
                             "hadoop_client"       : "org.apache.hadoop:hadoop-mapreduce-client-core:2.7.3",
                             "hadoop_auth"         : "org.apache.hadoop:hadoop-auth:2.7.3",
+                            "hadoop_hdfs"        : "org.apache.hadoop:hadoop-hdfs:2.7.1",
                             "pig"                 : "org.apache.pig:pig:0.15.0",
                             "hive_exec"           : "org.apache.hive:hive-exec:1.2.1",
                             "avro"                : "org.apache.avro:avro:1.7.7",

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ subprojects {
                             "jsch"                : "com.jcraft:jsch:0.1.54",
                             "http_client"         : "org.apache.httpcomponents:httpclient:4.5.2",
                             "http_core"           : "org.apache.httpcomponents:httpcore:4.4.5",
+                            "htrace"              : "org.apache.htrace:htrace-core:3.1.0-incubating",
                             "json_path"           : "com.jayway.jsonpath:json-path:2.2.0",
                             "jgit"                : "org.eclipse.jgit:org.eclipse.jgit:4.1.2.201602141800-r",
                             "jsoup"               : "org.jsoup:jsoup:1.8.3",

--- a/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
+++ b/hadoop-dataset-extractor-standalone/src/main/java/wherehows/SchemaFetch.java
@@ -78,6 +78,7 @@ public class SchemaFetch {
       try {
         Configuration hdfs_conf = new Configuration();
         hdfs_conf.set("hadoop.security.authentication", "Kerberos");
+        hdfs_conf.set("dfs.namenode.kerberos.principal.pattern", "*");
         UserGroupInformation.setConfiguration(hdfs_conf);
         UserGroupInformation.loginUserFromKeytab(principal, keyLocation);
         fs = FileSystem.get(hdfs_conf);

--- a/metadata-etl/build.gradle
+++ b/metadata-etl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   compile externalDependency.hadoop_hdfs
   compile externalDependency.jython
   compile externalDependency.mysql
+  compile externalDependency.htrace
   compile files("extralibs/mysql-connector-java-5.1.*.jar") // externalDependency.mysql
   compile files("extralibs/jython-standalone-2.7.0.jar") // externalDependency.jython
   compile fileTree(dir: 'extralibs', include: ['*.jar']) // externalDependency.oracle/teradata/gsp

--- a/metadata-etl/build.gradle
+++ b/metadata-etl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compile externalDependency.slf4j_api
   compile externalDependency.slf4j_log4j
   compile externalDependency.hive_exec
+  compile externalDependency.hadoop_hdfs
   compile externalDependency.jython
   compile externalDependency.mysql
   compile files("extralibs/mysql-connector-java-5.1.*.jar") // externalDependency.mysql

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -308,6 +308,11 @@ class HiveExtract:
     # os.chmod(sample_output_file, 0666)
     # sample_file_writer = FileWriter(sample_output_file)
 
+    if type(kerberos_auth) == str:
+      if kerberos_auth.lower() == 'false':
+        kerberos_auth = False
+      else:
+        kerberos_auth = True 
     self.schema_url_helper = SchemaUrlHelper.SchemaUrlHelper(hdfs_namenode_ipc_uri, kerberos_auth, kerberos_principal, keytab_file)
 
     for database_name in self.databases:

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -14,8 +14,11 @@
 
 from org.slf4j import LoggerFactory
 from com.ziclix.python.sql import zxJDBC
-import sys, os, re, json
+import sys, os, re, json, csv
 import datetime
+import SchemaUrlHelper
+from wherehows.common.writers import FileWriter
+from wherehows.common.schemas import HiveDependencyInstanceRecord
 from wherehows.common import Constant
 
 
@@ -52,7 +55,7 @@ class TableInfo:
 
 class HiveExtract:
   """
-  Extract hive metadata from hive metastore. store it in a json file
+  Extract hive metadata from hive metastore in mysql. store it in a json file
   """
   conn_hms = None
   db_dict = {}  # name : index
@@ -258,6 +261,15 @@ class HiveExtract:
       elif row_value[1]:
         full_name = row_value[1]
 
+      literal = None
+      if row_value[15] and not row_value[14]:  # schema_url is available but missing schema_literal
+        try:
+          literal = self.get_schema_literal_from_url(row_value[15])
+        except Exception as e:
+          self.logger.error(str(e))
+      elif row_value[14]:
+        literal = row_value[14]
+
       # put in schema result
       if full_name not in self.table_dict:
         schema[db_idx]['tables'].append(
@@ -269,7 +281,8 @@ class HiveExtract:
            TableInfo.view_expended_text: row_value[9], TableInfo.input_format: row_value[10],
            TableInfo.output_format: row_value[11], TableInfo.is_compressed: row_value[12],
            TableInfo.is_storedassubdirectories: row_value[13], TableInfo.etl_source: 'SERDE_PARAMS',
-           TableInfo.schema_literal: row_value[14], TableInfo.schema_url: row_value[15],
+           TableInfo.schema_literal: literal,
+           TableInfo.schema_url: row_value[15],
            TableInfo.field_delimiter: row_value[16]})
         table_idx += 1
         self.table_dict[full_name] = table_idx
@@ -277,7 +290,8 @@ class HiveExtract:
     self.logger.info("%s %6d tables processed for database %12s from SERDE_PARAM" % (
       datetime.datetime.now(), table_idx + 1, row_value[0]))
 
-  def run(self, schema_output_file, sample_output_file):
+  def run(self, schema_output_file, sample_output_file=None, hdfs_map_output_file=None,
+          hdfs_namenode_ipc_uri=None, kerberos_auth=False, kerberos_principal=None, keytab_file=None):
     """
     The entrance of the class, extract schema.
     One database per time
@@ -293,6 +307,8 @@ class HiveExtract:
     # open(sample_output_file, 'wb')
     # os.chmod(sample_output_file, 0666)
     # sample_file_writer = FileWriter(sample_output_file)
+
+    self.schema_url_helper = SchemaUrlHelper.SchemaUrlHelper(hdfs_namenode_ipc_uri, kerberos_auth, kerberos_principal, keytab_file)
 
     for database_name in self.databases:
       self.logger.info("Collecting hive tables in database : " + database_name)
@@ -325,17 +341,33 @@ class HiveExtract:
 
     schema_json_file.write(json.dumps(schema, indent=None) + '\n')
 
-    cur.close()
     schema_json_file.close()
 
-  def get_all_databases(self, database_white_list):
+    # fetch hive (managed/external) table to hdfs path mapping
+    rows = []
+    hdfs_map_csv_file = open(hdfs_map_output_file, 'wb')
+    os.chmod(hdfs_map_output_file, 0666)
+    begin = datetime.datetime.now().strftime("%H:%M:%S")
+    rows = self.get_hdfs_map()
+    hdfs_map_columns = ['db_name', 'table_name', 'cluster_uri', 'abstract_hdfs_path']
+    csv_writer = csv.writer(hdfs_map_csv_file, delimiter='\t', lineterminator='\n', quoting=csv.QUOTE_NONE)
+    csv_writer.writerow(hdfs_map_columns)
+    csv_writer.writerows(rows)
+    end = datetime.datetime.now().strftime("%H:%M:%S")
+    self.logger.info("Get hdfs map from SDS %12s [%s -> %s]\n" % (database_name, str(begin), str(end)))
+
+    cur.close()
+    hdfs_map_csv_file.close()
+
+  def get_all_databases(self, database_white_list, database_black_list):
     """
     Fetch all databases name from DBS table
     :return:
     """
     database_white_list = ",".join(["'" + x + "'" for x in database_white_list.split(',')])
-    fetch_all_database_names = "SELECT `NAME` FROM DBS WHERE NAME NOT LIKE 'u\\_%' OR NAME IN ({white_list})"\
-      .format(white_list=database_white_list)
+    database_black_list = ",".join(["'" + x + "'" for x in database_black_list.split(',')])
+    fetch_all_database_names = "SELECT `NAME` FROM DBS WHERE `NAME` IN ({white_list}) OR NOT (`NAME` IN ({black_list}) OR `NAME` LIKE 'u\\_%')"\
+      .format(white_list=database_white_list, black_list=database_black_list)
     self.logger.info(fetch_all_database_names)
     curs = self.conn_hms.cursor()
     curs.execute(fetch_all_database_names)
@@ -343,6 +375,100 @@ class HiveExtract:
     curs.close()
     return rows
 
+  def get_schema_literal_from_url(self, schema_url):
+    """
+    fetch avro schema literal from
+    - avsc file on hdfs via hdfs/webhdfs
+    - json string in schemaregistry via http
+    :param schema_url:  e.g. hdfs://server:port/data/tracking/abc/_schema.avsc http://schema-registry-vip-1:port/schemaRegistry/schemas/latest_with_type=xyz
+    :param schema: {database : _, type : _, tables : ['name' : _, ... '' : _] }
+    :return: json string of avro schema
+    """
+    if schema_url.startswith('hdfs://') or schema_url.startswith('/') or schema_url.startswith('webhdfs://'):
+      return self.schema_url_helper.get_from_hdfs(schema_url)
+    elif scheam_url.startswith('https://') or schema_url.startswith('http://'):
+      return self.schema_url_helper.get_from_http(schema_url)
+    else:
+      self.logger.error("get_schema_literal_from_url() gets a bad input: %s" % schema_url)
+      return ''
+
+  def get_hdfs_map(self):
+    """
+    Fetch the mapping from hdfs location to hive (managed and external) table
+    :return:
+    """
+
+    hdfs_map_sql = """select db_name, tbl_name table_name, cluster_uri,
+  cast(
+  case when substring_index(hdfs_path, '/', -4) regexp '[0-9]{4}/[0-9]{2}/[0-9]{2}/[0-9]{2}'
+       then substring(hdfs_path, 1, hdfs_path_len - length(substring_index(hdfs_path, '/', -4))-1)
+       when substring_index(hdfs_path, '/', -3) regexp '[0-9]{4}/[0-9]{2}/[0-9]{2}'
+       then substring(hdfs_path, 1, hdfs_path_len - length(substring_index(hdfs_path, '/', -3))-1)
+       when substring_index(hdfs_path, '/', -1) regexp '20[0-9]{2}([\\._-]?[0-9][0-9]){2,5}'
+         or substring_index(hdfs_path, '/', -1) regexp '1[3-6][0-9]{11}(-(PT|UTC|GMT|SCN)-[0-9]+)?'
+         or substring_index(hdfs_path, '/', -1) regexp '[0-9]+([\\._-][0-9]+)?'
+         or substring_index(hdfs_path, '/', -1) regexp '[vV][0-9]+([\\._-][0-9]+)?'
+         or substring_index(hdfs_path, '/', -1) regexp '(prod|ei|qa|dev)_[0-9]+\\.[0-9]+\\.[0-9]+_20[01][0-9]([_-]?[0-9][0-9]){2,5}'
+       then substring(hdfs_path, 1, hdfs_path_len - length(substring_index(hdfs_path, '/', -1))-1)
+       when hdfs_path regexp '/datepartition=20[01][0-9]([\\._-]?[0-9][0-9]){2,3}'
+         or hdfs_path regexp '/datepartition=[[:alnum:]]+'
+       then substring(hdfs_path, 1, locate('/datepartition=', hdfs_path)-1)
+       when hdfs_path regexp '/date_sk=20[01][0-9]([\\._-]?[0-9][0-9]){2,3}'
+       then substring(hdfs_path, 1, locate('/date_sk=', hdfs_path)-1)
+       when hdfs_path regexp '/ds=20[01][0-9]([\\._-]?[0-9][0-9]){2,3}'
+       then substring(hdfs_path, 1, locate('/ds=', hdfs_path)-1)
+       when hdfs_path regexp '/dt=20[01][0-9]([\\._-]?[0-9][0-9]){2,3}'
+       then substring(hdfs_path, 1, locate('/dt=', hdfs_path)-1)
+       when hdfs_path regexp '^/[[:alnum:]]+/[[:alnum:]]+/[[:alnum:]]+/20[01][0-9]([\\._-]?[0-9][0-9]){2,5}/'
+       then concat(substring_index(hdfs_path, '/', 4), '/*',
+                   substring(hdfs_path, length(substring_index(hdfs_path, '/', 5))+1))
+       when hdfs_path regexp '^/[[:alnum:]]+/[[:alnum:]]+/20[01][0-9]([\\._-]?[0-9][0-9]){2,5}/'
+       then concat(substring_index(hdfs_path, '/', 3), '/*',
+                   substring(hdfs_path, length(substring_index(hdfs_path, '/', 4))+1))
+       when substring_index(hdfs_path, '/', -3) regexp '^(prod|ei|qa|dev)_[0-9]+\\.[0-9]+\\.[0-9]+_20[01][0-9]([\\._-]?[0-9][0-9]){2,5}/'
+       then concat(substring(hdfs_path, 1, hdfs_path_len - length(substring_index(hdfs_path, '/', -3))-1), '/*/',
+                   substring_index(hdfs_path, '/', -2))
+       when substring_index(hdfs_path, '/', -2) regexp '^(prod|ei|qa|dev)_[0-9]+\\.[0-9]+\\.[0-9]+_20[01][0-9]([\\._-]?[0-9][0-9]){2,5}/'
+       then concat(substring(hdfs_path, 1, hdfs_path_len - length(substring_index(hdfs_path, '/', -2))-1), '/*/',
+                   substring_index(hdfs_path, '/', -1))
+       else hdfs_path
+  end as char(300)) abstract_hdfs_path
+from (
+    select d.NAME DB_NAME, t.TBL_NAME,
+      substring_index(s.LOCATION, '/', 3) cluster_uri,
+      substring(s.LOCATION, length(substring_index(s.LOCATION, '/', 3))+1) hdfs_path,
+      length(s.LOCATION) - length(substring_index(s.LOCATION, '/', 3)) as hdfs_path_len
+    from SDS s
+         join TBLS t
+      on s.SD_ID = t.SD_ID
+         join DBS d
+      on t.DB_ID = d.DB_ID
+         left join PARTITIONS p
+      on t.TBL_ID = p.TBL_ID
+    where p.PART_ID is null
+      and LOCATION is not null
+    union all
+    select d.NAME DB_NAME, t.TBL_NAME,
+      substring_index(s.LOCATION, '/', 3) cluster_uri,
+      substring(s.LOCATION, length(substring_index(s.LOCATION, '/', 3))+1) hdfs_path,
+      length(s.LOCATION) - length(substring_index(s.LOCATION, '/', 3)) as hdfs_path_len
+    from SDS s
+         join (select TBL_ID, MAX(SD_ID) SD_ID from PARTITIONS group by 1) p
+      on s.SD_ID = p.SD_ID
+         join TBLS t
+      on p.TBL_ID = t.TBL_ID
+         join DBS d
+      on t.DB_ID = d.DB_ID
+    where not LOCATION like 'hdfs:%__HIVE_DEFAULT_PARTITION__%'
+) x where hdfs_path not like '/tmp/%'
+order by 1,2"""
+
+    curs = self.conn_hms.cursor()
+    curs.execute(hdfs_map_sql)
+    rows = curs.fetchall()
+    curs.close()
+    self.logger.info("%6d Hive table => HDFS path mapping relations found." % len(rows))
+    return rows
 
 if __name__ == "__main__":
   args = sys.argv[1]
@@ -356,13 +482,25 @@ if __name__ == "__main__":
   if Constant.HIVE_DATABASE_WHITELIST_KEY in args:
     database_white_list = args[Constant.HIVE_DATABASE_WHITELIST_KEY]
   else:
-    database_white_list = ''
+    database_white_list = "''"
+
+  if Constant.HIVE_DATABASE_BLACKLIST_KEY in args:
+    database_black_list = args[Constant.HIVE_DATABASE_BLACKLIST_KEY]
+  else:
+    database_black_list = "''"
 
   e = HiveExtract()
   e.conn_hms = zxJDBC.connect(jdbc_url, username, password, jdbc_driver)
 
   try:
-    e.databases = e.get_all_databases(database_white_list)
-    e.run(args[Constant.HIVE_SCHEMA_JSON_FILE_KEY], None)
+    e.databases = e.get_all_databases(database_white_list, database_black_list)
+    e.run(args[Constant.HIVE_SCHEMA_JSON_FILE_KEY], \
+          None, \
+          args[Constant.HIVE_HDFS_MAP_CSV_FILE_KEY], \
+          args[Constant.HDFS_NAMENODE_IPC_URI_KEY], \
+          args[Constant.KERBEROS_AUTH_KEY], \
+          args[Constant.KERBEROS_PRINCIPAL_KEY], \
+          args[Constant.KERBEROS_KEYTAB_FILE_KEY]
+          )
   finally:
     e.conn_hms.close()

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -350,7 +350,7 @@ class HiveExtract:
     begin = datetime.datetime.now().strftime("%H:%M:%S")
     rows = self.get_hdfs_map()
     hdfs_map_columns = ['db_name', 'table_name', 'cluster_uri', 'abstract_hdfs_path']
-    csv_writer = csv.writer(hdfs_map_csv_file, delimiter='\t', lineterminator='\n', quoting=csv.QUOTE_NONE)
+    csv_writer = csv.writer(hdfs_map_csv_file, delimiter='\x1a', lineterminator='\n', quoting=csv.QUOTE_NONE)
     csv_writer.writerow(hdfs_map_columns)
     csv_writer.writerows(rows)
     end = datetime.datetime.now().strftime("%H:%M:%S")

--- a/metadata-etl/src/main/resources/jython/SchemaUrlHelper.py
+++ b/metadata-etl/src/main/resources/jython/SchemaUrlHelper.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+import sys, os
+import json
+from os.path import expanduser
+
+from java.util import Hashtable
+from java.io import InputStreamReader
+from java.util import Properties
+from java.util import Date
+
+from org.apache.commons.io import IOUtils
+from org.apache.hadoop.conf import Configuration
+from org.apache.hadoop.fs import FileSystem as Hdfs
+from org.apache.hadoop.fs import Path as HdfsPath
+from org.apache.hadoop.security import UserGroupInformation
+
+from jython import requests
+from org.slf4j import LoggerFactory
+
+
+class SchemaUrlHelper:
+  """
+  This class fetches schema literal from avro.schema.url
+  It supports:
+    * http://schema-registry-server:port/schemaRegistry/schemas/latest_with_type=SearchImpressionEvent
+    * hdfs://hadoop-name-node:port/data/external/Customer/Profile/daily/2016/01/01/_schema.avsc
+    * /data/databases/ADS/CAMPAIGNS/snapshot/v2.3/_schema.avsc
+  """
+
+  def __init__(self, hdfs_uri, kerberos=False, kerberos_principal=None, keytab_file=None):
+    """
+    :param hdfs_uri: hdfs://hadoop-name-node:port
+    :param kerberos: optional, if kerberos authentication is needed
+    :param kerberos_principal: optional, user@DOMAIN.COM
+    :param keytab_file: optional, user.keytab or ~/.kerberos/user.keytab
+    """
+
+    self.logger = LoggerFactory.getLogger(self.__class__.__name__)
+
+    hdfs_conf = Configuration()
+    if hdfs_uri.startswith('hdfs://'):
+      hdfs_conf.set(Hdfs.FS_DEFAULT_NAME_KEY, hdfs_uri)
+    elif hdfs_uri > "":
+      self.logger.error("%s is an invalid uri for hdfs namenode ipc bind." % hdfs_uri)
+
+    if kerberos == True:  #  init kerberos and keytab
+      if not kerberos_principal or not keytab_file or kerberos_principal == '' or keytab_file == '':
+        print "Kerberos Principal and Keytab File Name/Path are required!"
+
+      keytab_path = keytab_file
+      if keytab_file.startswith('/'):
+        if os.path.exists(keytab_file):
+          keytab_path = keytab_file
+          print "Using keytab at %s" % keytab_path
+      else:  # try relative path
+        all_locations = [os.getcwd(), expanduser("~") + "/.ssh",
+            expanduser("~") + "/.kerberos", expanduser("~") + "/.wherehows",
+            os.getenv("APP_HOME"), os.getenv("WH_HOME")]
+        for loc in all_locations:
+          if os.path.exists(loc + '/' + keytab_file):
+            keytab_path = loc + '/' + keytab_file
+            print "Using keytab at %s" % keytab_path
+            break
+
+      hdfs_conf.set("hadoop.security.authentication", "kerberos")
+      UserGroupInformation.setConfiguration(hdfs_conf)
+      UserGroupInformation.loginUserFromKeytab(kerberos_principal, keytab_path)
+
+    self.fs = Hdfs.get(hdfs_conf)
+
+    requests.packages.urllib3.disable_warnings()
+
+  def get_from_hdfs(self, file_loc):
+    """
+    Try to get the text content from HDFS based on file_loc
+    Return schema literal string
+    """
+
+    fp = HdfsPath(file_loc)
+    try:
+      if self.fs.exists(fp):
+        in_stream = self.fs.open(fp)
+        return IOUtils.toString(in_stream, 'UTF-8')
+      else:
+        return None
+    except:
+      return None    
+
+  def get_from_http(self, file_loc):
+    """
+    Try to get the schema from HTTP/HTTPS based on file_loc
+    """
+    try:
+      resp = requests.get(file_loc, verify=False)
+    except Exception as e:
+      self.logger.error(str(e))
+      return None
+
+    if resp.status_code == 200:
+      if 'content-length' in resp.headers:
+        self.logger.debug('GET {} bytes from {}'.format(resp.headers['content-length'], file_loc))
+      return resp.text
+    else:
+      # This means something went wrong.
+      raise Exception('Request Error', 'GET {} {}'.format(file_loc, resp.status_code))
+      return None
+
+
+
+
+if __name__ == "__main__":
+  HTTP_TEST_URI = ['http://ltx1-schema-registry-vip-1.prod.linkedin.com:12250/schemaRegistry/schemas/latest_with_type=NativeRealUserMonitoringEvent',
+                   'http://lva1-schema-registry-vip-2.corp.linkedin.com:12250/schemaRegistry/schemas/latest_with_type=MessageDeliveryEvent',
+                   'https://ipinfo.io/', 'https://api.github.com/users/linkedin']
+  HDFS_TEST_URI = ['hdfs://ltx1-unonn01.grid.linkedin.com:9000/data/dbchanges/Identity/Profile/daily/2016/09/29/_schema.avsc',
+                   '/data/dbchanges/Identity/Profile/daily/2016/10/01/_schema.avsc']
+
+  schema_url_helper = SchemaUrlHelper("hdfs://ltx1-unonn01.grid.linkedin.com:9000", kerberos=True, \
+                                      kerberos_principal="wherehow@GRID.LINKEDIN.COM", \
+                                      keytab_file="wherehow.headless.keytab")
+
+  for f in HDFS_TEST_URI:
+    print "Test HDFS:"
+    if f.startswith('hdfs://') or f.startswith('webhdfs://') or f.startswith('/'):
+      print "    Schema URL = %s" % f
+      print "Schema Literal = %s" % schema_url_helper.get_from_hdfs(f)
+
+  for f in HTTP_TEST_URI:
+    print "Test HTTP:"
+    if f.startswith('https://') or f.startswith('http://'):
+      print "    Schema URL = %s" % f
+      print "Schema Literal = %s" % schema_url_helper.get_from_http(f)

--- a/metadata-etl/src/main/resources/jython/SchemaUrlHelper.py
+++ b/metadata-etl/src/main/resources/jython/SchemaUrlHelper.py
@@ -77,6 +77,7 @@ class SchemaUrlHelper:
             break
 
       hdfs_conf.set("hadoop.security.authentication", "kerberos")
+      hdfs_conf.set("dfs.namenode.kerberos.principal.pattern", "*")
       UserGroupInformation.setConfiguration(hdfs_conf)
       UserGroupInformation.loginUserFromKeytab(kerberos_principal, keytab_path)
 

--- a/wherehows-common/src/main/java/wherehows/common/Constant.java
+++ b/wherehows-common/src/main/java/wherehows/common/Constant.java
@@ -115,7 +115,7 @@ public class Constant {
   public static final String HDFS_SAMPLE_LOCAL_PATH_KEY = "hdfs.local.sample";
   /** The property_name field in wh_etl_job_property table. The hfds sample data file location store on remote hadoop gateway */
   public static final String HDFS_SAMPLE_REMOTE_PATH_KEY = "hdfs.remote.sample";
-  /** The property_name field in wh_etl_job_property table. Hadoop cluster name */
+  /** The property_name field in wh_etl_job_property table. Hadoop cluster name in short form */
   public static final String HDFS_CLUSTER_KEY = "hdfs.cluster";
   /** The property_name field in wh_etl_job_property table. The list of directories as a start point to fetch metadata.
    * (include all of their sub directories) */
@@ -131,6 +131,8 @@ public class Constant {
   public static final String HDFS_FILE_SOURCE_MAP_KEY = "hdfs.file_path_regex_source_map";
   /** The property_name field in wh_etl_job_property table. Keytab file location */
   public static final String HDFS_REMOTE_KEYTAB_LOCATION_KEY = "hdfs.remote.keytab.location";
+  /** The property_name field in wh_etl_job_property table. hdfs default uri (IPC) */
+  public static final String HDFS_NAMENODE_IPC_URI_KEY = "hdfs.namenode.ipc.uri";
 
   /** The property_name field in wh_etl_job_property table. For dataset owner ETL. The hfds location to copy files */
   public static final String HDFS_REMOTE_WORKING_DIR = "hdfs.remote.working.dir";
@@ -172,6 +174,7 @@ public class Constant {
   public static final String HIVE_METASTORE_PASSWORD = "hive.metastore.password";
 
   public static final String HIVE_DATABASE_WHITELIST_KEY = "hive.database_white_list";
+  public static final String HIVE_DATABASE_BLACKLIST_KEY = "hive.database_black_list";
   public static final String HIVE_SCHEMA_JSON_FILE_KEY = "hive.schema_json_file";
   public static final String HIVE_DEPENDENCY_CSV_FILE_KEY = "hive.dependency_csv_file";
   public static final String HIVE_INSTANCE_CSV_FILE_KEY = "hive.instance_csv_file";
@@ -179,6 +182,10 @@ public class Constant {
   public static final String HIVE_SCHEMA_CSV_FILE_KEY = "hive.schema_csv_file";
   public static final String HIVE_HDFS_MAP_CSV_FILE_KEY = "hive.hdfs_map_csv_file";
   public static final String HIVE_FIELD_METADATA_KEY = "hive.field_metadata";
+
+  public static final String KERBEROS_AUTH_KEY = "kerberos.auth";
+  public static final String KERBEROS_PRINCIPAL_KEY = "kerberos.principal";
+  public static final String KERBEROS_KEYTAB_FILE_KEY = "kerberos.keytab.file";
 
   /** Property name of app id. For ETL process. ETL process will use this to identify the application */
   public static final String APP_ID_KEY = "app.id";


### PR DESCRIPTION
Some Avro datasets have schema url only, we need to visit schema url in one of the 3 options:

* full hdfs uri, such as hdfs://server:port/path/path
* hdfs path only, such as /path/path
* http or https uri, such as http://server:port/api/schema_name