### PR TITLE
WhereHows UI: display empty "create" UI form for Privacy Compliance and Confidential Spec

### DIFF
--- a/web/app/views/index.scala.html
+++ b/web/app/views/index.scala.html
@@ -701,18 +701,18 @@
             {{/dataset-access}}
           </div>
             <div id="compliancetab" class="tab-pane">
-                {{#dataset-compliance securitySpec=securitySpec
-                                      datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
-                                      onSave=(action "saveSecuritySpec")
-                                      onReset=(action "getSecuritySpec")}}
-                {{/dataset-compliance}}
+                {{dataset-compliance privacyCompliancePolicy=privacyCompliancePolicy
+                                     isNewPrivacyCompliancePolicy=isNewPrivacyCompliancePolicy
+                                     datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
+                                     onSave=(action "savePrivacyCompliancePolicy")
+                                     onReset=(action "resetPrivacyCompliancePolicy")}}
             </div>
             <div id="confidentialtab" class="tab-pane">
-                {{#dataset-confidential securitySpec=securitySpec
-                                        datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
-                                        onSave=(action "saveSecuritySpec")
-                                        onReset=(action "getSecuritySpec")}}
-                {{/dataset-confidential}}
+                {{dataset-confidential securitySpecification=securitySpecification
+                                       isNewSecuritySpecification=isNewSecuritySpecification
+                                       datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
+                                       onSave=(action "saveSecuritySpecification")
+                                       onReset=(action "resetSecuritySpecification")}}
             </div>
         </div>
       {{else}}
@@ -871,11 +871,11 @@
           </div>
           <div id="accessview" class="panel-collapse collapse" role="tabpanel" aria-labelledby="complianceHeading">
               <div class="panel-body">
-                  {{#dataset-compliance datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
-                                        securitySpec=securitySpec
-                                        onSave=(action "saveSecuritySpec")
-                                        onReset=(action "getSecuritySpec")}}
-                  {{/dataset-compliance}}
+                  {{dataset-compliance privacyCompliancePolicy=privacyCompliancePolicy
+                                       isNewPrivacyCompliancePolicy=isNewPrivacyCompliancePolicy
+                                       datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
+                                       onSave=(action "savePrivacyCompliancePolicy")
+                                       onReset=(action "resetPrivacyCompliancePolicy")}}
               </div>
           </div>
         </div>
@@ -892,11 +892,11 @@
               <div id="accessview" class="panel-collapse collapse" role="tabpanel"
                    aria-labelledby="confidentialHeading">
                   <div class="panel-body">
-                      {{#dataset-confidential securitySpec=securitySpec
-                                              datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
-                                              onSave=(action "saveSecuritySpec")
-                                              onReset=(action "getSecuritySpec")}}
-                      {{/dataset-confidential}}
+                      {{dataset-confidential securitySpecification=securitySpecification
+                                             isNewSecuritySpecification=isNewSecuritySpecification
+                                             datasetSchemaFieldsAndTypes=datasetSchemaFieldsAndTypes
+                                             onSave=(action "saveSecuritySpecification")
+                                             onReset=(action "resetSecuritySpecification")}}
                   </div>
               </div>
           </div>

--- a/web/app/views/main.scala.html
+++ b/web/app/views/main.scala.html
@@ -1358,18 +1358,22 @@
                         {{/ember-selector}}
                     </label>
 
-                    <div class="field-search">
-                        <input type="text"
-                               id="compliance-typeahead"
-                               class="field-search__input form-control"
-                               placeholder="Search for field names...">
-                    </div>
+                    <header class="typeahead-header">
+                        <div class="field-names">
+                            <h4>Field Names</h4>
+                            <input type="text"
+                                   id="compliance-typeahead"
+                                   class="field-search__input form-control"
+                                   placeholder="Filter field names...">
+                        </div>
+                        <h4>Data Type</h4>
+                    </header>
                     <section class="typeahead-matches">
                         {{#each matchingFields as |matchingField|}}
-                            {{#draggable-item content=matchingField.value class="draggable__item"}}
+                            {{#draggable-item content=matchingField.value class="draggable__item item-source"}}
                                 <span class="match-pill__value">{{matchingField.value}}</span>
                                 {{#if matchingField.dataType}}
-                                    <sub class="match-pill__data-type">Data Type: {{matchingField.dataType}}</sub>
+                                    <span class="match-pill__data-type">{{matchingField.dataType}}</span>
                                 {{/if}}
                             {{/draggable-item}}
                         {{else}}
@@ -1455,18 +1459,22 @@
                         {{/ember-selector}}
                     </label>
 
-                    <div class="field-search">
-                        <input type="text"
-                               id="confidential-typeahead"
-                               class="field-search__input form-control"
-                               placeholder="Search for field names...">
-                    </div>
+                    <header class="typeahead-header">
+                        <div class="field-names">
+                            <h4>Field Names</h4>
+                            <input type="text"
+                                   id="compliance-typeahead"
+                                   class="field-search__input form-control"
+                                   placeholder="Filter field names...">
+                        </div>
+                        <h4>Data Type</h4>
+                    </header>
                     <section class="typeahead-matches">
                         {{#each matchingFields as |matchingField|}}
-                            {{#draggable-item content=matchingField.value class="draggable__item"}}
+                            {{#draggable-item content=matchingField.value class="draggable__item item-source"}}
                                 <span class="match-pill__value">{{matchingField.value}}</span>
                                 {{#if matchingField.dataType}}
-                                    <sub class="match-pill__data-type">Data Type: {{matchingField.dataType}}</sub>
+                                    <span class="match-pill__data-type">{{matchingField.dataType}}</span>
                                 {{/if}}
                             {{/draggable-item}}
                         {{else}}

--- a/web/app/views/main.scala.html
+++ b/web/app/views/main.scala.html
@@ -1344,6 +1344,12 @@
         <script type="text/x-handlebars" id="components/dataset-compliance">
             <div id="compliance" class="tab-body">
                 {{#if privacyCompliancePolicy}}
+                    {{#if isNewPrivacyCompliancePolicy}}
+                        <h5 class="bg-info tab_head">
+                            This dataset does not have an associated "Privacy Compliance Policy".<br>
+                            To create one update fields as required and click the "Create" button below.
+                        </h5>
+                    {{/if}}
                     <label class="lbl">
                         <span class="lbl__text">Compliance Type</span>
                         {{#ember-selector values=complianceTypes
@@ -1421,6 +1427,12 @@
         <script type="text/x-handlebars" id="components/dataset-confidential">
             <div id="confidential" class="tab-body">
                 {{#if securitySpecification}}
+                    {{#if isNewSecuritySpecification}}
+                        <h5 class="bg-info tab_head">
+                            This dataset does not have an associated "Security Specification".<br>
+                            To create one update fields as required and click the "Create" button below.
+                        </h5>
+                    {{/if}}
                     <label class="lbl">
                         <span class="lbl__text">Retention</span>
                         {{#ember-selector values=retentionTypes

--- a/web/app/views/main.scala.html
+++ b/web/app/views/main.scala.html
@@ -1343,7 +1343,7 @@
 
         <script type="text/x-handlebars" id="components/dataset-compliance">
             <div id="compliance" class="tab-body">
-                {{#if securitySpec}}
+                {{#if privacyCompliancePolicy}}
                     <label class="lbl">
                         <span class="lbl__text">Compliance Type</span>
                         {{#ember-selector values=complianceTypes
@@ -1407,18 +1407,20 @@
                         </table>
                     </section>
                     <div class="cta">
-                        <button class="btn btn-primary" {{action 'saveCompliance'}}>Save</button>
+                        <button class="btn btn-primary" {{action 'saveCompliance'}}>
+                            {{if isNewPrivacyCompliancePolicy 'Create' 'Save'}}
+                        </button>
                         <button class="btn btn-default" {{action 'resetCompliance'}}>Reset</button>
                     </div>
                 {{else}}
-                    <h3>Compliance is not available</h3>
+                    <h3>An error occurred: Privacy Compliance Policy is not available.</h3>
                 {{/if}}
             </div>
         </script>
 
         <script type="text/x-handlebars" id="components/dataset-confidential">
             <div id="confidential" class="tab-body">
-                {{#if securitySpec}}
+                {{#if securitySpecification}}
                     <label class="lbl">
                         <span class="lbl__text">Retention</span>
                         {{#ember-selector values=retentionTypes
@@ -1497,18 +1499,21 @@
                         </table>
                     </section>
                     <div class="cta">
-                        {{#if isApproved}}<!-- TODO: Add flag to component -->
-                            <button class="btn btn-primary" {{action 'disapproveCompliance'}}>
+                        {{#if isApproved}}<!-- TODO: not yet implemented on BE -->
+                            <button class="btn btn-primary" {{action 'disapproveSecuritySpecification'}}>
                                 Remove Approval
                             </button>
                         {{else}}
-                            <button class="btn btn-primary" {{action 'approveCompliance'}}>Approve</button>
+                            <button class="btn btn-primary" {{action 'approveSecuritySpecification'}}>Approve</button>
                         {{/if}}
-                        <button class="btn btn-primary" {{action 'saveCompliance'}}>Save</button>
-                        <button class="btn btn-default" {{action 'resetCompliance'}}>Reset</button>
+
+                        <button class="btn btn-primary" {{action 'saveSecuritySpecification'}}>
+                            {{if isNewSecuritySpecification 'Create' 'Save'}}
+                        </button>
+                        <button class="btn btn-default" {{action 'resetSecuritySpecification'}}>Reset</button>
                     </div>
                 {{else}}
-                    <h3>Confidential spec is not available</h3>
+                    <h3>An error occurred: Security Specification is not available.</h3>
                 {{/if}}
             </div>
         </script>

--- a/web/public/javascripts/components/components.js
+++ b/web/public/javascripts/components/components.js
@@ -233,8 +233,8 @@ App.DatasetImpactComponent = Ember.Component.extend({
 });
 
 App.DatasetComplianceComponent = Ember.Component.extend({
-  matchingFields: [],
-  complianceType: Ember.computed.alias('securitySpec.complianceType'),
+  searchTerm: '',
+  complianceType: Ember.computed.alias('privacyCompliancePolicy.complianceType'),
   get complianceTypes() {
     return ['CUSTOM_PURGE', 'AUTO_PURGE', 'RETENTION_PURGE', 'NOT_APPLICABLE'].map(complianceType => ({
       value: complianceType,
@@ -247,13 +247,29 @@ App.DatasetComplianceComponent = Ember.Component.extend({
     return this.get('datasetSchemaFieldsAndTypes').mapBy('name');
   }),
 
+  matchingFields: Ember.computed('searchTerm', function () {
+    if (this.get('datasetSchemaFieldsAndTypes')) {
+      const searchTerm = this.get('searchTerm');
+      const matches = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), searchTerm);
+      return matches.map(value => {
+        const {type} = this.get('datasetSchemaFieldsAndTypes').filterBy('name', value).get('firstObject');
+        const dataType = Array.isArray(type) && type.toString().toUpperCase();
+
+        return {
+          value,
+          dataType
+        };
+      });
+    }
+  }),
+
   /**
-   * Aliases compliancePurgeEntities on securitySpec, and transforms each nested comma-delimited identifierField string
+   * Aliases compliancePurgeEntities on privacyCompliancePolicy, and transforms each nested comma-delimited identifierField string
    * into an array of fields that can easily be iterated over. Dependency on each identifierField will update
    * UI on updates
    */
-  purgeEntities: Ember.computed('securitySpec.compliancePurgeEntities.@each.identifierField', function () {
-    const compliancePurgeEntities = this.get('securitySpec.compliancePurgeEntities');
+  purgeEntities: Ember.computed('privacyCompliancePolicy.compliancePurgeEntities.@each.identifierField', function () {
+    const compliancePurgeEntities = this.get('privacyCompliancePolicy.compliancePurgeEntities');
     // Type ENUM is locally saved in the client.
     // The user is able to add a values to the identifier types that are not provided in the schema returned by the server.
     // Values are manually extracted from Nuage schema at develop time
@@ -276,7 +292,7 @@ App.DatasetComplianceComponent = Ember.Component.extend({
   }),
 
   didRender() {
-    const $typeahead = this.$('#compliance-typeahead');
+    const $typeahead = this.$('#compliance-typeahead') || [];
     if ($typeahead.length) {
       this.enableTypeaheadOn($typeahead);
     }
@@ -286,18 +302,7 @@ App.DatasetComplianceComponent = Ember.Component.extend({
     selector.autocomplete({
       source: request => {
         const {term = ''} = request;
-        const datasetSchemaFieldsAndTypes = this.get('datasetSchemaFieldsAndTypes');
-        const matchingFields = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), term);
-        // Using setObjects to reuse the previous matchingFields array
-        this.get('matchingFields').setObjects(matchingFields.map(value => {
-          const {type} = datasetSchemaFieldsAndTypes.filterBy('name', value).get('firstObject');
-          const dataType = Array.isArray(type) && type.toString().toUpperCase();
-
-          return {
-            value,
-            dataType
-          };
-        }));
+        this.set('searchTerm', term);
       }
     });
   },
@@ -309,13 +314,13 @@ App.DatasetComplianceComponent = Ember.Component.extend({
    */
   getPurgeEntity(id) {
     // There should be only one match in the resulting array
-    return this.get('securitySpec.compliancePurgeEntities')
+    return this.get('privacyCompliancePolicy.compliancePurgeEntities')
         .filterBy('identifierType', id)
         .get('firstObject');
   },
 
   addPurgeEntityToComplianceEntities(identifierType) {
-    this.get('securitySpec.compliancePurgeEntities').addObject({identifierType, identifierField: ''});
+    this.get('privacyCompliancePolicy.compliancePurgeEntities').addObject({identifierType, identifierField: ''});
     return this.getPurgeEntity(identifierType);
   },
 
@@ -372,7 +377,7 @@ App.DatasetComplianceComponent = Ember.Component.extend({
     },
 
     updateComplianceType ({value}) {
-      this.set('securitySpec.complianceType', value);
+      this.set('privacyCompliancePolicy.complianceType', value);
     },
 
     saveCompliance () {
@@ -389,16 +394,32 @@ App.DatasetComplianceComponent = Ember.Component.extend({
 });
 
 App.DatasetConfidentialComponent = Ember.Component.extend({
-  matchingFields: [],
-  retention: Ember.computed.alias('securitySpec.retentionPolicy.retentionType'),
-  geographicAffinity: Ember.computed.alias('securitySpec.geographicAffinity.affinity'),
-  recordOwnerType: Ember.computed.alias('securitySpec.recordOwnerType'),
+  searchTerm: '',
+  retention: Ember.computed.alias('securitySpecification.retentionPolicy.retentionType'),
+  geographicAffinity: Ember.computed.alias('securitySpecification.geographicAffinity.affinity'),
+  recordOwnerType: Ember.computed.alias('securitySpecification.recordOwnerType'),
   datasetSchemaFieldNames: Ember.computed('datasetSchemaFieldsAndTypes', function () {
     return this.get('datasetSchemaFieldsAndTypes').mapBy('name');
   }),
 
+  matchingFields: Ember.computed('searchTerm', function () {
+    if (this.get('datasetSchemaFieldsAndTypes')) {
+      const searchTerm = this.get('searchTerm');
+      const matches = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), searchTerm);
+      return matches.map(value => {
+        const {type} = this.get('datasetSchemaFieldsAndTypes').filterBy('name', value).get('firstObject');
+        const dataType = Array.isArray(type) && type.toString().toUpperCase();
+
+        return {
+          value,
+          dataType
+        };
+      });
+    }
+  }),
+
   didRender() {
-    const $typeahead = this.$('#confidential-typeahead');
+    const $typeahead = this.$('#confidential-typeahead') || [];
     if ($typeahead.length) {
       this.enableTypeaheadOn($typeahead);
     }
@@ -408,18 +429,7 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
     selector.autocomplete({
       source: request => {
         const {term = ''} = request;
-        const datasetSchemaFieldsAndTypes = this.get('datasetSchemaFieldsAndTypes');
-        const matchingFields = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), term);
-        // Using setObjects to reuse the previous matchingFields array
-        this.get('matchingFields').setObjects(matchingFields.map(value => {
-          const {type} = datasetSchemaFieldsAndTypes.filterBy('name', value).get('firstObject');
-          const dataType = Array.isArray(type) && type.toString().toUpperCase();
-
-          return {
-            value,
-            dataType
-          };
-        }));
+        this.set('searchTerm', term);
       }
     });
   },
@@ -445,8 +455,13 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
     }));
   },
 
-  classification: Ember.computed('securitySpec.classification', function () {
-    const confidentialClassification = this.get('securitySpec.classification');
+  classification: Ember.computed('securitySpecification.classification', function () {
+    const classifiers = ['highlyConfidential', 'confidential', 'limitedDistribution', 'mustBeEncrypted', 'mustBeMasked'];
+    const defaultClassification = classifiers.reduce((classification, classifier) => {
+      classification[classifier] = [];
+      return classification;
+    }, {});
+    const confidentialClassification = this.get('securitySpecification.classification') || defaultClassification;
     const formatAsCapitalizedStringWithSpaces = string => string.replace(/[A-Z]/g, match => ` ${match}`).capitalize();
 
     return Object.keys(confidentialClassification).map(classifier => ({
@@ -457,7 +472,7 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
   }),
 
   _toggleOnClassification(classifier, key, operation) {
-    this.get(`securitySpec.classification.${key}`)[`${operation}Object`](classifier);
+    this.get(`securitySpecification.classification.${key}`)[`${operation}Object`](classifier);
   },
 
   actions: {
@@ -470,31 +485,33 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
     },
 
     updateRetentionType({value}) {
-      this.set('securitySpec.retentionPolicy.retentionType', value);
+      this.set('securitySpecification.retentionPolicy.retentionType', value);
     },
 
     updateGeographicAffinity({value}) {
-      this.set('securitySpec.geographicAffinity.affinity', value);
+      this.set('securitySpecification.geographicAffinity.affinity', value);
     },
 
     updateRecordOwnerType({value}) {
-      this.set('securitySpec.recordOwnerType', value);
+      this.set('securitySpecification.recordOwnerType', value);
     },
 
-    saveCompliance () {
+    saveSecuritySpecification () {
       this.get('onSave')();
       return false;
     },
+
     approveCompliance () {
       //TODO: not implemented
     },
+
     disapproveCompliance () {
       //TODO: not implemented
     },
 
     // Rolls back changes made to the compliance spec to current
     // server state
-    resetCompliance () {
+    resetSecuritySpecification () {
       this.get('onReset')();
     }
   }

--- a/web/public/javascripts/components/components.js
+++ b/web/public/javascripts/components/components.js
@@ -247,7 +247,7 @@ App.DatasetComplianceComponent = Ember.Component.extend({
     return this.get('datasetSchemaFieldsAndTypes').mapBy('name');
   }),
 
-  matchingFields: Ember.computed('searchTerm', function () {
+  matchingFields: Ember.computed('searchTerm', 'datasetSchemaFieldsAndTypes', function () {
     if (this.get('datasetSchemaFieldsAndTypes')) {
       const searchTerm = this.get('searchTerm');
       const matches = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), searchTerm);
@@ -300,6 +300,7 @@ App.DatasetComplianceComponent = Ember.Component.extend({
 
   enableTypeaheadOn(selector) {
     selector.autocomplete({
+      minLength: 0,
       source: request => {
         const {term = ''} = request;
         this.set('searchTerm', term);
@@ -402,7 +403,7 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
     return this.get('datasetSchemaFieldsAndTypes').mapBy('name');
   }),
 
-  matchingFields: Ember.computed('searchTerm', function () {
+  matchingFields: Ember.computed('searchTerm', 'datasetSchemaFieldsAndTypes', function () {
     if (this.get('datasetSchemaFieldsAndTypes')) {
       const searchTerm = this.get('searchTerm');
       const matches = $.ui.autocomplete.filter(this.get('datasetSchemaFieldNames'), searchTerm);
@@ -427,6 +428,7 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
 
   enableTypeaheadOn(selector) {
     selector.autocomplete({
+      minLength: 0,
       source: request => {
         const {term = ''} = request;
         this.set('searchTerm', term);

--- a/web/public/javascripts/routers/datasets.js
+++ b/web/public/javascripts/routers/datasets.js
@@ -208,35 +208,107 @@ App.DatasetRoute = Ember.Route.extend({
     var urn = '';
     var name = '';
 
-    const getAndUpdateSchema = id => {
-      /**
-       * Parses a JSON dataset schema representation and extracts the field names and types into a list of maps
-       * @param {JSON} schema
-       * @returns {Array.<*>}
-       */
-      const getFieldNamesAndTypesFrom = (schema = JSON.stringify({})) => {
-        const getFieldTypeSet = ({fields = []}) => fields.map(({name, type: [firstType, ...type], fields}) => {
-          if (fields) {
-            return getFieldTypeSet({fields});
-          }
-
-          return {
-            name,
-            type: firstType === 'null' ? type : [firstType, ...type]
-          };
-        });
-
-        // Flatten nested structure if present
-        return [].concat(...getFieldTypeSet(JSON.parse(schema))); // TODO: cover n-th dimension, if expected
+    /**
+     * Builds a privacyCompliancePolicy map with default / unset values for non null properties
+     */
+    const createPrivacyCompliancePolicy = () => {
+      // TODO: Move to a more accessible location, this app does not use modules at the moment, so potentially
+      // ->TODO: registering it as factory
+      const complianceTypes = ['AUTO_PURGE', 'CUSTOM_PURGE', 'LIMITED_RETENTION', 'PURGE_NOT_APPLICABLE'];
+      const policy = {
+        //default to first item in compliance types list
+        complianceType: complianceTypes.get('firstObject'),
+        compliancePurgeEntities: []
       };
-      Promise.all([Ember.$.getJSON(`api/v1/datasets/${id}`), Ember.$.getJSON(`api/v1/datasets/${id}/security`)])
-          .then(([{dataset: {schema}}, {securitySpec}]) => {
-            schema && controller.set('datasetSchemaFieldsAndTypes', getFieldNamesAndTypesFrom(schema));
-            controller.set('securitySpec', securitySpec);
-          });
-    };
-    controller.set("hasProperty", false);
 
+      // Ensure we deep clone map to prevent mutation from consumers
+      return JSON.parse(JSON.stringify(policy));
+    };
+
+    /**
+     * Builds a securitySpecification map with default / unset values for non null properties as per avro schema
+     * @param {number} id
+     */
+    const createSecuritySpecification = id => {
+      const securitySpecification = {
+        classification: null,
+        datasetId: id,
+        geographicAffinity: {affinity: ''},
+        recordOwnerType: '',
+        retentionPolicy: {retentionType: ''}
+      };
+
+      return JSON.parse(JSON.stringify(securitySpecification));
+    };
+
+    /**
+     * Series of chain-able functions invoked to set set properties on the controller required for dataset tab sections
+     * @type {{privacyCompliancePolicy: ((id)), securitySpecification: ((id)), datasetSchemaFieldNamesAndTypes: ((id))}}
+     */
+    const fetchThenSetOnController = {
+      privacyCompliancePolicy(id) {
+        Ember.$.getJSON(`api/v1/datasets/${id}/compliance`)
+            .then(({privacyCompliance = createPrivacyCompliancePolicy(), return_code}) =>
+                controller.setProperties({
+                  'isNewPrivacyCompliancePolicy': return_code === 404,
+                  'privacyCompliancePolicy': privacyCompliance
+                }));
+
+        return this;
+      },
+
+      securitySpecification(id) {
+        Ember.$.getJSON(`api/v1/datasets/${id}/security`)
+            .then(({securitySpecification = createSecuritySpecification(id), return_code}) =>
+                controller.setPropertes({
+                  'isNewSecuritySpecification': return_code === 404,
+                  'securitySpecification': securitySpecification
+                }));
+
+        return this;
+      },
+
+      datasetSchemaFieldNamesAndTypes(id) {
+        Ember.$.getJSON(`api/v1/datasets/${id}`)
+            .then(({dataset: {schema} = {schema: undefined}} = {}) => {
+              /**
+               * Parses a JSON dataset schema representation and extracts the field names and types into a list of maps
+               * @param {JSON} schema
+               * @returns {Array.<*>}
+               */
+              function getFieldNamesAndTypesFrom(schema = JSON.stringify({})) {
+                /**
+                 * schema argument may contain property with name `fields` or `fields` may be nested in `schema` object
+                 * with same name.
+                 * Unfortunately shape is inconsistent depending of dataset queried.
+                 * Use `fields` property if present and is an array, otherwise use `fields` property on `schema`.
+                 * Will default to empty array.
+                 * @param {Array} [nestedFields]
+                 * @param {Array} [fields]
+                 * @returns {Array.<*>}
+                 */
+                function getFieldTypeMappingArray({schema: {fields: nestedFields = []} = {schema: {}}, fields}) {
+                  fields = Array.isArray(fields) ? fields : nestedFields;
+
+                  // As above, field may contain a label with string property or a name property
+                  return fields.map(({label: {string} = {}, name, type}) => ({
+                    name: string || name,
+                    type: Array.isArray(type) ? (type[0] === 'null' ? type.slice(1) : type) : [type]
+                  }));
+                }
+
+                schema = JSON.parse(schema);
+                return [].concat(...getFieldTypeMappingArray(schema));
+              }
+
+              controller.set('datasetSchemaFieldsAndTypes', getFieldNamesAndTypesFrom(schema));
+            });
+
+        return this;
+      }
+    };
+
+    controller.set("hasProperty", false);
 
     if (params && params.id) {
       ({id, source, urn, name} = params);
@@ -255,8 +327,14 @@ App.DatasetRoute = Ember.Route.extend({
       datasetController.set('detailview', true);
     }
 
-    controller.set('datasetId', id);
-    getAndUpdateSchema(id);
+    // Don't set default zero Ids on controller
+    if (id) {
+      controller.set('datasetId', id);
+      // Creates list of partially applied functions from `fetchThenSetController` and invokes each in turn
+      Object.keys(fetchThenSetOnController)
+          .map(funcRef => fetchThenSetOnController[funcRef]['bind'](fetchThenSetOnController, id))
+          .forEach(func => func());
+    }
 
     var instanceUrl = 'api/v1/datasets/' + id + "/instances";
       $.get(instanceUrl, function(data) {

--- a/web/public/javascripts/routers/datasets.js
+++ b/web/public/javascripts/routers/datasets.js
@@ -260,7 +260,7 @@ App.DatasetRoute = Ember.Route.extend({
       securitySpecification(id) {
         Ember.$.getJSON(`api/v1/datasets/${id}/security`)
             .then(({securitySpecification = createSecuritySpecification(id), return_code}) =>
-                controller.setPropertes({
+                controller.setProperties({
                   'isNewSecuritySpecification': return_code === 404,
                   'securitySpecification': securitySpecification
                 }));

--- a/web/public/javascripts/search.js
+++ b/web/public/javascripts/search.js
@@ -106,7 +106,8 @@
         });
 
         $.get('/api/v1/autocomplete/search', function(data){
-            $('#searchInput').autocomplete({
+            const $searchInput = $('#searchInput');
+            $searchInput.autocomplete({
                 source: function( req, res ) {
                     var results = $.ui.autocomplete.filter(data.source, extractLast( req.term ));
                     res(results.slice(0,maxReturnedResults));
@@ -122,8 +123,10 @@
                     this.value = terms.join( ", " );
                     return false;
             }
-
         });
+            $searchInput.on('autocompleteselect', () => {
+                document.querySelector('#searchBtn').click();
+            });
 
         });
 
@@ -397,6 +400,14 @@
                     window.location = '/#/search?keywords=' + btoa(keyword) +
                         '&category=' + window.g_currentCategory + '&source=default&page=1'
                 }
+            }
+        });
+
+    // This is a stop gap implementation to solve the issue with handling the enter key on user search
+    document.querySelector('#searchInput')
+        .addEventListener('keypress', ({keyCode}) => {
+            if (keyCode === 13) {
+                document.querySelector('#searchBtn').click();
             }
         });
 

--- a/web/public/stylesheets/wherehows.css
+++ b/web/public/stylesheets/wherehows.css
@@ -578,6 +578,11 @@ ul.breadcrumbs a {
     padding: .5em;
 }
 
+.tab_head {
+    padding: 15px;
+    line-height: 2;
+}
+
 .lbl {
     display: inline-block;
     padding: .5em;

--- a/web/public/stylesheets/wherehows.css
+++ b/web/public/stylesheets/wherehows.css
@@ -596,14 +596,11 @@ ul.breadcrumbs a {
     padding: .5em;
 }
 
-.field-search {
-    height: 50px;
-    width: 700px;
-    margin: 1.5em 0;
-}
 
 .field-search__input {
-    height: 100%;
+    display: flex;
+    flex-grow: 1;
+    width: 50%;
 }
 
 .drop-bucket {
@@ -631,17 +628,14 @@ ul.breadcrumbs a {
 
 .draggable__item {
     overflow: hidden;
-    width: 140px;
     list-style-type: none;
-    display: inline-block;
+    display: flex;
+    align-items: stretch;
     background-color: #d3d3d3;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-    padding: 5px 20px 5px 5px;
-    margin: 10px 5px;
     cursor: pointer;
     position: relative;
+    border: 1px solid;
+    margin-bottom: 2px;
 }
 
 .draggable__item .glyphicon-remove {
@@ -650,8 +644,30 @@ ul.breadcrumbs a {
     top: 3px;
 }
 
+.draggable__item.item-source {
+    cursor: move;
+}
+
+.draggable__item.item-source :before {
+    content: '.';
+    position: absolute;
+    left: 1px;
+    top: -2px;
+    font-size: 20px;
+    line-height: 26px;
+    color: #292724;
+    text-shadow: 0 5px #292724,
+    0 10px #292724,
+    5px 0 #292724,
+    5px 5px #292724,
+    5px 10px #292724,
+    10px 0 #292724,
+    10px 5px #292724,
+    10px 10px #292724;
+}
+
 .drop-bucket__td > .drop-region {
-    min-height: 70px;;
+    min-height: 70px;
 }
 
 .classification-list-help {
@@ -661,18 +677,48 @@ ul.breadcrumbs a {
 
 .typeahead-matches {
     width: 700px;
-    padding: 20px 5px;
+    height: 200px;
+    overflow-y: scroll;
+    margin-bottom: 15px;
 }
 
+.typeahead-header {
+    display: flex;
+    align-items: center;
+    width: 700px;
+    border: 1px solid #d3d3d3;
+}
+
+.field-names {
+    display: flex;
+    width: 500px;
+    align-items: center;
+}
+
+.typeahead-header h4 {
+    margin: 0;
+    padding: 0 3px;
+}
+
+.field-names h4 {
+    display: flex;
+    flex-grow: 2;
+}
+
+
 .match-pill__data-type {
-    display: inline-block;
-    width: 100%;
+    display: flex;
+    line-height: 3;
+    padding: 0 5px 0 15px;
 }
 
 .match-pill__value {
     display: inline-block;
-    width: 100%;
+    width: 500px;
     -ms-text-overflow: ellipsis;
     text-overflow: ellipsis;
     overflow: hidden;
+    line-height: 3;
+    border-right: 1px solid;
+    padding: 0 5px 0 25px;
 }


### PR DESCRIPTION
*DSS-5677: Refactors matching field feature for typeahead on DatasetComplianceComponent and DatasetConfidentialComponent components. Will render all possible results before search input is recieved on component
*DSS-5677: Adds ability to create a new PrivacyCompliancePolicy and SecuritySpecification from the client UI. Also fixes issue with matching fields and data type properties on schema with inconsistent shapes
*DSS-5677: Changes component from block syntax to inline. Add property for creating a new PrivacyCompliancePolicy and SecuritySpecification for datasets without either