### PR TITLE
Add retry for ETL jobs failed at initialization

### DIFF
--- a/metadata-etl/src/main/java/metadata/etl/EtlJob.java
+++ b/metadata-etl/src/main/java/metadata/etl/EtlJob.java
@@ -175,6 +175,7 @@ public abstract class EtlJob {
   public void run()
     throws Exception {
     setup();
+    logger.info("PySystem path: " + interpreter.getSystemState().path.toString());
     extract();
     transform();
     load();

--- a/metadata-etl/src/main/java/metadata/etl/Launcher.java
+++ b/metadata-etl/src/main/java/metadata/etl/Launcher.java
@@ -78,9 +78,12 @@ public class Launcher {
       etlJob.run();
     } catch (Exception e) {
       StringWriter sw = new StringWriter();
-      PrintWriter pw = new PrintWriter(sw);
-      e.printStackTrace(pw);
-      logger.error(sw.toString());
+      e.printStackTrace(new PrintWriter(sw));
+      String errorString = sw.toString();
+      logger.error(errorString);
+      if (errorString.contains("IndexError") || errorString.contains("ImportError")) {
+        System.exit(2);
+      }
       System.exit(1);
     }
 

--- a/metadata-etl/src/main/resources/jython/AzkabanExtract.py
+++ b/metadata-etl/src/main/resources/jython/AzkabanExtract.py
@@ -25,15 +25,12 @@ from wherehows.common.utils import AzkabanJobExecUtil
 from wherehows.common import Constant
 from wherehows.common.enums import SchedulerType
 from com.ziclix.python.sql import zxJDBC
-import os
-import DbUtil
-import sys
-import gzip
-import StringIO
-import json
-import datetime
-import time
 from org.slf4j import LoggerFactory
+import os, sys, json, gzip
+import StringIO
+import datetime, time
+import DbUtil
+
 
 class AzkabanExtract:
 

--- a/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -14,12 +14,9 @@
 
 from wherehows.common import Constant
 from com.ziclix.python.sql import zxJDBC
-import DbUtil
-import sys
-import json
-import urllib
-import urllib2
 from org.slf4j import LoggerFactory
+import sys, json
+import urllib2
 
 
 class ElasticSearchIndex():


### PR DESCRIPTION
If ETL jobs fails within short time after start, and the Error message is of ImportError or IndexError (args), then the etljob actor will retry the job at most 2 more times. 
Those initialization error will have return status code 2 instead of 1.