### PR TITLE
change default value for static boosting score to 1

### DIFF
--- a/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -202,7 +202,7 @@ class ElasticSearchIndex():
           static_boosting_score = 65;
 
           SELECT d.*,
-              COALESCE(s.static_boosting_score,0) as static_boosting_score
+              COALESCE(s.static_boosting_score,1) as static_boosting_score
           FROM dict_dataset d
           LEFT JOIN cfg_search_score_boost s
           ON d.id = s.id


### PR DESCRIPTION
The static boosting score default value should be set as 1, as it will be used to product with other values. If set as 0, then the result will be always 0, which ends with wrong ranking. 