### PR TITLE
DSS-6197 & DSS-6198 Fixes render issues with compliance confidential tabs and field values

### DIFF
--- a/web/public/javascripts/components/components.js
+++ b/web/public/javascripts/components/components.js
@@ -468,7 +468,13 @@ App.DatasetConfidentialComponent = Ember.Component.extend({
   },
 
   classification: Ember.computed('securitySpecification.classification', function () {
-    const confidentialClassification = this.get('securitySpecification.classification');
+    const defaultClassification = [
+      'highlyConfidential', 'confidential', 'limitedDistribution', 'mustBeEncrypted', 'mustBeMasked'
+    ].reduce((classification, classifier) => {
+      classification[classifier] = [];
+      return classification;
+    }, {});
+    const confidentialClassification = this.get('securitySpecification.classification') || defaultClassification;
     const formatAsCapitalizedStringWithSpaces = string => string.replace(/[A-Z]/g, match => ` ${match}`).capitalize();
 
     return Object.keys(confidentialClassification).map(classifier => ({


### PR DESCRIPTION
	DSS-6198: Fixes issue with nested fields not getting rendered in the schema for compliance and confidential tabs
	DSS-6197: Adds default value for classification property on security
specification if not defined