### PR TITLE
myql57_pk_not_null - primary key columns must be not null

### DIFF
--- a/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
+++ b/data-model/DDL/ETL_DDL/dataset_info_metadata.sql
@@ -17,7 +17,7 @@ CREATE TABLE dataset_deployment (
   `dataset_id`      INT UNSIGNED NOT NULL,
   `dataset_urn`     VARCHAR(200) NOT NULL,
   `deployment_tier` VARCHAR(20)  NOT NULL,
-  `datacenter`      VARCHAR(20)        DEFAULT NULL,
+  `datacenter`      VARCHAR(20)  NOT NULL,
   `region`          VARCHAR(50)        DEFAULT NULL,
   `zone`            VARCHAR(50)        DEFAULT NULL,
   `cluster`         VARCHAR(100)       DEFAULT NULL,

--- a/data-model/DDL/ETL_DDL/kafka_tracking.sql
+++ b/data-model/DDL/ETL_DDL/kafka_tracking.sql
@@ -80,7 +80,7 @@ CREATE TABLE `stg_kafka_gobblin_distcp` (
   `cluster`     VARCHAR(20) NOT NULL,
   `dataset`     VARCHAR(100) NOT NULL,
   `partition_type`  VARCHAR(20) DEFAULT NULL,
-  `partition_name`  VARCHAR(50) DEFAULT NULL,
+  `partition_name`  VARCHAR(50) NOT NULL,
   `upsteam_timestamp` BIGINT(20) DEFAULT NULL,
   `origin_timestamp`  BIGINT(20) DEFAULT NULL,
   `source_path`     VARCHAR(200) DEFAULT NULL,


### PR DESCRIPTION
These columns cannot be NULL in order to create the tables in MySQL 5.7 as they are part of the tables' primary keys.    Updated the DDL to make them NOT NULL.