### PR TITLE
Fix null comparison in SQL, refactor some queries

### DIFF
--- a/data-model/DDL/ETL_DDL/git_metadata.sql
+++ b/data-model/DDL/ETL_DDL/git_metadata.sql
@@ -90,23 +90,22 @@ CREATE TABLE `stg_repo_owner` (
   `scm_type`        VARCHAR(20) NOT NULL,
   `repo_id`         INT DEFAULT NULL,
   `dataset_group`   VARCHAR(200) DEFAULT NULL COMMENT 'dataset group name, database name, etc',
-  `owner_type`      VARCHAR(50) DEFAULT NULL COMMENT 'which acl file this owner is in',
-  `owner_name`      VARCHAR(50) DEFAULT NULL COMMENT 'one owner name',
+  `owner_type`      VARCHAR(50) NOT NULL COMMENT 'which acl file this owner is in',
+  `owner_name`      VARCHAR(50) NOT NULL COMMENT 'one owner name',
   `sort_id`         INT UNSIGNED DEFAULT NULL,
   `paths`           TEXT CHAR SET utf8 DEFAULT NULL COMMENT 'covered paths by this acl',
   PRIMARY KEY (`scm_repo_fullname`, `scm_type`, `owner_type`, `owner_name`, `app_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = latin1;
 
-
 CREATE TABLE stg_database_scm_map (
-  `database_name` VARCHAR(100) COMMENT 'database name',
-  `database_type` VARCHAR(50) COMMENT 'database type',
-  `app_name` VARCHAR(127) COMMENT 'the name of application',
-  `scm_type` VARCHAR(50) COMMENT 'scm type',
-  `scm_url` VARCHAR(127) COMMENT 'scm url',
-  `committers` VARCHAR(500) COMMENT 'committers',
-  `filepath` VARCHAR(200) COMMENT 'filepath',
-  `app_id` INT COMMENT 'application id of the namesapce',
+  `database_name`   VARCHAR(100) NOT NULL COMMENT 'database name',
+  `database_type`   VARCHAR(50) NOT NULL COMMENT 'database type',
+  `app_name`        VARCHAR(127) NOT NULL COMMENT 'the name of application',
+  `scm_type`        VARCHAR(50) NOT NULL COMMENT 'scm type',
+  `scm_url`         VARCHAR(127) DEFAULT NULL COMMENT 'scm url',
+  `committers`      VARCHAR(500) DEFAULT NULL COMMENT 'committers',
+  `filepath`        VARCHAR(200) DEFAULT NULL COMMENT 'filepath',
+  `app_id`          SMALLINT(5) UNSIGNED COMMENT 'application id of the namesapce',
   `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
   PRIMARY KEY (`database_type`,`database_name`,`scm_type`,`app_name`)
 ) ENGINE = InnoDB DEFAULT CHARSET = latin1;

--- a/metadata-etl/src/main/resources/jython/HdfsLoad.py
+++ b/metadata-etl/src/main/resources/jython/HdfsLoad.py
@@ -221,22 +221,6 @@ class HdfsLoad:
            and (char_length(trim(description)) = 0
            or description in ('null', 'N/A', 'nothing', 'empty', 'none'));
 
-        insert into field_comments (
-          user_id, comment, created, modified, comment_crc32_checksum
-        )
-        select 0 user_id, description, now() created, now() modified, crc32(description) from
-        (
-          select sf.description
-          from stg_dict_field_detail sf left join field_comments fc
-            on sf.description = fc.comment
-          where sf.description is not null
-            and fc.id is null
-            and sf.db_id = {db_id}
-          group by 1 order by 1
-        ) d;
-
-        analyze table field_comments;
-
         -- update stg_dict_field_detail dataset_id
         update stg_dict_field_detail sf, dict_dataset d
         set sf.dataset_id = d.id where sf.urn = d.urn
@@ -254,7 +238,7 @@ class HdfsLoad:
             ) x
             ON s.dataset_id = x.dataset_id
             AND s.field_name = x.field_name
-            AND s.parent_path = x.parent_path
+            AND s.parent_path <=> x.parent_path
           WHERE s.field_name is null
         ; -- run time : ~2min
 
@@ -266,9 +250,9 @@ class HdfsLoad:
           select x.field_id, s.*
           from (select * from stg_dict_field_detail where db_id = {db_id}) s
             join dict_field_detail x
-              on s.field_name = x.field_name
-              and coalesce(s.parent_path, '*') = coalesce(x.parent_path, '*')
-              and s.dataset_id = x.dataset_id
+              on s.dataset_id = x.dataset_id
+              and s.field_name = x.field_name
+              and s.parent_path <=> x.parent_path
           where (x.sort_id <> s.sort_id
                 or x.parent_sort_id <> s.parent_sort_id
                 or x.data_type <> s.data_type
@@ -307,25 +291,42 @@ class HdfsLoad:
              left join dict_field_detail t
           on sf.dataset_id = t.dataset_id
          and sf.field_name = t.field_name
-         and sf.parent_path = t.parent_path
+         and sf.parent_path <=> t.parent_path
         where db_id = {db_id} and t.field_id is null
         ;
 
         analyze table dict_field_detail;
 
-        -- delete old record in stagging
+        -- delete old record in staging field comment map
         delete from stg_dict_dataset_field_comment where db_id = {db_id};
 
-        -- insert
-        insert into stg_dict_dataset_field_comment
-        select t.field_id field_id, fc.id comment_id, sf.dataset_id dataset_id, {db_id}
+        -- insert new field comments
+        insert into field_comments (
+          user_id, comment, created, modified, comment_crc32_checksum
+        )
+        select 0 user_id, description, now() created, now() modified, crc32(description) from
+        (
+          select sf.description
+          from stg_dict_field_detail sf left join field_comments fc
+            on sf.description = fc.comment
+          where sf.description is not null
+            and fc.id is null
+            and sf.db_id = {db_id}
+          group by 1 order by 1
+        ) d;
+
+        analyze table field_comments;
+
+        -- insert field to comment map to staging
+        insert ignore into stg_dict_dataset_field_comment
+        select t.field_id field_id, fc.id comment_id, sf.dataset_id, {db_id}
                 from stg_dict_field_detail sf
                       join field_comments fc
                   on sf.description = fc.comment
                       join dict_field_detail t
                   on sf.dataset_id = t.dataset_id
                  and sf.field_name = t.field_name
-                 and sf.parent_path = t.parent_path
+                 and sf.parent_path <=> t.parent_path
         where sf.db_id = {db_id};
 
         -- have default comment, insert it set default to 0
@@ -335,7 +336,6 @@ class HdfsLoad:
           where field_id in (select field_id from stg_dict_dataset_field_comment)
         and is_default = 1 ) and db_id = {db_id};
 
-
         -- doesn't have this comment before, insert into it and set as default
         insert ignore into dict_dataset_field_comment
         select sd.field_id, sd.comment_id, sd.dataset_id, 1 from stg_dict_dataset_field_comment sd
@@ -344,10 +344,6 @@ class HdfsLoad:
          and d.comment_id = sd.comment_id
         where d.comment_id is null
         and sd.db_id = {db_id};
-
-
-        DELETE FROM stg_dict_field_detail where db_id = {db_id};
-
         '''.format(source_file=self.input_field_file, db_id=self.db_id)
 
     self.executeCommands(load_field_cmd)

--- a/metadata-etl/src/main/resources/jython/OracleExtract.py
+++ b/metadata-etl/src/main/resources/jython/OracleExtract.py
@@ -307,7 +307,7 @@ class OracleExtract:
       return None
 
   def trim_newline(self, line):
-    return None if line is None else line.replace('\n', ' ').replace('\r', ' ').encode('ascii', 'ignore')
+    return line.replace('\n', ' ').replace('\r', ' ').strip().encode('ascii', 'ignore') if line else None
 
   def write_csv(self, csv_filename, csv_columns, data_list):
     csvfile = open(csv_filename, 'wb')


### PR DESCRIPTION
- Use NULL-safe equal to operator <=> when comparing dateset field parent_path, which can be null. 
- Refactor some SQL code