### PR TITLE
Fix Hive Extract job file writing issues, add more authentication log

### DIFF
--- a/metadata-etl/src/main/resources/jython/HiveTransform.py
+++ b/metadata-etl/src/main/resources/jython/HiveTransform.py
@@ -13,8 +13,7 @@
 #
 
 import json
-import datetime
-import sys, os
+import sys
 import time
 from com.ziclix.python.sql import zxJDBC
 from org.slf4j import LoggerFactory
@@ -49,9 +48,10 @@ class HiveTransform:
     :param hive_field_metadata: output data file for hive field metadata
     :return:
     """
-    f_json = open(input)
-    all_data = json.load(f_json)
-    f_json.close()
+    all_data = []
+    with open(input) as input_file:
+        for line in input_file:
+            all_data.append(json.loads(line))
 
     dataset_idx = -1
 


### PR DESCRIPTION
For Hive extract:
- Fix Hive extract json.dumps Out Of Memory issue by writing to file line by line.
- Catch exception in writing to CSV file : 'unescaped char'

For frontend authentication:
- differentiate AuthenticationException with CommunicationException
- add more logging