### PR TITLE
Elastic search completion suggester for type ahead

### DIFF
--- a/data-model/ELASTICSEARCH/index_mapping.json
+++ b/data-model/ELASTICSEARCH/index_mapping.json
@@ -44,6 +44,9 @@
         "metric_name": {
           "type": "string"
         },
+        "metric_name_suggest": {
+          "type": "completion"
+        },
         "metric_ref_id": {
           "type": "string"
         },
@@ -85,31 +88,6 @@
         }
       }
     },
-    "field": {
-      "_parent": {
-        "type": "dataset"
-      },
-      "_routing": {
-        "required": true
-      },
-      "properties": {
-        "comments": {
-          "type": "string"
-        },
-        "dataset_id": {
-          "type": "long"
-        },
-        "field_name": {
-          "type": "string"
-        },
-        "parent_path": {
-          "type": "string"
-        },
-        "sort_id": {
-          "type": "long"
-        }
-      }
-    },
     "comment": {
       "_parent": {
         "type": "dataset"
@@ -143,6 +121,9 @@
         "name": {
           "type": "string"
         },
+        "name_suggest": {
+          "type": "completion"
+        },
         "parent_name": {
           "type": "string"
         },
@@ -166,6 +147,31 @@
         }
       }
     },
+    "field": {
+      "_parent": {
+        "type": "dataset"
+      },
+      "_routing": {
+        "required": true
+      },
+      "properties": {
+        "comments": {
+          "type": "string"
+        },
+        "dataset_id": {
+          "type": "long"
+        },
+        "field_name": {
+          "type": "string"
+        },
+        "parent_path": {
+          "type": "string"
+        },
+        "sort_id": {
+          "type": "long"
+        }
+      }
+    },
     "flow_jobs": {
       "properties": {
         "app_code": {
@@ -185,6 +191,9 @@
         },
         "flow_name": {
           "type": "string"
+        },
+        "flow_name_suggest": {
+          "type": "completion"
         },
         "flow_path": {
           "type": "string"
@@ -218,6 +227,9 @@
             },
             "job_name": {
               "type": "string"
+            },
+            "job_name_suggest": {
+              "type": "completion"
             },
             "job_path": {
               "type": "string"

--- a/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -220,6 +220,9 @@ class ElasticSearchIndex():
     while result:
         row = dict(zip(description, result))
 
+        name_suggest_info = {
+            'input' : [row['name']]
+        }
         dataset_detail = {
             'name': row['name'],
             'source': row['source'],
@@ -230,7 +233,8 @@ class ElasticSearchIndex():
             'properties': row['properties'],
             'schema': row['schema'],
             'fields': row['fields'],
-            'static_boosting_score': row['static_boosting_score']
+            'static_boosting_score': row['static_boosting_score'],
+            'name_suggest': name_suggest_info
         }
 
         params.append('{ "index": { "_id": ' + str(row['id']) + ' }}')
@@ -260,6 +264,9 @@ class ElasticSearchIndex():
       result = self.wh_cursor.fetchone()
       while result:
           row = dict(zip(description, result))
+          metric_name_suggest_info = {
+              'input' : [row['metric_name']]
+          }
           metric_detail = {
                 'metric_id': row['metric_id'],
                 'metric_name': row['metric_name'],
@@ -287,7 +294,8 @@ class ElasticSearchIndex():
                 'urn': row['urn'],
                 'metric_url': row['metric_url'],
                 'wiki_url': row['wiki_url'],
-                'scm_url': row['scm_url']
+                'scm_url': row['scm_url'],
+                'metric_name_suggest': metric_name_suggest_info
           }
           params.append('{ "index": { "_id": ' + str(row['metric_id']) + '  }}')
           params.append(json.dumps(metric_detail))
@@ -332,6 +340,12 @@ class ElasticSearchIndex():
           job_result = job_cursor.fetchone()
           while job_result:
               job_row = dict(zip(job_description, job_result))
+              flow_name_suggest_info = {
+                  'input' : [row['flow_name']]
+              }
+              job_name_suggest_info = {
+                  'input' : [job_row['job_name']]
+              }
               jobs_row_detail = {
                   'app_id': job_row['app_id'],
                   'flow_id': job_row['flow_id'],
@@ -344,7 +358,8 @@ class ElasticSearchIndex():
                   'post_jobs': job_row['post_jobs'],
                   'is_current': job_row['is_current'],
                   'is_first': job_row['is_first'],
-                  'is_last': job_row['is_last']
+                  'is_last': job_row['is_last'],
+                  'job_name_suggest': job_name_suggest_info
                }
               jobs_info.append(jobs_row_detail)
               job_result = job_cursor.fetchone()
@@ -361,7 +376,8 @@ class ElasticSearchIndex():
               'is_active': row['is_active'],
               'is_scheduled': row['is_scheduled'],
               'pre_flows': row['pre_flows'],
-              'jobs': jobs_info
+              'jobs': jobs_info,
+              'flow_name_suggest': flow_name_suggest_info
           }
           params.append(json.dumps(jobs_detail))
 


### PR DESCRIPTION
In this check in, 
1, Updated ES custom analyzers with whitespace tokenizer and word delimiter filter
For the fields of dataset name, metric name, flow name and job name
2, Adopted Elastic search completion suggester which is optimized for speed. This also eliminates the access to mySQL in DAO for auto complete. In addition, this also lays the foundation for future scoring of type aheads. For all datasets/metrics/flows