### PR TITLE
Allow the logback directory for ETL jobs to be overridden using system property

### DIFF
--- a/backend-service/app/actors/ConfigUtil.java
+++ b/backend-service/app/actors/ConfigUtil.java
@@ -86,6 +86,7 @@ class ConfigUtil {
         .add("-Dconfig=" + configFile)
         .add("-DCONTEXT=" + etlJobName.name())
         .add("-Dlogback.configurationFile=etl_logback.xml")
+        .add("-DLOG_DIR=" + directoryPath)
         .add("metadata.etl.Launcher")
         .build();
   }

--- a/backend-service/app/actors/EtlJobActor.java
+++ b/backend-service/app/actors/EtlJobActor.java
@@ -21,6 +21,7 @@ import models.daos.EtlJobDao;
 import models.daos.EtlJobPropertyDao;
 import msgs.EtlJobMessage;
 import play.Logger;
+import play.Play;
 import shared.Global;
 
 import java.io.BufferedReader;
@@ -28,6 +29,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.Properties;
+import wherehows.common.Constant;
+
 
 /**
  * Created by zechen on 9/4/15.
@@ -35,6 +38,8 @@ import java.util.Properties;
 public class EtlJobActor extends UntypedActor {
 
   private Process process;
+
+  private static final String ETL_TEMP_DIR = Play.application().configuration().getString("etl.temp_dir");
 
   @Override
   public void onReceive(Object message)
@@ -46,6 +51,8 @@ public class EtlJobActor extends UntypedActor {
         props = EtlJobPropertyDao.getJobProperties(msg.getEtlJobName(), msg.getRefId());
         Properties whProps = EtlJobPropertyDao.getWherehowsProperties();
         props.putAll(whProps);
+        props.setProperty(Constant.WH_APP_FOLDER_KEY, ETL_TEMP_DIR);
+
         EtlJobDao.startRun(msg.getWhEtlExecId(), "Job started!");
 
         // start a new process here

--- a/backend-service/application.env.template
+++ b/backend-service/application.env.template
@@ -16,3 +16,6 @@ WHZ_DB_URL=
 # A comma-separated list of JOB IDs to run
 WHZ_ETL_JOB_IDS=
 WHZ_KAFKA_JOB_IDS=
+
+# Temp directory for ETL job
+WHZ_ETL_TEMP_DIR=

--- a/backend-service/conf/application.conf
+++ b/backend-service/conf/application.conf
@@ -59,3 +59,5 @@ scheduler.jobid.whitelist = ${WHZ_ETL_JOB_IDS}
 scheduler.check.interval = 10
 # start the following list of kafka consumer etl jobs
 # kafka.consumer.etl.jobid = ${WHZ_KAFKA_JOB_IDS}
+
+etl.temp_dir = ${WHZ_ETL_TEMP_DIR}

--- a/backend-service/conf/etl_logback.xml
+++ b/backend-service/conf/etl_logback.xml
@@ -15,6 +15,8 @@
 
 -->
 <configuration packagingData="false">
+    <variable name="LOG_DIR" value="${LOG_DIR:-/var/tmp/wherehows}"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <Target>System.out</Target>
         <encoder>
@@ -23,13 +25,13 @@
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!--See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
-        <File>/var/tmp/wherehows/${CONTEXT:-default}.log</File>
+        <File>${LOG_DIR}/${CONTEXT:-default}.log</File>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <maxIndex>10</maxIndex>
-            <FileNamePattern>/var/tmp/wherehows/${CONTEXT:-default}.log.%i</FileNamePattern>
+            <FileNamePattern>${LOG_DIR}/${CONTEXT:-default}.log.%i</FileNamePattern>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <MaxFileSize>5MB</MaxFileSize>

--- a/backend-service/test/actors/ConfigUtilTest.java
+++ b/backend-service/test/actors/ConfigUtilTest.java
@@ -54,7 +54,8 @@ public class ConfigUtilTest {
     // then:
     assertThat(command).contains("java", "-a", "-b", "-cp", System.getProperty("java.class.path"),
         "-Dconfig=" + applicationDirectory + "/exec/1.properties", "-DCONTEXT=LDAP_USER_ETL",
-        "-Dlogback.configurationFile=etl_logback.xml", "metadata.etl.Launcher");
+        "-DLOG_DIR=" + applicationDirectory, "-Dlogback.configurationFile=etl_logback.xml",
+        "metadata.etl.Launcher");
   }
 
   @Test


### PR DESCRIPTION
See https://logback.qos.ch/manual/configuration.html#variableSubstitution for more details.