### PR TITLE
retrieve source modification time for hive and dalids

### DIFF
--- a/metadata-etl/src/main/resources/jython/HiveTransform.py
+++ b/metadata-etl/src/main/resources/jython/HiveTransform.py
@@ -199,12 +199,12 @@ class HiveTransform:
         instance_file_writer.append(dataset_instance_record)
 
         if dataset_urn not in self.dataset_dict:
-          dataset_scehma_record = DatasetSchemaRecord(table['dataset_name'], json.dumps(schema_json), json.dumps(prop_json),
-                                                    json.dumps(flds),
-                                                    dataset_urn,
-                                                    'Hive', one_db_info['type'], table['type'],
-                                                    '', (table[TableInfo.create_time] if table.has_key(
-            TableInfo.create_time) else None), (table["lastAlterTime"]) if table.has_key("lastAlterTime") else None)
+          dataset_scehma_record = DatasetSchemaRecord(table['dataset_name'], json.dumps(schema_json),
+                                                      json.dumps(prop_json),
+                                                      json.dumps(flds), dataset_urn, 'Hive', one_db_info['type'],
+                                                      table['type'], '',
+                                                      table.get(TableInfo.create_time),
+                                                      (int(table.get(TableInfo.source_modified_time,"0"))))
           schema_file_writer.append(dataset_scehma_record)
 
           dataset_idx += 1
@@ -224,9 +224,6 @@ class HiveTransform:
     instance_file_writer.close()
     schema_file_writer.close()
     field_file_writer.close()
-
-  def convert_timestamp(self, time_string):
-    return int(time.mktime(time.strptime(time_string, "%Y-%m-%d %H:%M:%S")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Retrieve source modification time for hive and dalids and clean up some code in Hive job.
The test was run against Db34, on Holdem. To check results, you can log in and see the field updated for datasets. Next step is to integrate with UI to display this info and filter/sort by this info.