### PR TITLE
Adding docker support to WhereHows.

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,3 @@
+archives/
+runtime/
+.env

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+The docker directory contains all docker related source code.
+
+Here is how to use it:
+1. First ensure that docker and docker-compose are installed.  The docker compose script uses version 3, so be sure that
+the version you install supports that.
+2. From the WhereHows root, run prepare-docker-archives.sh
+3. Edit docker/.env if necessary.
+4. From the docker directory: $ docker-compose up
+5. In your local browser, open localhost:9000
+6. Also, the backend app is hosted on localhost:9001
+
+If any step fails in the script, you can run individual steps in it, the script is pretty intuitive and has comments.
+
+Hope that helps.

--- a/docker/archive-factory/.gitignore
+++ b/docker/archive-factory/.gitignore
@@ -1,0 +1,2 @@
+originals/*.zip
+tmp/

--- a/docker/archive-factory/build-backend.sh
+++ b/docker/archive-factory/build-backend.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ -d "tmp" ]; then
+  rm -rf tmp
+fi
+
+mkdir tmp
+cp originals/backend.zip tmp
+cd tmp
+unzip backend.zip
+mv backend-ser* backend-service
+
+# Some people may want to remove the documentation of the API.
+# rm -rf backend-service/share
+rm backend-service/README.md
+
+# leave the option to change the secret later.
+sed -i 's/changeme/$PLAY_CRYPTO_SECRET/g' backend-service/conf/application.conf
+
+tar zcvf backend-service.tar.gz backend-service
+
+cp *.tar.gz ../../backend-service/archives

--- a/docker/archive-factory/build-web.sh
+++ b/docker/archive-factory/build-web.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -d "tmp" ]; then
+  rm -rf tmp
+fi
+
+mkdir tmp
+cp originals/web.zip tmp
+cd tmp
+unzip web.zip
+mv wherehows-* wherehows
+
+# some may wish to remove the docs
+# rm -rf wherehows/share
+
+rm README.md
+
+# correct a few things that won't work in docker.
+
+# leave the option to change the play crypto secret later.
+sed -i 's/changeme/$PLAY_CRYPTO_SECRET/g' wherehows/conf/application.conf
+
+# localhost usually does not work within docker, give people the power
+# to change that from outside of docker with environment variables.
+sed -i 's/localhost:8888/$HDFS_HOST:8888/g' wherehows/conf/application.conf
+sed -i 's/localhost/$MYSQL_HOST/g' wherehows/conf/application.conf
+
+tar zcvf web.tar.gz wherehows
+
+cp web.tar.gz ../../web/archives

--- a/docker/backend-service/Dockerfile
+++ b/docker/backend-service/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.10
+
+RUN mkdir /application;
+
+WORKDIR /application
+
+ADD archives/jdk-8u101-linux-x64.tar.gz /application
+ADD archives/backend-service.tar.gz /application
+
+RUN ln -s jdk1.8.0_101 jdk8;
+
+WORKDIR /application/backend-service
+
+ENV JAVA_HOME=/application/jdk8; \
+    PATH=/application/jdk8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+CMD bin/backend-service

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3"
+services:
+  mysql:
+    image: "wherehows/mysql:1"
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: wherehows
+  backend:
+    image: "wherehows/backend:1"
+    ports:
+      - "9001:9000"
+    environment:
+      WHZ_DB_USERNAME: wherehows
+      WHZ_DB_PASSWORD: wherehows
+      WHZ_DB_URL: jdbc:mysql://mysql:3306/wherehows
+      PLAY_CRYPTO_SECRET: changeme
+    links:
+      - "mysql:mysql"
+  web:
+    image: "wherehows/web:1"
+    ports:
+      - "9000:9000"
+    environment:
+      WHZ_DB_USERNAME: wherehows
+      WHZ_DB_PASSWORD: wherehows
+      WHZ_DB_URL: jdbc:mysql://mysql:3306/wherehows
+      MYSQL_HOST: mysql
+      HDFS_HOST: "127.0.0.1"
+    links:
+      - "mysql:mysql"

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,16 @@
+FROM mysql:5.7.17
+
+RUN mkdir /usr/local/wherehows; echo "alias ll=ls -al" > /etc/profile;
+
+COPY binary/*.sh /usr/local/bin/
+COPY ETL_DDL /usr/local/wherehows/ETL_DDL
+COPY WEB_DDL /usr/local/wherehows/WEB_DDL
+COPY binary/*.sql /usr/local/wherehows/
+
+HEALTHCHECK --interval=5s --timeout=3s CMD mysqladmin -pwherehows ping
+
+VOLUME /var/lib/mysql
+VOLUME /var/log/mysql
+
+# note that the default command is still 'mysqld'
+ENTRYPOINT /usr/local/bin/run-for-wherehows.sh

--- a/docker/mysql/ETL_DDL/dataset_info_metadata.sql
+++ b/docker/mysql/ETL_DDL/dataset_info_metadata.sql
@@ -1,0 +1,214 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+
+CREATE TABLE IF NOT EXISTS dataset_deployment (
+  `dataset_id`      INT UNSIGNED NOT NULL,
+  `dataset_urn`     VARCHAR(200) NOT NULL,
+  `deployment_tier` VARCHAR(20)  NOT NULL,
+  `datacenter`      VARCHAR(20)        NOT NULL,
+  `region`          VARCHAR(50)        DEFAULT NULL,
+  `zone`            VARCHAR(50)        DEFAULT NULL,
+  `cluster`         VARCHAR(100)       DEFAULT NULL,
+  `container`       VARCHAR(100)       DEFAULT NULL,
+  `enabled`         BOOLEAN      NOT NULL,
+  `additional_info` TEXT CHAR SET utf8 DEFAULT NULL,
+  `modified_time`   INT UNSIGNED       DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `deployment_tier`, `datacenter`),
+  UNIQUE KEY (`dataset_urn`, `deployment_tier`, `datacenter`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_capacity (
+  `dataset_id`    INT UNSIGNED NOT NULL,
+  `dataset_urn`   VARCHAR(200) NOT NULL,
+  `capacity_name` VARCHAR(100) NOT NULL,
+  `capacity_type` VARCHAR(50)  DEFAULT NULL,
+  `capacity_unit` VARCHAR(20)  DEFAULT NULL,
+  `capacity_low`  DOUBLE       DEFAULT NULL,
+  `capacity_high` DOUBLE       DEFAULT NULL,
+  `modified_time` INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `capacity_name`),
+  UNIQUE KEY (`dataset_urn`, `capacity_name`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_tag (
+  `dataset_id`    INT UNSIGNED NOT NULL,
+  `dataset_urn`   VARCHAR(200) NOT NULL,
+  `tag`           VARCHAR(100) NOT NULL,
+  `modified_time` INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `tag`),
+  UNIQUE KEY (`dataset_urn`, `tag`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_case_sensitivity (
+  `dataset_id`    INT UNSIGNED NOT NULL,
+  `dataset_urn`   VARCHAR(200) NOT NULL,
+  `dataset_name`  BOOLEAN      NOT NULL,
+  `field_name`    BOOLEAN      NOT NULL,
+  `data_content`  BOOLEAN      NOT NULL,
+  `modified_time` INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`),
+  UNIQUE KEY (`dataset_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_reference (
+  `dataset_id`       INT UNSIGNED NOT NULL,
+  `dataset_urn`      VARCHAR(200) NOT NULL,
+  `reference_type`   VARCHAR(20)  NOT NULL,
+  `reference_format` VARCHAR(50)  NOT NULL,
+  `reference_list`   TEXT CHAR SET utf8 DEFAULT NULL,
+  `modified_time`    INT UNSIGNED       DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `reference_type`, `reference_format`),
+  UNIQUE KEY (`dataset_urn`, `reference_type`, `reference_format`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_partition (
+  `dataset_id`                INT UNSIGNED NOT NULL,
+  `dataset_urn`               VARCHAR(200) NOT NULL,
+  `total_partition_level`     SMALLINT UNSIGNED  DEFAULT NULL,
+  `partition_spec_text`       TEXT CHAR SET utf8 DEFAULT NULL,
+  `has_time_partition`        BOOLEAN            DEFAULT NULL,
+  `has_hash_partition`        BOOLEAN            DEFAULT NULL,
+  `partition_keys`            TEXT CHAR SET utf8 DEFAULT NULL,
+  `time_partition_expression` VARCHAR(100)       DEFAULT NULL,
+  `modified_time`             INT UNSIGNED       DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`),
+  UNIQUE KEY (`dataset_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS `dataset_privacy_compliance` (
+  `dataset_id`                INT(10) UNSIGNED NOT NULL,
+  `dataset_urn`               VARCHAR(200)     NOT NULL,
+  `compliance_purge_type`     VARCHAR(30)      DEFAULT NULL
+  COMMENT 'AUTO_PURGE,CUSTOM_PURGE,LIMITED_RETENTION,PURGE_NOT_APPLICABLE',
+  `compliance_purge_entities` VARCHAR(2000)    DEFAULT NULL,
+  `modified_time`             INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`),
+  UNIQUE KEY `dataset_urn` (`dataset_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS `dataset_security` (
+  `dataset_id`                INT(10) UNSIGNED NOT NULL,
+  `dataset_urn`               VARCHAR(200)     NOT NULL,
+  `classification`            VARCHAR(500)     DEFAULT NULL
+  COMMENT 'JSON: confidential fields',
+  `record_owner_type`         VARCHAR(50)      DEFAULT NULL
+  COMMENT 'MEMBER,CUSTOMER,INTERNAL,COMPANY,GROUP',
+  `retention_policy`          VARCHAR(200)     DEFAULT NULL
+  COMMENT 'JSON: specification of retention',
+  `geographic_affinity`       VARCHAR(200)     DEFAULT NULL
+  COMMENT 'JSON: must be stored in the geo region',
+  `modified_time`             INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`),
+  UNIQUE KEY `dataset_urn` (`dataset_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS dataset_constraint (
+  `dataset_id`            INT UNSIGNED NOT NULL,
+  `dataset_urn`           VARCHAR(200) NOT NULL,
+  `constraint_type`       VARCHAR(20)  NOT NULL,
+  `constraint_sub_type`   VARCHAR(20)  NOT NULL,
+  `constraint_name`       VARCHAR(50)        DEFAULT NULL,
+  `constraint_expression` VARCHAR(200) NOT NULL,
+  `enabled`               BOOLEAN      NOT NULL,
+  `referred_fields`       TEXT               DEFAULT NULL,
+  `additional_reference`  TEXT CHAR SET utf8 DEFAULT NULL,
+  `modified_time`         INT UNSIGNED       DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `constraint_type`, `constraint_sub_type`, `constraint_expression`),
+  UNIQUE KEY (`dataset_urn`, `constraint_type`, `constraint_sub_type`, `constraint_expression`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_index (
+  `dataset_id`     INT UNSIGNED NOT NULL,
+  `dataset_urn`    VARCHAR(200) NOT NULL,
+  `index_type`     VARCHAR(20)  NOT NULL,
+  `index_name`     VARCHAR(50)  NOT NULL,
+  `is_unique`      BOOLEAN      NOT NULL,
+  `indexed_fields` TEXT         DEFAULT NULL,
+  `modified_time`  INT UNSIGNED DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`, `index_name`),
+  UNIQUE KEY (`dataset_urn`, `index_name`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_schema_info (
+  `dataset_id`                   INT UNSIGNED NOT NULL,
+  `dataset_urn`                  VARCHAR(200) NOT NULL,
+  `is_backward_compatible`       BOOLEAN                  DEFAULT NULL,
+  `create_time`                  BIGINT       NOT NULL,
+  `revision`                     INT UNSIGNED             DEFAULT NULL,
+  `version`                      VARCHAR(20)              DEFAULT NULL,
+  `name`                         VARCHAR(100)             DEFAULT NULL,
+  `description`                  TEXT CHAR SET utf8       DEFAULT NULL,
+  `original_schema`              MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  `key_schema`                   MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  `is_field_name_case_sensitive` BOOLEAN                  DEFAULT NULL,
+  `field_schema`                 MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  `change_data_capture_fields`   TEXT                     DEFAULT NULL,
+  `audit_fields`                 TEXT                     DEFAULT NULL,
+  `modified_time`                INT UNSIGNED             DEFAULT NULL
+  COMMENT 'the modified time in epoch',
+  PRIMARY KEY (`dataset_id`),
+  UNIQUE KEY (`dataset_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS dataset_inventory (
+  `event_date`                    DATE         NOT NULL,
+  `data_platform`                 VARCHAR(50)  NOT NULL,
+  `native_name`                   VARCHAR(200) NOT NULL,
+  `data_origin`                   VARCHAR(20)  NOT NULL,
+  `change_actor_urn`              VARCHAR(200)       DEFAULT NULL,
+  `change_type`                   VARCHAR(20)        DEFAULT NULL,
+  `change_time`                   BIGINT UNSIGNED    DEFAULT NULL,
+  `change_note`                   TEXT CHAR SET utf8 DEFAULT NULL,
+  `native_type`                   VARCHAR(20)        DEFAULT NULL,
+  `uri`                           VARCHAR(200)       DEFAULT NULL,
+  `dataset_name_case_sensitivity` BOOLEAN            DEFAULT NULL,
+  `field_name_case_sensitivity`   BOOLEAN            DEFAULT NULL,
+  `data_content_case_sensitivity` BOOLEAN            DEFAULT NULL,
+  PRIMARY KEY (`data_platform`, `native_name`, `data_origin`, `event_date`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;

--- a/docker/mysql/ETL_DDL/dataset_metadata.sql
+++ b/docker/mysql/ETL_DDL/dataset_metadata.sql
@@ -1,0 +1,355 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- create statement for dataset related tables :
+-- dict_dataset, dict_dataset_sample, dict_field_detail, dict_dataset_schema_history
+
+-- stagging table for dataset
+CREATE TABLE IF NOT EXISTS `stg_dict_dataset` (
+  `name`                        VARCHAR(200) NOT NULL,
+  `schema`                      MEDIUMTEXT CHARACTER SET utf8,
+  `schema_type`                 VARCHAR(50) DEFAULT 'JSON' COMMENT 'JSON, Hive, DDL, XML, CSV',
+  `properties`                  TEXT CHARACTER SET utf8,
+  `fields`                      MEDIUMTEXT CHARACTER SET utf8,
+  `db_id`                       SMALLINT UNSIGNED,
+  `urn`                         VARCHAR(200) NOT NULL,
+  `source`                      VARCHAR(50) NULL,
+  `location_prefix`             VARCHAR(200) NULL,
+  `parent_name`                 VARCHAR(200) NULL COMMENT 'Schema Name for RDBMS, Group Name for Jobs/Projects/Tracking Datasets on HDFS',
+  `storage_type`                ENUM('Table', 'View', 'Avro', 'ORC', 'RC', 'Sequence', 'Flat File', 'JSON', 'XML', 'Thrift', 'Parquet', 'Protobuff') NULL,
+  `ref_dataset_name`            VARCHAR(200) NULL,
+  `ref_dataset_id`              INT(11) UNSIGNED NULL COMMENT 'Refer to Master/Main dataset for Views/ExternalTables',
+  `status_id`                   SMALLINT(6) UNSIGNED NULL COMMENT 'Reserve for dataset status',
+  `dataset_type`                VARCHAR(30) NULL
+  COMMENT 'hdfs, hive, kafka, teradata, mysql, sqlserver, file, nfs, pinot, salesforce, oracle, db2, netezza, cassandra, hbase, qfs, zfs',
+  `hive_serdes_class`           VARCHAR(300)                                                                                NULL,
+  `is_partitioned`              CHAR(1)                                                                                     NULL,
+  `partition_layout_pattern_id` SMALLINT(6)                                                                                 NULL,
+  `sample_partition_full_path`  VARCHAR(256) COMMENT 'sample partition full path of the dataset',
+  `source_created_time`         INT UNSIGNED                                                                                NULL
+  COMMENT 'source created time of the flow',
+  `source_modified_time`        INT UNSIGNED                                                                                NULL
+  COMMENT 'latest source modified time of the flow',
+  `created_time`                INT UNSIGNED COMMENT 'wherehows created time',
+  `modified_time`               INT UNSIGNED COMMENT 'latest wherehows modified',
+  `wh_etl_exec_id`              BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`urn`, `db_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1
+  PARTITION BY HASH(db_id)
+  PARTITIONS 8;
+
+-- dataset table
+CREATE TABLE IF NOT EXISTS `dict_dataset` (
+  `id`                          INT(11) UNSIGNED NOT NULL                                                                   AUTO_INCREMENT,
+  `name`                        VARCHAR(200) CHARACTER SET utf8                                                             NOT NULL,
+  `schema`                      MEDIUMTEXT CHARACTER SET utf8,
+  `schema_type`                 VARCHAR(50)                                                                                 DEFAULT 'JSON'
+  COMMENT 'JSON, Hive, DDL, XML, CSV',
+  `properties`                  TEXT CHARACTER SET utf8,
+  `fields`                      MEDIUMTEXT CHARACTER SET utf8,
+  `urn`                         VARCHAR(200) CHARACTER SET utf8                                                             NOT NULL,
+  `source`                      VARCHAR(50)                                                                                 NULL
+  COMMENT 'The original data source type (for dataset in data warehouse). Oracle, Kafka ...',
+  `location_prefix`             VARCHAR(200)                                                                                NULL,
+  `parent_name`                 VARCHAR(200)                                                                                NULL
+  COMMENT 'Schema Name for RDBMS, Group Name for Jobs/Projects/Tracking Datasets on HDFS ',
+  `storage_type`                ENUM('Table', 'View', 'Avro', 'ORC', 'RC', 'Sequence', 'Flat File', 'JSON', 'XML', 'Thrift', 'Parquet', 'Protobuff') NULL,
+  `ref_dataset_id`              INT(11) UNSIGNED                                                                            NULL
+  COMMENT 'Refer to Master/Main dataset for Views/ExternalTables',
+  `status_id`                   SMALLINT(6) UNSIGNED                                                                        NULL
+  COMMENT 'Reserve for dataset status',
+  `dataset_type`                VARCHAR(30)                                                                                 NULL
+  COMMENT 'hdfs, hive, kafka, teradata, mysql, sqlserver, file, nfs, pinot, salesforce, oracle, db2, netezza, cassandra, hbase, qfs, zfs',
+  `hive_serdes_class`           VARCHAR(300)                                                                                NULL,
+  `is_partitioned`              CHAR(1)                                                                                     NULL,
+  `partition_layout_pattern_id` SMALLINT(6)                                                                                 NULL,
+  `sample_partition_full_path`  VARCHAR(256)
+  COMMENT 'sample partition full path of the dataset',
+  `source_created_time`         INT UNSIGNED                                                                                NULL
+  COMMENT 'source created time of the flow',
+  `source_modified_time`        INT UNSIGNED                                                                                NULL
+  COMMENT 'latest source modified time of the flow',
+  `created_time`                INT UNSIGNED COMMENT 'wherehows created time',
+  `modified_time`               INT UNSIGNED COMMENT 'latest wherehows modified',
+  `wh_etl_exec_id`              BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_dataset_urn` (`urn`),
+  FULLTEXT KEY `fti_datasets_all` (`name`, `schema`, `properties`, `urn`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = latin1;
+
+-- stagging table for sample data
+CREATE TABLE IF NOT EXISTS `stg_dict_dataset_sample` (
+  `db_id`      SMALLINT  UNSIGNED,
+  `urn`        VARCHAR(200) NOT NULL DEFAULT '',
+  `dataset_id` INT(11)               NULL,
+  `ref_urn`    VARCHAR(200)          NULL,
+  `ref_id`     INT(11)               NULL,
+  `data`       MEDIUMTEXT,
+  PRIMARY KEY (`db_id`, `urn`),
+  KEY `ref_urn_key` (`ref_urn`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+-- sample data table
+CREATE TABLE IF NOT EXISTS `dict_dataset_sample` (
+  `id`         INT(11) NOT NULL AUTO_INCREMENT,
+  `dataset_id` INT(11)          NULL,
+  `urn`        VARCHAR(200)     NULL,
+  `ref_id`     INT(11)          NULL
+  COMMENT 'Reference dataset id of which dataset that we fetch sample from. e.g. for tables we do not have permission, fetch sample data from DWH_STG correspond tables',
+  `data`       MEDIUMTEXT,
+  `modified`   DATETIME         NULL,
+  `created`    DATETIME         NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ak_dict_dataset_sample__datasetid` (`dataset_id`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = utf8;
+
+-- stagging table for field detail
+CREATE TABLE IF NOT EXISTS `stg_dict_field_detail` (
+  `db_id`          SMALLINT  UNSIGNED,
+  `urn`            VARCHAR(200)         NOT NULL,
+  `sort_id`        SMALLINT(5) UNSIGNED NOT NULL,
+  `parent_sort_id` SMALLINT(5) UNSIGNED NOT NULL,
+  `parent_path`    VARCHAR(200)                  NULL,
+  `field_name`     VARCHAR(100)         NOT NULL,
+  `field_label`    VARCHAR(100)                  NULL,
+  `data_type`      VARCHAR(50)          NOT NULL,
+  `data_size`      INT(10) UNSIGNED              NULL,
+  `data_precision` TINYINT(3) UNSIGNED           NULL,
+  `data_scale`     TINYINT(3) UNSIGNED           NULL,
+  `is_nullable`    CHAR(1)                       NULL,
+  `is_indexed`     CHAR(1)                       NULL,
+  `is_partitioned` CHAR(1)                       NULL,
+  `is_distributed` CHAR(1)                       NULL,
+  `default_value`  VARCHAR(200)                  NULL,
+  `namespace`      VARCHAR(200)                  NULL,
+  `description`    VARCHAR(1000)                 NULL,
+  `last_modified`  TIMESTAMP            NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `dataset_id`     INT UNSIGNED         NULL COMMENT 'used to opitimize metadata ETL performance',
+  KEY `idx_stg_dict_field_detail__description` (`description`(100)),
+  PRIMARY KEY (`urn`, `sort_id`, `db_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1
+  PARTITION BY HASH(db_id)
+  PARTITIONS 8;
+
+-- field detail table
+CREATE TABLE IF NOT EXISTS `dict_field_detail` (
+  `field_id`           INT(11) UNSIGNED     NOT NULL AUTO_INCREMENT,
+  `dataset_id`         INT(11) UNSIGNED     NOT NULL,
+  `fields_layout_id`   INT(11) UNSIGNED     NOT NULL,
+  `sort_id`            SMALLINT(6) UNSIGNED NOT NULL,
+  `parent_sort_id`     SMALLINT(5) UNSIGNED NOT NULL,
+  `parent_path`        VARCHAR(200)                  NULL,
+  `field_name`         VARCHAR(100)         NOT NULL,
+  `field_label`        VARCHAR(100)                  NULL,
+  `data_type`          VARCHAR(50)          NOT NULL,
+  `data_size`          INT(10) UNSIGNED              NULL,
+  `data_precision`     TINYINT(4)                    NULL
+  COMMENT 'only in decimal type',
+  `data_fraction`      TINYINT(4)                    NULL
+  COMMENT 'only in decimal type',
+  `default_comment_id` INT(11) UNSIGNED              NULL
+  COMMENT 'a list of comment_id',
+  `comment_ids`        VARCHAR(500)                  NULL,
+  `is_nullable`        CHAR(1)                       NULL,
+  `is_indexed`         CHAR(1)                       NULL
+  COMMENT 'only in RDBMS',
+  `is_partitioned`     CHAR(1)                       NULL
+  COMMENT 'only in RDBMS',
+  `is_distributed`     TINYINT(4)                    NULL
+  COMMENT 'only in RDBMS',
+  `is_recursive`       CHAR(1)                       NULL,
+  `confidential_flags` VARCHAR(200)                  NULL,
+  `default_value`      VARCHAR(200)                  NULL,
+  `namespace`          VARCHAR(200)                  NULL,
+  `java_data_type`     VARCHAR(50)                   NULL
+  COMMENT 'correspond type in java',
+  `jdbc_data_type`     VARCHAR(50)                   NULL
+  COMMENT 'correspond type in jdbc',
+  `pig_data_type`      VARCHAR(50)                   NULL
+  COMMENT 'correspond type in pig',
+  `hcatalog_data_type` VARCHAR(50)                   NULL
+  COMMENT 'correspond type in hcatalog',
+  `modified`           TIMESTAMP            NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`field_id`),
+  UNIQUE KEY `uix_dict_field__datasetid_parentpath_fieldname` (`dataset_id`, `parent_path`, `field_name`) USING BTREE,
+  UNIQUE KEY `uix_dict_field__datasetid_sortid` (`dataset_id`, `sort_id`) USING BTREE
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = latin1
+  COMMENT = 'Flattened Fields/Columns';
+
+-- schema history
+CREATE TABLE IF NOT EXISTS `dict_dataset_schema_history` (
+  `id`            INT(11) AUTO_INCREMENT NOT NULL,
+  `dataset_id`    INT(11)                NULL,
+  `urn`           VARCHAR(200)           NOT NULL,
+  `modified_date` DATE                   NULL,
+  `schema`        MEDIUMTEXT CHARACTER SET utf8 NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY `uk_dict_dataset_schema_history__urn_modified` (`urn`, `modified_date`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0;
+
+-- staging table table of fields to comments mapping
+CREATE TABLE IF NOT EXISTS `stg_dict_dataset_field_comment` (
+  `field_id` int(11) UNSIGNED NOT NULL,
+  `comment_id` bigint(20) NOT NULL,
+  `dataset_id` int(11) UNSIGNED NOT NULL,
+  `db_id` smallint(6) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`field_id`,`comment_id`, `db_id`)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8
+  PARTITION BY HASH(db_id)
+  PARTITIONS 8
+;
+
+-- fields to comments mapping
+CREATE TABLE IF NOT EXISTS `dict_dataset_field_comment` (
+  `field_id`   INT(11) UNSIGNED NOT NULL,
+  `comment_id` BIGINT(20) NOT NULL,
+  `dataset_id` INT(11) UNSIGNED NOT NULL,
+  `is_default` TINYINT(1) NULL DEFAULT '0',
+  PRIMARY KEY (field_id, comment_id),
+  KEY (comment_id)
+)
+  ENGINE = InnoDB;
+
+-- dataset comments
+CREATE TABLE IF NOT EXISTS comments (
+  `id`           INT(11) AUTO_INCREMENT                                                                       NOT NULL,
+  `text`         TEXT CHARACTER SET utf8                                                                      NOT NULL,
+  `user_id`      INT(11)                                                                                      NOT NULL,
+  `dataset_id`   INT(11)                                                                                      NOT NULL,
+  `created`      DATETIME                                                                                     NULL,
+  `modified`     DATETIME                                                                                     NULL,
+  `comment_type` ENUM('Description', 'Grain', 'Partition', 'ETL Schedule', 'DQ Issue', 'Question', 'Comment') NULL,
+  PRIMARY KEY (id),
+  KEY `user_id` (`user_id`) USING BTREE,
+  KEY `dataset_id` (`dataset_id`) USING BTREE,
+  FULLTEXT KEY `fti_comment` (`text`)
+)
+  ENGINE = InnoDB
+  CHARACTER SET latin1
+  COLLATE latin1_swedish_ci
+  AUTO_INCREMENT = 0;
+
+-- field comments
+CREATE TABLE IF NOT EXISTS `field_comments` (
+  `id`                     INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`                INT(11)          NOT NULL DEFAULT '0',
+  `comment`                VARCHAR(4000)    NOT NULL,
+  `created`                TIMESTAMP        NOT NULL,
+  `modified`               TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `comment_crc32_checksum` INT(11) UNSIGNED          NULL COMMENT '4-byte CRC32',
+  PRIMARY KEY (`id`),
+  KEY `comment_key` (`comment`(100)),
+  FULLTEXT KEY `fti_comment` (`comment`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = utf8;
+
+-- dict_dataset_instance
+CREATE TABLE IF NOT EXISTS dict_dataset_instance  (
+	dataset_id           	int(11) UNSIGNED NOT NULL,
+	db_id                	smallint(6) UNSIGNED COMMENT 'FK to cfg_database'  NOT NULL DEFAULT '0',
+	deployment_tier      	enum('local','grid','dev','int','ei','ei2','ei3','qa','stg','prod') NOT NULL DEFAULT 'dev',
+	data_center          	varchar(30) COMMENT 'data center code: lva1, ltx1, dc2, dc3...'  NULL DEFAULT '*',
+	server_cluster       	varchar(150) COMMENT 'sfo1-bigserver, jfk3-sqlserver03'  NULL DEFAULT '*',
+	slice                	varchar(50) COMMENT 'virtual group/tenant id/instance tag'  NOT NULL DEFAULT '*',
+	status_id            	smallint(6) UNSIGNED COMMENT 'Reserve for dataset status'  NULL,
+	native_name          	varchar(250) NOT NULL,
+	logical_name         	varchar(250) NOT NULL,
+	version              	varchar(30) COMMENT '1.2.3 or 0.3.131'  NULL,
+	version_sort_id      	bigint(20) COMMENT '4-digit for each version number: 000100020003, 000000030131'  NOT NULL DEFAULT '0',
+	schema_text           MEDIUMTEXT CHARACTER SET utf8 NULL,
+	ddl_text              MEDIUMTEXT CHARACTER SET utf8 NULL,
+	instance_created_time	int(10) UNSIGNED COMMENT 'source instance created time'  NULL,
+	created_time         	int(10) UNSIGNED COMMENT 'wherehows created time'  NULL,
+	modified_time        	int(10) UNSIGNED COMMENT 'latest wherehows modified'  NULL,
+	wh_etl_exec_id       	bigint(20) COMMENT 'wherehows etl execution id that modified this record'  NULL,
+	PRIMARY KEY(dataset_id,db_id,version_sort_id)
+)
+ENGINE = InnoDB
+CHARACTER SET latin1
+COLLATE latin1_swedish_ci
+AUTO_INCREMENT = 0
+	PARTITION BY HASH(db_id)
+	(PARTITION p0,
+	PARTITION p1,
+	PARTITION p2,
+	PARTITION p3,
+	PARTITION p4,
+	PARTITION p5,
+	PARTITION p6,
+	PARTITION p7);
+
+CREATE INDEX logical_name USING BTREE
+	ON dict_dataset_instance(logical_name);
+CREATE INDEX server_cluster USING BTREE
+	ON dict_dataset_instance(server_cluster, deployment_tier, data_center, slice);
+CREATE INDEX native_name USING BTREE
+	ON dict_dataset_instance(native_name);
+
+
+CREATE TABLE IF NOT EXISTS stg_dict_dataset_instance  (
+	dataset_urn          	varchar(200) NOT NULL,
+	db_id                	smallint(6) UNSIGNED NOT NULL DEFAULT '0',
+	deployment_tier      	enum('local','grid','dev','int','ei','ei2','ei3','qa','stg','prod') NOT NULL DEFAULT 'dev',
+	data_center          	varchar(30) COMMENT 'data center code: lva1, ltx1, dc2, dc3...'  NULL DEFAULT '*',
+	server_cluster       	varchar(150) COMMENT 'sfo1-bigserver'  NULL DEFAULT '*',
+	slice                	varchar(50) COMMENT 'virtual group/tenant id/instance tag'  NOT NULL DEFAULT '*',
+	status_id            	smallint(6) UNSIGNED COMMENT 'Reserve for dataset status'  NULL,
+	native_name          	varchar(250) NOT NULL,
+	logical_name         	varchar(250) NOT NULL,
+	version              	varchar(30) COMMENT '1.2.3 or 0.3.131'  NULL,
+	schema_text           MEDIUMTEXT CHARACTER SET utf8 NULL,
+	ddl_text              MEDIUMTEXT CHARACTER SET utf8 NULL,
+	instance_created_time	int(10) UNSIGNED COMMENT 'source instance created time'  NULL,
+	created_time         	int(10) UNSIGNED COMMENT 'wherehows created time'  NULL,
+	wh_etl_exec_id       	bigint(20) COMMENT 'wherehows etl execution id that modified this record'  NULL,
+	dataset_id           	int(11) UNSIGNED NULL,
+	abstract_dataset_urn 	varchar(200) NULL,
+	PRIMARY KEY(dataset_urn,db_id)
+)
+ENGINE = InnoDB
+CHARACTER SET latin1
+COLLATE latin1_swedish_ci
+AUTO_INCREMENT = 0
+	PARTITION BY HASH(db_id)
+	(PARTITION p0,
+	PARTITION p1,
+	PARTITION p2,
+	PARTITION p3,
+	PARTITION p4,
+	PARTITION p5,
+	PARTITION p6,
+	PARTITION p7);
+CREATE INDEX server_cluster USING BTREE
+	ON stg_dict_dataset_instance(server_cluster, deployment_tier, data_center, slice);
+

--- a/docker/mysql/ETL_DDL/etl_configure_tables.sql
+++ b/docker/mysql/ETL_DDL/etl_configure_tables.sql
@@ -1,0 +1,254 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- configuration tables
+CREATE TABLE IF NOT EXISTS `wh_etl_job` (
+  `wh_etl_job_id`   INT(10) UNSIGNED  NOT NULL AUTO_INCREMENT
+  COMMENT 'id of the etl job',
+  `wh_etl_job_name` VARCHAR(127)      NOT NULL
+  COMMENT 'etl job name',
+  `wh_etl_type`     VARCHAR(127)               DEFAULT NULL
+  COMMENT 'type of the etl service',
+  `cron_expr`       VARCHAR(127)               DEFAULT NULL
+  COMMENT 'frequency in crob expression',
+  `ref_id`          SMALLINT(6)       NOT NULL
+  COMMENT 'id of application/database where etl job runs',
+  `ref_id_type`     ENUM('APP', 'DB') NOT NULL
+  COMMENT 'flag the ref_id is an application or a database',
+  `timeout`         INT(11)                    DEFAULT NULL
+  COMMENT 'timeout in seconds for this etl job',
+  `next_run`        INT(10) UNSIGNED           DEFAULT NULL
+  COMMENT 'next run time',
+  `comments`        VARCHAR(200)               DEFAULT NULL,
+  `cmd_param`       VARCHAR(500)               DEFAULT ''
+  COMMENT 'command line parameters for launch the job',
+  `is_active`       CHAR(1)                    DEFAULT 'Y'
+  COMMENT 'determine if this job is active or not',
+  PRIMARY KEY (`wh_etl_job_id`),
+  UNIQUE KEY `etl_unique` (`wh_etl_job_name`, `ref_id`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = utf8
+  COMMENT = 'WhereHows ETL jobs table';
+
+CREATE TABLE IF NOT EXISTS `wh_etl_job_execution` (
+  `wh_etl_exec_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT
+  COMMENT 'job execution id',
+  `wh_etl_job_id`  INT(10) UNSIGNED             DEFAULT NULL
+  COMMENT 'id of the etl job',
+  `status`         VARCHAR(31)                  DEFAULT NULL
+  COMMENT 'status of etl job execution',
+  `request_time`   INT(10) UNSIGNED             DEFAULT NULL
+  COMMENT 'request time of the execution',
+  `start_time`     INT(10) UNSIGNED             DEFAULT NULL
+  COMMENT 'start time of the execution',
+  `end_time`       INT(10) UNSIGNED             DEFAULT NULL
+  COMMENT 'end time of the execution',
+  `message`        VARCHAR(1024)                DEFAULT NULL
+  COMMENT 'debug information message',
+  `host_name`      VARCHAR(200)                 DEFAULT NULL
+  COMMENT 'host machine name of the job execution',
+  `process_id`     INT UNSIGNED                 DEFAULT NULL
+  COMMENT 'job execution process id',
+  PRIMARY KEY (`wh_etl_exec_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'WhereHows ETL execution table';
+
+CREATE TABLE IF NOT EXISTS `wh_etl_job_property` (
+  `id`              INT(10)           NOT NULL AUTO_INCREMENT,
+  `wh_etl_job_name` VARCHAR(127)      NOT NULL
+  COMMENT 'etl job name',
+  `ref_id`          SMALLINT(6)       NOT NULL
+  COMMENT 'id of application/database where etl job runs',
+  `ref_id_type`     ENUM('APP', 'DB') NOT NULL
+  COMMENT 'flag the ref_id is an application or a database',
+  `property_name`   VARCHAR(127)      NOT NULL
+  COMMENT 'property name',
+  `property_value`  TEXT COMMENT 'property value',
+  `is_encrypted`    CHAR(1)                    DEFAULT 'N'
+  COMMENT 'whether the value is encrypted',
+  `comments`        VARCHAR(100)               DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `property_unique` (`wh_etl_job_name`, `ref_id`, `property_name`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Etl job configuration table';
+
+CREATE TABLE IF NOT EXISTS `wh_property` (
+  `property_name`  VARCHAR(127) NOT NULL
+  COMMENT 'property name',
+  `property_value` TEXT COMMENT 'property value',
+  `is_encrypted`   CHAR(1)      DEFAULT 'N'
+  COMMENT 'whether the value is encrypted',
+  `group_name`     VARCHAR(127) DEFAULT NULL
+  COMMENT 'group name for the property',
+  PRIMARY KEY (`property_name`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'WhereHows properties table';
+
+CREATE TABLE IF NOT EXISTS `cfg_application` (
+  `app_id`                  SMALLINT    UNSIGNED NOT NULL,
+  `app_code`                VARCHAR(128)         NOT NULL,
+  `description`             VARCHAR(512)         NOT NULL,
+  `tech_matrix_id`          SMALLINT(5) UNSIGNED DEFAULT '0',
+  `doc_url`                 VARCHAR(512)         DEFAULT NULL,
+  `parent_app_id`           INT(11) UNSIGNED     NOT NULL,
+  `app_status`              CHAR(1)              NOT NULL,
+  `last_modified`           TIMESTAMP            NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `is_logical`              CHAR(1)                       DEFAULT NULL,
+  `uri_type`                VARCHAR(25)                   DEFAULT NULL,
+  `uri`                     VARCHAR(1000)                 DEFAULT NULL,
+  `lifecycle_layer_id`      TINYINT(4) UNSIGNED           DEFAULT NULL,
+  `short_connection_string` VARCHAR(50)                   DEFAULT NULL,
+  PRIMARY KEY (`app_id`),
+  UNIQUE KEY `idx_cfg_application__appcode` (`app_code`) USING HASH
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS cfg_database  (
+	db_id                  	smallint(6) UNSIGNED NOT NULL,
+	db_code                	varchar(30) COMMENT 'Unique string without space'  NOT NULL,
+	primary_dataset_type    varchar(30) COMMENT 'What type of dataset this DB supports' NOT NULL DEFAULT '*',
+	description            	varchar(128) NOT NULL,
+	is_logical             	char(1) COMMENT 'Is a group, which contains multiple physical DB(s)'  NOT NULL DEFAULT 'N',
+	deployment_tier        	varchar(20) COMMENT 'Lifecycle/FabricGroup: local,dev,sit,ei,qa,canary,preprod,pr'  NULL DEFAULT 'prod',
+	data_center            	varchar(200) COMMENT 'Code name of its primary data center. Put * for all data cen'  NULL DEFAULT '*',
+	associated_dc_num      	tinyint(4) UNSIGNED COMMENT 'Number of associated data centers'  NOT NULL DEFAULT '1',
+	cluster                	varchar(200) COMMENT 'Name of Fleet, Group of Servers or a Server'  NULL DEFAULT '*',
+	cluster_size           	smallint(6) COMMENT 'Num of servers in the cluster'  NOT NULL DEFAULT '1',
+	extra_deployment_tag1  	varchar(50) COMMENT 'Additional tag. Such as container_group:HIGH'  NULL,
+	extra_deployment_tag2  	varchar(50) COMMENT 'Additional tag. Such as slice:i0001'  NULL,
+	extra_deployment_tag3  	varchar(50) COMMENT 'Additional tag. Such as region:eu-west-1'  NULL,
+	replication_role       	varchar(10) COMMENT 'master or slave or broker'  NULL,
+	jdbc_url               	varchar(1000) NULL,
+	uri                    	varchar(1000) NULL,
+	short_connection_string	varchar(50) COMMENT 'Oracle TNS Name, ODBC DSN, TDPID...' NULL,
+  last_modified          	timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY(db_id),
+  UNIQUE KEY `uix_cfg_database__dbcode` (db_code) USING HASH
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8
+COMMENT = 'Abstract different storage instances as databases' ;
+
+
+CREATE TABLE IF NOT EXISTS stg_cfg_object_name_map  (
+	object_type             	varchar(100) NOT NULL,
+	object_sub_type         	varchar(100) NULL,
+	object_name             	varchar(350) NOT NULL,
+	object_urn              	varchar(350) NULL,
+	object_dataset_id       	int(11) UNSIGNED NULL,
+	map_phrase              	varchar(100) NULL,
+	is_identical_map        	char(1) NULL DEFAULT 'N',
+	mapped_object_type      	varchar(100) NOT NULL,
+	mapped_object_sub_type  	varchar(100) NULL,
+	mapped_object_name      	varchar(350) NOT NULL,
+	mapped_object_urn       	varchar(350) NULL,
+	mapped_object_dataset_id	int(11) UNSIGNED NULL,
+	description             	varchar(500) NULL,
+	last_modified           	timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY(object_name, mapped_object_name),
+  KEY idx_stg_cfg_object_name_map__mappedobjectname (mapped_object_name) USING BTREE
+)
+ENGINE = InnoDB
+CHARACTER SET latin1
+COLLATE latin1_swedish_ci
+COMMENT = 'Map alias (when is_identical_map=Y) and view dependency' ;
+
+CREATE TABLE IF NOT EXISTS cfg_object_name_map  (
+  obj_name_map_id         int(11) AUTO_INCREMENT NOT NULL,
+  object_type             varchar(100) NOT NULL,
+  object_sub_type         varchar(100) NULL,
+  object_name             varchar(350) NOT NULL COMMENT 'this is the derived/child object',
+  map_phrase              varchar(100) NULL,
+  object_dataset_id       int(11) UNSIGNED NULL COMMENT 'can be the abstract dataset id for versioned objects',
+  is_identical_map        char(1) NOT NULL DEFAULT 'N' COMMENT 'Y/N',
+  mapped_object_type      varchar(100) NOT NULL,
+  mapped_object_sub_type  varchar(100) NULL,
+  mapped_object_name      varchar(350) NOT NULL COMMENT 'this is the original/parent object',
+  mapped_object_dataset_id	int(11) UNSIGNED NULL COMMENT 'can be the abstract dataset id for versioned objects',
+  description             varchar(500) NULL,
+  last_modified           timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(obj_name_map_id),
+  KEY idx_cfg_object_name_map__mappedobjectname (mapped_object_name) USING BTREE,
+  CONSTRAINT uix_cfg_object_name_map__objectname_mappedobjectname UNIQUE (object_name, mapped_object_name)
+)
+ENGINE = InnoDB
+CHARACTER SET latin1
+AUTO_INCREMENT = 1
+COMMENT = 'Map alias (when is_identical_map=Y) and view dependency. Always map from Derived/Child (object) back to its Original/Parent (mapped_object)' ;
+
+
+CREATE TABLE IF NOT EXISTS cfg_deployment_tier  (
+  tier_id      	tinyint(4) NOT NULL,
+  tier_code    	varchar(25) COMMENT 'local,dev,test,qa,stg,prod' NOT NULL,
+  tier_label    varchar(50) COMMENT 'display full name' NULL,
+  sort_id       smallint(6) COMMENT '3-digit for group, 3-digit within group' NOT NULL,
+  last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(tier_id),
+  UNIQUE KEY uix_cfg_deployment_tier__tiercode (tier_code)
+)
+ENGINE = InnoDB
+AUTO_INCREMENT = 0
+COMMENT = 'http://en.wikipedia.org/wiki/Deployment_environment';
+
+
+CREATE TABLE IF NOT EXISTS cfg_data_center  (
+	data_center_id    	smallint(6) NOT NULL DEFAULT '0',
+	data_center_code  	varchar(30) NOT NULL,
+	data_center_name  	varchar(50) NOT NULL,
+	time_zone         	varchar(50) NOT NULL,
+	city              	varchar(50) NOT NULL,
+	state             	varchar(25) NULL,
+	country           	varchar(50) NOT NULL,
+	longtitude        	decimal(10,6) NULL,
+	latitude          	decimal(10,6) NULL,
+	data_center_status	char(1) COMMENT 'A,D,U' NULL,
+	last_modified     	timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY(data_center_id),
+  UNIQUE KEY uix_cfg_data_center__datacentercode (data_center_code)
+)
+ENGINE = InnoDB
+AUTO_INCREMENT = 0
+COMMENT = 'https://en.wikipedia.org/wiki/Data_center' ;
+
+
+CREATE TABLE IF NOT EXISTS cfg_cluster  (
+	cluster_id    	        smallint(6) NOT NULL DEFAULT '0',
+	cluster_code  	        varchar(80) NOT NULL,
+	cluster_short_name      varchar(50) NOT NULL,
+	cluster_type       	varchar(50) NOT NULL,
+	deployment_tier_code    varchar(25) NOT NULL,
+	data_center_code        varchar(30) NULL,
+	description             varchar(200) NULL,
+	last_modified     	timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY(cluster_id),
+  UNIQUE KEY uix_cfg_cluster__clustercode (cluster_code)
+)
+COMMENT = 'https://en.wikipedia.org/wiki/Computer_cluster' ;
+
+
+CREATE TABLE IF NOT EXISTS cfg_search_score_boost (
+  `id` INT COMMENT 'dataset id',
+  `static_boosting_score` INT COMMENT 'static boosting score for elastic search',
+  PRIMARY KEY (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = latin1;

--- a/docker/mysql/ETL_DDL/executor_metadata.sql
+++ b/docker/mysql/ETL_DDL/executor_metadata.sql
@@ -1,0 +1,521 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+CREATE TABLE IF NOT EXISTS flow (
+  app_id               SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id              INT UNSIGNED      NOT NULL
+  COMMENT 'flow id either inherit from source or generated',
+  flow_name            VARCHAR(255) COMMENT 'name of the flow',
+  flow_group           VARCHAR(255) COMMENT 'flow group or project name',
+  flow_path            VARCHAR(1024) COMMENT 'flow path from top level',
+  flow_level           SMALLINT COMMENT 'flow level, 0 for top level flow',
+  source_created_time  INT UNSIGNED COMMENT 'source created time of the flow',
+  source_modified_time INT UNSIGNED COMMENT 'latest source modified time of the flow',
+  source_version       VARCHAR(255) COMMENT 'latest source version of the flow',
+  is_active            CHAR(1) COMMENT 'determine if it is an active flow',
+  is_scheduled         CHAR(1) COMMENT 'determine if it is a scheduled flow',
+  pre_flows            VARCHAR(2048) COMMENT 'comma separated flow ids that run before this flow',
+  main_tag_id          INT COMMENT 'main tag id',
+  created_time         INT UNSIGNED COMMENT 'wherehows created time of the flow',
+  modified_time        INT UNSIGNED COMMENT 'latest wherehows modified time of the flow',
+  wh_etl_exec_id       BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255)),
+  INDEX flow_name_idx (app_id, flow_group(127), flow_name(127))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow (
+  app_id               SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id              INT UNSIGNED COMMENT 'flow id either inherit from source or generated',
+  flow_name            VARCHAR(255) COMMENT 'name of the flow',
+  flow_group           VARCHAR(255) COMMENT 'flow group or project name',
+  flow_path            VARCHAR(1024) COMMENT 'flow path from top level',
+  flow_level           SMALLINT COMMENT 'flow level, 0 for top level flow',
+  source_created_time  INT UNSIGNED COMMENT 'source created time of the flow',
+  source_modified_time INT UNSIGNED COMMENT 'latest source modified time of the flow',
+  source_version       VARCHAR(255) COMMENT 'latest source version of the flow',
+  is_active            CHAR(1) COMMENT 'determine if it is an active flow',
+  is_scheduled         CHAR(1) COMMENT 'determine if it is a scheduled flow',
+  pre_flows            VARCHAR(2048) COMMENT 'comma separated flow ids that run before this flow',
+  main_tag_id          INT COMMENT 'main tag id',
+  created_time         INT UNSIGNED COMMENT 'wherehows created time of the flow',
+  modified_time        INT UNSIGNED COMMENT 'latest wherehows modified time of the flow',
+  wh_etl_exec_id       BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_source_id_map (
+  app_id           SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id          INT UNSIGNED      NOT NULL AUTO_INCREMENT
+  COMMENT 'flow id generated ',
+  source_id_string VARCHAR(1024) COMMENT 'source string id of the flow',
+  source_id_uuid   VARCHAR(255) COMMENT 'source uuid id of the flow',
+  source_id_uri    VARCHAR(255) COMMENT 'source uri id of the flow',
+  PRIMARY KEY (app_id, flow_id),
+  INDEX flow_path_idx (app_id, source_id_string(255))
+)
+  ENGINE = MyISAM
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow id mapping table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_job (
+  app_id               SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id              INT UNSIGNED      NOT NULL
+  COMMENT 'flow id',
+  first_source_version VARCHAR(255) COMMENT 'first source version of the flow under this dag version',
+  last_source_version  VARCHAR(255) COMMENT 'last source version of the flow under this dag version',
+  dag_version          INT               NOT NULL
+  COMMENT 'derived dag version of the flow',
+  job_id               INT UNSIGNED      NOT NULL
+  COMMENT 'job id either inherit from source or generated',
+  job_name             VARCHAR(255) COMMENT 'job name',
+  job_path             VARCHAR(1024) COMMENT 'job path from top level',
+  job_type_id          SMALLINT COMMENT 'type id of the job',
+  job_type             VARCHAR(63) COMMENT 'type of the job',
+  ref_flow_id          INT UNSIGNED NULL COMMENT 'the reference flow id of the job if the job is a subflow',
+  pre_jobs             VARCHAR(20000) CHAR SET latin1 COMMENT 'comma separated job ids that run before this job',
+  post_jobs            VARCHAR(20000) CHAR SET latin1 COMMENT 'comma separated job ids that run after this job',
+  is_current           CHAR(1) COMMENT 'determine if it is a current job',
+  is_first             CHAR(1) COMMENT 'determine if it is the first job',
+  is_last              CHAR(1) COMMENT 'determine if it is the last job',
+  created_time         INT UNSIGNED COMMENT 'wherehows created time of the flow',
+  modified_time        INT UNSIGNED COMMENT 'latest wherehows modified time of the flow',
+  wh_etl_exec_id       BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, job_id, dag_version),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX ref_flow_id_idx (app_id, ref_flow_id),
+  INDEX job_path_idx (app_id, job_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler job table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_job (
+  app_id         SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id        INT UNSIGNED COMMENT 'flow id',
+  flow_path      VARCHAR(1024) COMMENT 'flow path from top level',
+  source_version VARCHAR(255) COMMENT 'last source version of the flow under this dag version',
+  dag_version    INT COMMENT 'derived dag version of the flow',
+  job_id         INT UNSIGNED COMMENT 'job id either inherit from source or generated',
+  job_name       VARCHAR(255) COMMENT 'job name',
+  job_path       VARCHAR(1024) COMMENT 'job path from top level',
+  job_type_id    SMALLINT COMMENT 'type id of the job',
+  job_type       VARCHAR(63) COMMENT 'type of the job',
+  ref_flow_id    INT UNSIGNED  NULL COMMENT 'the reference flow id of the job if the job is a subflow',
+  ref_flow_path  VARCHAR(1024) COMMENT 'the reference flow path of the job if the job is a subflow',
+  pre_jobs       VARCHAR(20000) CHAR SET latin1 COMMENT 'comma separated job ids that run before this job',
+  post_jobs      VARCHAR(20000) CHAR SET latin1 COMMENT 'comma separated job ids that run after this job',
+  is_current     CHAR(1) COMMENT 'determine if it is a current job',
+  is_first       CHAR(1) COMMENT 'determine if it is the first job',
+  is_last        CHAR(1) COMMENT 'determine if it is the last job',
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX (app_id, job_id, dag_version),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255)),
+  INDEX ref_flow_path_idx (app_id, ref_flow_path(255)),
+  INDEX job_path_idx (app_id, job_path(255)),
+  INDEX job_type_idx (job_type)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler job table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS job_source_id_map (
+  app_id           SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  job_id           INT UNSIGNED      NOT NULL AUTO_INCREMENT
+  COMMENT 'job id generated',
+  source_id_string VARCHAR(1024) COMMENT 'job full path string',
+  source_id_uuid   VARCHAR(255) COMMENT 'source uuid id of the flow',
+  source_id_uri    VARCHAR(255) COMMENT 'source uri id of the flow',
+  PRIMARY KEY (app_id, job_id),
+  INDEX job_path_idx (app_id, source_id_string(255))
+)
+  ENGINE = MyISAM
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow id mapping table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_dag (
+  app_id         SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id        INT UNSIGNED NOT NULL
+  COMMENT 'flow id',
+  source_version VARCHAR(255) COMMENT 'last source version of the flow under this dag version',
+  dag_version    INT COMMENT 'derived dag version of the flow',
+  dag_md5        VARCHAR(255) COMMENT 'md5 checksum for this dag version',
+  is_current     CHAR(1) COMMENT 'if this source version of the flow is current',
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, flow_id, source_version),
+  INDEX flow_dag_md5_idx (app_id, flow_id, dag_md5),
+  INDEX flow_id_idx (app_id, flow_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Flow dag reference table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_dag (
+  app_id         SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id        INT UNSIGNED NOT NULL
+  COMMENT 'flow id',
+  source_version VARCHAR(255) COMMENT 'last source version of the flow under this dag version',
+  dag_version    INT COMMENT 'derived dag version of the flow',
+  dag_md5        VARCHAR(255) COMMENT 'md5 checksum for this dag version',
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, flow_id, source_version),
+  INDEX flow_dag_md5_idx (app_id, flow_id, dag_md5),
+  INDEX flow_id_idx (app_id, flow_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Flow dag reference table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_dag_edge (
+  app_id          SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id         INT UNSIGNED COMMENT 'flow id',
+  flow_path       VARCHAR(1024) COMMENT 'flow path from top level',
+  source_version  VARCHAR(255) COMMENT 'last source version of the flow under this dag version',
+  source_job_id   INT UNSIGNED COMMENT 'job id either inherit from source or generated',
+  source_job_path VARCHAR(1024) COMMENT 'source job path from top level',
+  target_job_id   INT UNSIGNED COMMENT 'job id either inherit from source or generated',
+  target_job_path VARCHAR(1024) COMMENT 'target job path from top level',
+  wh_etl_exec_id  BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX flow_version_idx (app_id, flow_id, source_version),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255)),
+  INDEX source_job_path_idx (app_id, source_job_path(255)),
+  INDEX target_job_path_idx (app_id, target_job_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Flow dag table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_execution (
+  app_id           SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_exec_id     BIGINT UNSIGNED   NOT NULL
+  COMMENT 'flow execution id either from the source or generated',
+  flow_exec_uuid   VARCHAR(255) COMMENT 'source flow execution uuid',
+  flow_id          INT UNSIGNED      NOT NULL
+  COMMENT 'flow id',
+  flow_name        VARCHAR(255) COMMENT 'name of the flow',
+  source_version   VARCHAR(255) COMMENT 'source version of the flow',
+  flow_exec_status VARCHAR(31) COMMENT 'status of flow execution',
+  attempt_id       SMALLINT COMMENT 'attempt id',
+  executed_by      VARCHAR(127) COMMENT 'people who executed the flow',
+  start_time       INT UNSIGNED COMMENT 'start time of the flow execution',
+  end_time         INT UNSIGNED COMMENT 'end time of the flow execution',
+  is_adhoc         CHAR(1) COMMENT 'determine if it is a ad-hoc execution',
+  is_backfill      CHAR(1) COMMENT 'determine if it is a back-fill execution',
+  created_time     INT UNSIGNED COMMENT 'etl create time',
+  modified_time    INT UNSIGNED COMMENT 'etl modified time',
+  wh_etl_exec_id   BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, flow_exec_id),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_name_idx (app_id, flow_name)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow execution table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_execution_id_map (
+  app_id             SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_exec_id       BIGINT UNSIGNED   NOT NULL AUTO_INCREMENT
+  COMMENT 'generated flow execution id',
+  source_exec_string VARCHAR(1024) COMMENT 'source flow execution string',
+  source_exec_uuid   VARCHAR(255) COMMENT 'source uuid id of the flow execution',
+  source_exec_uri    VARCHAR(255) COMMENT 'source uri id of the flow execution',
+  PRIMARY KEY (app_id, flow_exec_id),
+  INDEX flow_exec_uuid_idx (app_id, source_exec_uuid)
+)
+  ENGINE = MyISAM
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow execution id mapping table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_execution (
+  app_id           SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_exec_id     BIGINT UNSIGNED COMMENT 'flow execution id',
+  flow_exec_uuid   VARCHAR(255) COMMENT 'source flow execution uuid',
+  flow_id          INT UNSIGNED COMMENT 'flow id',
+  flow_name        VARCHAR(255) COMMENT 'name of the flow',
+  flow_path        VARCHAR(1024) COMMENT 'flow path from top level',
+  source_version   VARCHAR(255) COMMENT 'source version of the flow',
+  flow_exec_status VARCHAR(31) COMMENT 'status of flow execution',
+  attempt_id       SMALLINT COMMENT 'attempt id',
+  executed_by      VARCHAR(127) COMMENT 'people who executed the flow',
+  start_time       INT UNSIGNED COMMENT 'start time of the flow execution',
+  end_time         INT UNSIGNED COMMENT 'end time of the flow execution',
+  is_adhoc         CHAR(1) COMMENT 'determine if it is a ad-hoc execution',
+  is_backfill      CHAR(1) COMMENT 'determine if it is a back-fill execution',
+  wh_etl_exec_id   BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX flow_exec_idx (app_id, flow_exec_id),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow execution table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS job_execution (
+  app_id          SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_exec_id    BIGINT UNSIGNED COMMENT 'flow execution id',
+  job_exec_id     BIGINT UNSIGNED   NOT NULL
+  COMMENT 'job execution id either inherit or generated',
+  job_exec_uuid   VARCHAR(255) COMMENT 'job execution uuid',
+  flow_id         INT UNSIGNED      NOT NULL
+  COMMENT 'flow id',
+  source_version  VARCHAR(255) COMMENT 'source version of the flow',
+  job_id          INT UNSIGNED      NOT NULL
+  COMMENT 'job id',
+  job_name        VARCHAR(255) COMMENT 'job name',
+  job_exec_status VARCHAR(31) COMMENT 'status of flow execution',
+  attempt_id      SMALLINT COMMENT 'attempt id',
+  start_time      INT UNSIGNED COMMENT 'start time of the execution',
+  end_time        INT UNSIGNED COMMENT 'end time of the execution',
+  is_adhoc        CHAR(1) COMMENT 'determine if it is a ad-hoc execution',
+  is_backfill     CHAR(1) COMMENT 'determine if it is a back-fill execution',
+  created_time    INT UNSIGNED COMMENT 'etl create time',
+  modified_time   INT UNSIGNED COMMENT 'etl modified time',
+  wh_etl_exec_id  BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, job_exec_id),
+  INDEX flow_exec_id_idx (app_id, flow_exec_id),
+  INDEX job_id_idx (app_id, job_id),
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX job_name_idx (app_id, flow_id, job_name)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler job execution table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS job_execution_id_map (
+  app_id             SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the job',
+  job_exec_id        BIGINT UNSIGNED   NOT NULL AUTO_INCREMENT
+  COMMENT 'generated job execution id',
+  source_exec_string VARCHAR(1024) COMMENT 'source job execution string',
+  source_exec_uuid   VARCHAR(255) COMMENT 'source uuid id of the job execution',
+  source_exec_uri    VARCHAR(255) COMMENT 'source uri id of the job execution',
+  PRIMARY KEY (app_id, job_exec_id),
+  INDEX job_exec_uuid_idx (app_id, source_exec_uuid)
+)
+  ENGINE = MyISAM
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler job execution id mapping table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_job_execution (
+  app_id          SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id         INT UNSIGNED COMMENT 'flow id',
+  flow_path       VARCHAR(1024) COMMENT 'flow path from top level',
+  source_version  VARCHAR(255) COMMENT 'source version of the flow',
+  flow_exec_id    BIGINT UNSIGNED COMMENT 'flow execution id',
+  flow_exec_uuid  VARCHAR(255) COMMENT 'flow execution uuid',
+  job_id          INT UNSIGNED COMMENT 'job id',
+  job_name        VARCHAR(255) COMMENT 'job name',
+  job_path        VARCHAR(1024) COMMENT 'job path from top level',
+  job_exec_id     BIGINT UNSIGNED COMMENT 'job execution id either inherit or generated',
+  job_exec_uuid   VARCHAR(255) COMMENT 'job execution uuid',
+  job_exec_status VARCHAR(31) COMMENT 'status of flow execution',
+  attempt_id      SMALLINT COMMENT 'attempt id',
+  start_time      INT UNSIGNED COMMENT 'start time of the execution',
+  end_time        INT UNSIGNED COMMENT 'end time of the execution',
+  is_adhoc        CHAR(1) COMMENT 'determine if it is a ad-hoc execution',
+  is_backfill     CHAR(1) COMMENT 'determine if it is a back-fill execution',
+  wh_etl_exec_id  BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX flow_id_idx (app_id, flow_id),
+  INDEX flow_path_idx (app_id, flow_path(255)),
+  INDEX job_path_idx (app_id, job_path(255)),
+  INDEX flow_exec_idx (app_id, flow_exec_id),
+  INDEX job_exec_idx (app_id, job_exec_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler job execution table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_schedule (
+  app_id               SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id              INT UNSIGNED      NOT NULL
+  COMMENT 'flow id',
+  unit                 VARCHAR(31) COMMENT 'unit of time',
+  frequency            INT COMMENT 'frequency of the unit',
+  cron_expression      VARCHAR(127) COMMENT 'cron expression',
+  is_active            CHAR(1) COMMENT 'determine if it is an active schedule',
+  included_instances   VARCHAR(127) COMMENT 'included instance',
+  excluded_instances   VARCHAR(127) COMMENT 'excluded instance',
+  effective_start_time INT UNSIGNED COMMENT 'effective start time of the flow execution',
+  effective_end_time   INT UNSIGNED COMMENT 'effective end time of the flow execution',
+  created_time         INT UNSIGNED COMMENT 'etl create time',
+  modified_time        INT UNSIGNED COMMENT 'etl modified time',
+  ref_id               VARCHAR(255) COMMENT 'reference id of this schedule',
+  wh_etl_exec_id       BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, flow_id, ref_id),
+  INDEX (app_id, flow_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow schedule table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_schedule (
+  app_id               SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id              INT UNSIGNED COMMENT 'flow id',
+  flow_path            VARCHAR(1024) COMMENT 'flow path from top level',
+  unit                 VARCHAR(31) COMMENT 'unit of time',
+  frequency            INT COMMENT 'frequency of the unit',
+  cron_expression      VARCHAR(127) COMMENT 'cron expression',
+  included_instances   VARCHAR(127) COMMENT 'included instance',
+  excluded_instances   VARCHAR(127) COMMENT 'excluded instance',
+  effective_start_time INT UNSIGNED COMMENT 'effective start time of the flow execution',
+  effective_end_time   INT UNSIGNED COMMENT 'effective end time of the flow execution',
+  ref_id               VARCHAR(255) COMMENT 'reference id of this schedule',
+  wh_etl_exec_id       BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX (app_id, flow_id),
+  INDEX (app_id, flow_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler flow schedule table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS flow_owner_permission (
+  app_id         SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id        INT UNSIGNED      NOT NULL
+  COMMENT 'flow id',
+  owner_id       VARCHAR(63) COMMENT 'identifier of the owner',
+  permissions    VARCHAR(255) COMMENT 'permissions of the owner',
+  owner_type     VARCHAR(31) COMMENT 'whether is a group owner or not',
+  created_time   INT UNSIGNED COMMENT 'etl create time',
+  modified_time  INT UNSIGNED COMMENT 'etl modified time',
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that create this record',
+  PRIMARY KEY (app_id, flow_id, owner_id),
+  INDEX flow_index (app_id, flow_id),
+  INDEX owner_index (app_id, owner_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler owner table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS stg_flow_owner_permission (
+  app_id         SMALLINT UNSIGNED NOT NULL
+  COMMENT 'application id of the flow',
+  flow_id        INT UNSIGNED COMMENT 'flow id',
+  flow_path      VARCHAR(1024) COMMENT 'flow path from top level',
+  owner_id       VARCHAR(63) COMMENT 'identifier of the owner',
+  permissions    VARCHAR(255) COMMENT 'permissions of the owner',
+  owner_type     VARCHAR(31) COMMENT 'whether is a group owner or not',
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that create this record',
+  INDEX flow_index (app_id, flow_id),
+  INDEX owner_index (app_id, owner_id),
+  INDEX flow_path_idx (app_id, flow_path(255))
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'Scheduler owner table' PARTITION BY HASH (app_id) PARTITIONS 8;
+
+CREATE TABLE IF NOT EXISTS job_execution_ext_reference (
+	app_id         	smallint(5) UNSIGNED COMMENT 'application id of the flow'  NOT NULL,
+	job_exec_id    	bigint(20) UNSIGNED COMMENT 'job execution id either inherit or generated'  NOT NULL,
+	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  DEFAULT '0',
+	ext_ref_type	varchar(50) COMMENT 'YARN_JOB_ID, DB_SESSION_ID, PID, INFA_WORKFLOW_RUN_ID, CASSCADE_WORKFLOW_ID'  NOT NULL,
+    ext_ref_sort_id smallint(6) COMMENT 'sort id 0..n within each ext_ref_type' NOT NULL DEFAULT '0',
+	ext_ref_id      varchar(100) COMMENT 'external reference id' NOT NULL,
+	created_time   	int(10) UNSIGNED COMMENT 'etl create time'  NULL,
+	wh_etl_exec_id 	bigint(20) COMMENT 'wherehows etl execution id that create this record'  NULL,
+	PRIMARY KEY(app_id,job_exec_id,attempt_id,ext_ref_type,ext_ref_sort_id)
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = latin1
+COMMENT = 'External reference ids for the job execution'
+PARTITION BY HASH(app_id)
+   (	PARTITION p0,
+	PARTITION p1,
+	PARTITION p2,
+	PARTITION p3,
+	PARTITION p4,
+	PARTITION p5,
+	PARTITION p6,
+	PARTITION p7)
+;
+
+CREATE INDEX idx_job_execution_ext_ref__ext_ref_id USING BTREE
+	ON job_execution_ext_reference(ext_ref_id);
+
+
+CREATE TABLE IF NOT EXISTS stg_job_execution_ext_reference (
+	app_id         	smallint(5) UNSIGNED COMMENT 'application id of the flow'  NOT NULL,
+	job_exec_id    	bigint(20) UNSIGNED COMMENT 'job execution id either inherit or generated'  NOT NULL,
+	attempt_id     	smallint(6) COMMENT 'job execution attempt id'  DEFAULT '0',
+	ext_ref_type	varchar(50) COMMENT 'YARN_JOB_ID, DB_SESSION_ID, PID, INFA_WORKFLOW_RUN_ID, CASSCADE_WORKFLOW_ID'  NOT NULL,
+    ext_ref_sort_id smallint(6) COMMENT 'sort id 0..n within each ext_ref_type' NOT NULL DEFAULT '0',
+	ext_ref_id      varchar(100) COMMENT 'external reference id' NOT NULL,
+	created_time   	int(10) UNSIGNED COMMENT 'etl create time'  NULL,
+	wh_etl_exec_id 	bigint(20) COMMENT 'wherehows etl execution id that create this record'  NULL,
+	PRIMARY KEY(app_id,job_exec_id,attempt_id,ext_ref_type,ext_ref_sort_id)
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = latin1
+COMMENT = 'staging table for job_execution_ext_reference'
+PARTITION BY HASH(app_id)
+   (	PARTITION p0,
+	PARTITION p1,
+	PARTITION p2,
+	PARTITION p3,
+	PARTITION p4,
+	PARTITION p5,
+	PARTITION p6,
+	PARTITION p7)
+;
+
+CREATE TABLE IF NOT EXISTS `cfg_job_type` (
+  `job_type_id` SMALLINT(6) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `job_type`    VARCHAR(50)          NOT NULL,
+  `description` VARCHAR(200)         NULL,
+  PRIMARY KEY (`job_type_id`),
+  UNIQUE KEY `ak_cfg_job_type__job_type` (`job_type`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 55
+  DEFAULT CHARSET = utf8
+  COMMENT = 'job types used in mutliple schedulers';
+
+CREATE TABLE IF NOT EXISTS `cfg_job_type_reverse_map` (
+  `job_type_actual`   VARCHAR(50)
+                      CHARACTER SET ascii NOT NULL,
+  `job_type_id`       SMALLINT(6) UNSIGNED NOT NULL,
+  `description`       VARCHAR(200)         NULL,
+  `job_type_standard` VARCHAR(50)          NOT NULL,
+  PRIMARY KEY (`job_type_actual`),
+  UNIQUE KEY `cfg_job_type_reverse_map_uk` (`job_type_actual`),
+  KEY `cfg_job_type_reverse_map_job_type_id_fk` (`job_type_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COMMENT = 'The reverse map of the actual job type to standard job type';

--- a/docker/mysql/ETL_DDL/git_metadata.sql
+++ b/docker/mysql/ETL_DDL/git_metadata.sql
@@ -1,0 +1,111 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+CREATE TABLE IF NOT EXISTS `source_code_commit_info` (
+  `app_id`          SMALLINT(5) UNSIGNED DEFAULT NULL,
+  `repository_urn`  VARCHAR(300) CHAR SET latin1 NOT NULL COMMENT 'the git repo urn',
+  `commit_id`       VARCHAR(50) CHAR SET latin1  NOT NULL COMMENT 'the sha-1 hash of the commit',
+  `file_path`       VARCHAR(600) CHAR SET latin1 NOT NULL COMMENT 'the path to the file',
+  `file_name`       VARCHAR(127)                 NOT NULL COMMENT 'the file name',
+  `commit_time`     INT UNSIGNED COMMENT 'the commit time',
+  `committer_name`  VARCHAR(128)                 NOT NULL COMMENT 'name of the committer',
+  `committer_email` VARCHAR(128)         DEFAULT NULL COMMENT 'email of the committer',
+  `author_name`     VARCHAR(128)                 NOT NULL COMMENT 'name of the author',
+  `author_email`    VARCHAR(128)                 NOT NULL COMMENT 'email of the author',
+  `message`         VARCHAR(1024)                NOT NULL COMMENT 'message of the commit',
+  `created_time`    INT UNSIGNED COMMENT 'wherehows created time',
+  `modified_time`   INT UNSIGNED COMMENT 'latest wherehows modified',
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (repository_urn, file_path, commit_id),
+  KEY (commit_id),
+  KEY (repository_urn, file_name, committer_email)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS `stg_source_code_commit_info` (
+  `app_id`          SMALLINT(5) UNSIGNED DEFAULT NULL,
+  `repository_urn`  VARCHAR(300) CHAR SET latin1 NOT NULL COMMENT 'the git repo urn',
+  `commit_id`       VARCHAR(50) CHAR SET latin1  NOT NULL COMMENT 'the sha-1 hash of the commit',
+  `file_path`       VARCHAR(600) CHAR SET latin1 NOT NULL COMMENT 'the path to the file',
+  `file_name`       VARCHAR(127)                 NOT NULL COMMENT 'the file name',
+  `commit_time`     INT UNSIGNED COMMENT 'the commit time',
+  `committer_name`  VARCHAR(128)                 NOT NULL COMMENT 'name of the committer',
+  `committer_email` VARCHAR(128)         DEFAULT NULL COMMENT 'email of the committer',
+  `author_name`     VARCHAR(128)                 NOT NULL COMMENT 'name of the author',
+  `author_email`    VARCHAR(128)                 NOT NULL COMMENT 'email of the author',
+  `message`         VARCHAR(1024)                NOT NULL COMMENT 'message of the commit',
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (repository_urn, file_path, commit_id),
+  KEY (commit_id),
+  KEY (repository_urn, file_name, committer_email)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
+
+CREATE TABLE IF NOT EXISTS `stg_git_project` (
+  `app_id`          SMALLINT(5) UNSIGNED NOT NULL,
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  `project_name`    VARCHAR(100) NOT NULL,
+  `scm_type`        VARCHAR(20) NOT NULL COMMENT 'git, svn or other',
+  `owner_type`      VARCHAR(50) DEFAULT NULL,
+  `owner_name`      VARCHAR(300) DEFAULT NULL COMMENT 'owner names in comma separated list',
+  `create_time`     VARCHAR(50) DEFAULT NULL,
+  `num_of_repos`    INT UNSIGNED DEFAULT NULL,
+  `repos`           MEDIUMTEXT DEFAULT NULL COMMENT 'repo names in comma separated list',
+  `license`         VARCHAR(100) DEFAULT NULL,
+  `description`     MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  PRIMARY KEY (`project_name`, `scm_type`, `app_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS `stg_product_repo` (
+  `app_id`          SMALLINT(5) UNSIGNED NOT NULL,
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  `scm_repo_fullname` VARCHAR(100) NOT NULL,
+  `scm_type`        VARCHAR(20) NOT NULL,
+  `repo_id`         INT UNSIGNED DEFAULT NULL,
+  `project`         VARCHAR(100) DEFAULT NULL,
+  `dataset_group`   VARCHAR(200) DEFAULT NULL COMMENT 'dataset group name, database name, etc',
+  `owner_type`      VARCHAR(50) DEFAULT NULL,
+  `owner_name`      VARCHAR(300) DEFAULT NULL COMMENT 'owner names in comma separated list',
+  `multiproduct_name` VARCHAR(100) DEFAULT NULL,
+  `product_type`    VARCHAR(100) DEFAULT NULL,
+  `product_version` VARCHAR(50) DEFAULT NULL,
+  `namespace`       VARCHAR(100) DEFAULT NULL,
+  PRIMARY KEY (`scm_repo_fullname`, `scm_type`, `app_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS `stg_repo_owner` (
+  `app_id`          SMALLINT(5) UNSIGNED NOT NULL,
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  `scm_repo_fullname` VARCHAR(100) NOT NULL,
+  `scm_type`        VARCHAR(20) NOT NULL,
+  `repo_id`         INT DEFAULT NULL,
+  `dataset_group`   VARCHAR(200) DEFAULT NULL COMMENT 'dataset group name, database name, etc',
+  `owner_type`      VARCHAR(50) NOT NULL COMMENT 'which acl file this owner is in',
+  `owner_name`      VARCHAR(50) NOT NULL COMMENT 'one owner name',
+  `sort_id`         INT UNSIGNED DEFAULT NULL,
+  `paths`           TEXT CHAR SET utf8 DEFAULT NULL COMMENT 'covered paths by this acl',
+  PRIMARY KEY (`scm_repo_fullname`, `scm_type`, `owner_type`, `owner_name`, `app_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
+CREATE TABLE IF NOT EXISTS stg_database_scm_map (
+  `database_name`   VARCHAR(100) NOT NULL COMMENT 'database name',
+  `database_type`   VARCHAR(50) NOT NULL COMMENT 'database type',
+  `app_name`        VARCHAR(127) NOT NULL COMMENT 'the name of application',
+  `scm_type`        VARCHAR(50) NOT NULL COMMENT 'scm type',
+  `scm_url`         VARCHAR(127) DEFAULT NULL COMMENT 'scm url',
+  `committers`      VARCHAR(500) DEFAULT NULL COMMENT 'committers',
+  `filepath`        VARCHAR(200) DEFAULT NULL COMMENT 'filepath',
+  `app_id`          SMALLINT(5) UNSIGNED COMMENT 'application id of the namesapce',
+  `wh_etl_exec_id`  BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`database_type`,`database_name`,`scm_type`,`app_name`)
+) ENGINE = InnoDB DEFAULT CHARSET = latin1;

--- a/docker/mysql/ETL_DDL/kafka_tracking.sql
+++ b/docker/mysql/ETL_DDL/kafka_tracking.sql
@@ -1,0 +1,171 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+
+-- creation statement for Kafka event related tables
+-- Gobblin:
+--   + GobblinTrackingEvent: compaction
+--   + GobblinTrackingEvent_Distcp_Ng: distcp
+--   + GobblinTrackingEvent_Lumos: rdbms/nosql
+-- Hive Metastore
+--   + MetastoreTableAudit
+--   + MetastorePartitionAudit
+-- Mapping {Kafka topic => stg table} is loaded in
+-- backend-service/app/actors/KafkaConsumerMaster.java
+-- Avro schemas of the Kafka event are available in
+-- data-model/avro
+
+-- staging table for Gobblin tracking event compaction
+CREATE TABLE IF NOT EXISTS `stg_kafka_gobblin_compaction` (
+  `cluster`         VARCHAR(20) NOT NULL,
+  `dataset`         VARCHAR(100) NOT NULL,
+  `partition_type`  VARCHAR(20) DEFAULT NULL,
+  `partition_name`  VARCHAR(50) DEFAULT NULL,
+  `record_count`        BIGINT(20) DEFAULT NULL,
+  `late_record_count`   BIGINT(20) DEFAULT NULL,
+  `dedupe_status`   VARCHAR(20) DEFAULT NULL,
+  `job_context`     VARCHAR(50) DEFAULT NULL,
+  `project_name`    VARCHAR(50) DEFAULT NULL,
+  `flow_name`       VARCHAR(100) DEFAULT NULL,
+  `job_name`        VARCHAR(100) DEFAULT NULL,
+  `flow_exec_id`    INT(11) DEFAULT NULL,
+  `log_event_time`  BIGINT(20) NOT NULL,
+  PRIMARY KEY (`dataset`,`cluster`,`log_event_time`)
+)
+  ENGINE=InnoDB
+  DEFAULT CHARSET=latin1;
+
+
+-- staging table for Gobblin tracking event lumos
+CREATE TABLE IF NOT EXISTS `stg_kafka_gobblin_lumos` (
+  `cluster`     VARCHAR(20) NOT NULL,
+  `dataset`     VARCHAR(100) NOT NULL,
+  `location`    VARCHAR(200) NOT NULL,
+  `partition_type`    VARCHAR(20) DEFAULT NULL,
+  `partition_name`    VARCHAR(50) DEFAULT NULL,
+  `subpartition_type` VARCHAR(20) DEFAULT NULL,
+  `subpartition_name` VARCHAR(50) DEFAULT NULL,
+  `max_data_date_epoch3`  BIGINT(20) DEFAULT NULL,
+  `max_data_key`          BIGINT(20) DEFAULT NULL,
+  `record_count`          BIGINT(20) DEFAULT NULL,
+  `source_datacenter`     VARCHAR(10) DEFAULT NULL,
+  `source_deployment_env` VARCHAR(10) DEFAULT NULL,
+  `source_database` VARCHAR(50) DEFAULT NULL,
+  `source_table`    VARCHAR(50) DEFAULT NULL,
+  `job_context`     VARCHAR(50) DEFAULT NULL,
+  `project_name`    VARCHAR(100) DEFAULT NULL,
+  `flow_name`       VARCHAR(100) DEFAULT NULL,
+  `job_name`        VARCHAR(100) DEFAULT NULL,
+  `flow_exec_id`    INT(11) DEFAULT NULL,
+  `log_event_time`  BIGINT(20) NOT NULL,
+  PRIMARY KEY (`dataset`,`cluster`,`log_event_time`)
+)
+  ENGINE=InnoDB
+  DEFAULT CHARSET=latin1;
+
+
+-- staging table for Gobblin tracking event distcp_ng
+CREATE TABLE IF NOT EXISTS `stg_kafka_gobblin_distcp` (
+  `cluster`     VARCHAR(20) NOT NULL,
+  `dataset`     VARCHAR(100) NOT NULL,
+  `partition_type`  VARCHAR(20) DEFAULT NULL,
+  `partition_name`  VARCHAR(50) NOT NULL,
+  `upsteam_timestamp` BIGINT(20) DEFAULT NULL,
+  `origin_timestamp`  BIGINT(20) DEFAULT NULL,
+  `source_path`     VARCHAR(200) DEFAULT NULL,
+  `target_path`     VARCHAR(200) DEFAULT NULL,
+  `job_context`     VARCHAR(50) DEFAULT NULL,
+  `project_name`    VARCHAR(100) DEFAULT NULL,
+  `flow_name`       VARCHAR(100) DEFAULT NULL,
+  `job_name`        VARCHAR(100) DEFAULT NULL,
+  `flow_exec_id`    INT(11) DEFAULT NULL,
+  `log_event_time`  BIGINT(20) NOT NULL,
+  PRIMARY KEY (`dataset`,`cluster`,`partition_name`,`log_event_time`)
+)
+  ENGINE=InnoDB
+  DEFAULT CHARSET=latin1;
+
+
+-- staging table for Metastore Audit Event, include TableAudit / PartitionAudit
+CREATE TABLE IF NOT EXISTS `stg_kafka_metastore_audit` (
+  `server`          VARCHAR(20) NOT NULL,
+  `instance`        VARCHAR(20) NOT NULL,
+  `app_name`        VARCHAR(50) NOT NULL,
+  `event_name`      VARCHAR(50) NOT NULL,
+  `event_type`      VARCHAR(30) NOT NULL,
+  `log_event_time`  BIGINT(20) NOT NULL,
+  `metastore_thrift_uri`  VARCHAR(200) DEFAULT NULL,
+  `metastore_version`     VARCHAR(20) DEFAULT NULL,
+  `is_successful`         VARCHAR(5) DEFAULT NULL,
+  `is_data_deleted`       VARCHAR(5) DEFAULT NULL,
+  `db_name`         VARCHAR(100) NOT NULL,
+  `table_name`      VARCHAR(100) NOT NULL,
+  `time_partition`  VARCHAR(100) NOT NULL,
+  `location`        VARCHAR(200) DEFAULT NULL,
+  `owner`           VARCHAR(100) DEFAULT NULL,
+  `create_time`     BIGINT(20) DEFAULT NULL,
+  `last_access_time`  BIGINT(20) DEFAULT NULL,
+  `old_info`          MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  `new_info`          MEDIUMTEXT CHAR SET utf8 DEFAULT NULL,
+  PRIMARY KEY (`db_name`,`table_name`,`time_partition`,`instance`,`log_event_time`,`event_type`)
+)
+  ENGINE=InnoDB
+  DEFAULT CHARSET=latin1;
+
+
+-- Combine multiple data log status from Kafka events into a status table
+SET TIME_ZONE='US/Pacific';	-- this needs to be customized based on your time zone
+SELECT @@session.time_zone, current_timestamp;
+
+CREATE TABLE IF NOT EXISTS log_dataset_instance_load_status  (
+	dataset_id         	int(11) UNSIGNED NOT NULL DEFAULT '0',
+	db_id              	smallint(6) NOT NULL DEFAULT '0',
+	dataset_type       	varchar(30) COMMENT 'hive,teradata,oracle,hdfs...'  NOT NULL,
+	dataset_native_name	varchar(200) NOT NULL,
+	operation_type     	varchar(50) COMMENT 'load, merge, compact, update, delete'  NULL,
+	partition_grain    	varchar(30) COMMENT 'snapshot, delta, daily, daily, monthly...'  NOT NULL,
+	partition_expr     	varchar(500) COMMENT 'partition name or expression'  NOT NULL,
+	data_time_expr     	varchar(20) COMMENT 'datetime literal of the data datetime'  NOT NULL,
+	data_time_epoch    	int(11) COMMENT 'epoch second of the data datetime'  NOT NULL,
+	record_count       	bigint(20) NULL,
+	size_in_byte       	bigint(20) NULL,
+	log_time_epoch     	int(11) COMMENT 'When data is loaded or published'  NOT NULL,
+	ref_dataset_type   	varchar(30) COMMENT 'Refer to the underlying dataset'  NULL,
+	ref_db_id          	int(11) COMMENT 'Refer to db of the underlying dataset'  NULL,
+	ref_uri            	varchar(300) COMMENT 'Table name or HDFS location'  NULL,
+	last_modified      	timestamp NULL,
+	PRIMARY KEY(dataset_id,db_id,data_time_epoch,partition_grain,partition_expr),
+	KEY(dataset_native_name),
+	KEY(ref_uri)
+)
+ENGINE = InnoDB
+CHARACTER SET latin1
+AUTO_INCREMENT = 0
+COMMENT = 'Capture the load/publish ops for dataset instance'
+PARTITION BY RANGE COLUMNS (data_time_epoch)
+( PARTITION P201601 VALUES LESS THAN (unix_timestamp(date'2016-02-01')),
+  PARTITION P201602 VALUES LESS THAN (unix_timestamp(date'2016-03-01')),
+  PARTITION P201603 VALUES LESS THAN (unix_timestamp(date'2016-04-01')),
+  PARTITION P201604 VALUES LESS THAN (unix_timestamp(date'2016-05-01')),
+  PARTITION P201605 VALUES LESS THAN (unix_timestamp(date'2016-06-01')),
+  PARTITION P201606 VALUES LESS THAN (unix_timestamp(date'2016-07-01')),
+  PARTITION P201607 VALUES LESS THAN (unix_timestamp(date'2016-08-01')),
+  PARTITION P201608 VALUES LESS THAN (unix_timestamp(date'2016-09-01')),
+  PARTITION P201609 VALUES LESS THAN (unix_timestamp(date'2016-10-01')),
+  PARTITION P201610 VALUES LESS THAN (unix_timestamp(date'2016-11-01')),
+  PARTITION P201611 VALUES LESS THAN (unix_timestamp(date'2016-12-01')),
+  PARTITION P201612 VALUES LESS THAN (unix_timestamp(date'2017-01-01')),
+  PARTITION P203507 VALUES LESS THAN (unix_timestamp(date'2035-08-01'))
+) ;
+

--- a/docker/mysql/ETL_DDL/lineage_metadata.sql
+++ b/docker/mysql/ETL_DDL/lineage_metadata.sql
@@ -1,0 +1,92 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- created statements for lineage related tables
+CREATE TABLE IF NOT EXISTS `stg_job_execution_data_lineage` (
+  `app_id`                 SMALLINT(5) UNSIGNED                                ,
+  `flow_exec_id`           BIGINT(20) UNSIGNED                                 ,
+  `job_exec_id`            BIGINT(20) UNSIGNED                                 ,
+  `job_exec_uuid`          VARCHAR(100)                                        NULL,
+  `job_name`               VARCHAR(255)                                        NULL,
+  `job_start_unixtime`     BIGINT(20)                                          NOT NULL,
+  `job_finished_unixtime`  BIGINT(20)                                          NOT NULL,
+
+  `db_id`                  SMALLINT(5) UNSIGNED                                NULL,
+  `abstracted_object_name` VARCHAR(255)                                        NOT NULL,
+  `full_object_name`       VARCHAR(1000)                                       NOT NULL,
+  `partition_start`        VARCHAR(50)                                         NULL,
+  `partition_end`          VARCHAR(50)                                         NULL,
+  `partition_type`         VARCHAR(20)                                         NULL,
+  `layout_id`              SMALLINT(5) UNSIGNED                                NULL,
+  `storage_type`           VARCHAR(16)                                         NULL,
+
+  `source_target_type`     ENUM('source', 'target', 'lookup', 'temp') NOT NULL,
+  `srl_no`                 SMALLINT(5) UNSIGNED                       NOT NULL DEFAULT '1'
+  COMMENT 'the sorted number of this record in all records of this job related operation',
+  `source_srl_no`          SMALLINT(5) UNSIGNED                                NULL
+  COMMENT 'the related record of this record',
+  `operation`              VARCHAR(64)                                         NULL,
+  `record_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `insert_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `delete_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `update_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `flow_path`              VARCHAR(1024)                                       NULL,
+  `created_date`           INT UNSIGNED,
+  `wh_etl_exec_id`              INT(11)                                        NULL
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS `job_execution_data_lineage` (
+  `app_id`                 SMALLINT(5) UNSIGNED                       NOT NULL,
+  `flow_exec_id`           BIGINT(20) UNSIGNED                                 NOT NULL,
+  `job_exec_id`            BIGINT(20) UNSIGNED                                 NOT NULL
+  COMMENT 'in azkaban this is a smart key combined execution id and sort id of the job',
+  `job_exec_uuid`          VARCHAR(100)                                        NULL
+  COMMENT 'some scheduler do not have this value, e.g. Azkaban',
+  `job_name`               VARCHAR(255)                                        NOT NULL,
+  `job_start_unixtime`     BIGINT(20)                                          NOT NULL,
+  `job_finished_unixtime`  BIGINT(20)                                          NOT NULL,
+
+  `db_id`                  SMALLINT(5) UNSIGNED                                NULL,
+  `abstracted_object_name` VARCHAR(255)                               NOT NULL,
+  `full_object_name`       VARCHAR(1000)                                       NULL,
+  `partition_start`        VARCHAR(50)                                         NULL,
+  `partition_end`          VARCHAR(50)                                         NULL,
+  `partition_type`         VARCHAR(20)                                         NULL,
+  `layout_id`              SMALLINT(5) UNSIGNED                                NULL
+  COMMENT 'layout of the dataset',
+  `storage_type`           VARCHAR(16)                                         NULL,
+
+  `source_target_type`     ENUM('source', 'target', 'lookup', 'temp') NOT NULL,
+  `srl_no`                 SMALLINT(5) UNSIGNED                       NOT NULL DEFAULT '1'
+  COMMENT 'the sorted number of this record in all records of this job related operation',
+  `source_srl_no`          SMALLINT(5) UNSIGNED                                NULL
+  COMMENT 'the related record of this record',
+  `operation`              VARCHAR(64)                                         NULL,
+  `record_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `insert_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `delete_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `update_count`           BIGINT(20) UNSIGNED                                 NULL,
+  `flow_path`              VARCHAR(1024)                                       NULL,
+  `created_date`           INT UNSIGNED,
+  `wh_etl_exec_id`              INT(11)                                        NULL,
+
+  PRIMARY KEY (`app_id`, `job_exec_id`, `srl_no`),
+  KEY `idx_flow_path` (`app_id`, `flow_path`(300)),
+  KEY `idx_job_execution_data_lineage__object_name` (`abstracted_object_name`, `source_target_type`) USING BTREE
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = latin1
+  COMMENT = 'Lineage table' PARTITION BY HASH (app_id) PARTITIONS 8;

--- a/docker/mysql/ETL_DDL/metric_metadata.sql
+++ b/docker/mysql/ETL_DDL/metric_metadata.sql
@@ -1,0 +1,51 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- metrics table
+CREATE TABLE IF NOT EXISTS dict_business_metric  (
+  `metric_id`                	SMALLINT(6) UNSIGNED AUTO_INCREMENT NOT NULL,
+  `metric_name`              	VARCHAR(200) NOT NULL,
+  `metric_description`       	VARCHAR(500) NULL,
+  `dashboard_name`           	VARCHAR(100) COMMENT 'Hierarchy Level 1'  NULL,
+  `metric_group`             	VARCHAR(100) COMMENT 'Hierarchy Level 2'  NULL,
+  `metric_category`          	VARCHAR(100) COMMENT 'Hierarchy Level 3'  NULL,
+  `metric_sub_category`         VARCHAR(100) COMMENT 'Additional Classification, such as Product, Line of Business' NULL,
+  `metric_level`		VARCHAR(50) COMMENT 'CORE, DEPARTMENT, TEAM, OPERATION, STRATEGIC, TIER1, TIER2' NULL, 
+  `metric_source_type`       	VARCHAR(50) COMMENT 'Table, Cube, File, Web Service'  NULL,
+  `metric_source`            	VARCHAR(300) CHAR SET latin1 COMMENT 'Table Name, Cube Name, URL'  NULL,
+  `metric_source_dataset_id`	INT(11) COMMENT 'If metric_source can be matched in dict_dataset' NULL,
+  `metric_ref_id_type`       	VARCHAR(50) CHAR SET latin1 COMMENT 'DWH, ABTEST, FINANCE, SEGMENT, SALESAPP' NULL,
+  `metric_ref_id`            	VARCHAR(100) CHAR SET latin1 COMMENT 'ID in the reference system' NULL,
+  `metric_type`			VARCHAR(100) COMMENT 'NUMBER, BOOLEAN, LIST' NULL,
+  `metric_additive_type`     	VARCHAR(100) COMMENT 'FULL, SEMI, NONE' NULL,
+  `metric_grain`             	VARCHAR(100) COMMENT 'DAILY, WEEKLY, UNIQUE, ROLLING 7D, ROLLING 30D' NULL,
+  `metric_display_factor`    	DECIMAL(10,4) COMMENT '0.01, 1000, 1000000, 1000000000' NULL,
+  `metric_display_factor_sym`	VARCHAR(20) COMMENT '%, (K), (M), (B), (GB), (TB), (PB)' NULL,
+  `metric_good_direction`	VARCHAR(20) COMMENT 'UP, DOWN, ZERO, FLAT' NULL,
+  `metric_formula`           	TEXT COMMENT 'Expression, Code Snippet or Calculation Logic' NULL,
+  `dimensions`			VARCHAR(500) CHAR SET latin1 NULL,
+  `owners`                 	VARCHAR(300) NULL,
+  `tags`			VARCHAR(300) NULL,
+  `urn`                         VARCHAR(300) CHAR SET latin1 NOT NULL,
+  `metric_url`			VARCHAR(300) CHAR SET latin1 NULL,
+  `wiki_url`              	VARCHAR(300) CHAR SET latin1 NULL,
+  `scm_url`               	VARCHAR(300) CHAR SET latin1 NULL,
+  PRIMARY KEY(metric_id),
+  KEY `idx_dict_business_metric__urn` (`urn`) USING BTREE,
+  KEY `idx_dict_business_metric__ref_id` (`metric_ref_id`) USING BTREE,
+  FULLTEXT KEY `fti_dict_business_metric_all` (`metric_name`, `metric_description`, `metric_category`, `metric_group`, `dashboard_name`)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+;

--- a/docker/mysql/ETL_DDL/owner_metadata.sql
+++ b/docker/mysql/ETL_DDL/owner_metadata.sql
@@ -1,0 +1,120 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+
+CREATE TABLE IF NOT EXISTS dataset_owner (
+  `dataset_id` INT UNSIGNED NOT NULL,
+  `dataset_urn` VARCHAR(200) NOT NULL,
+  `owner_id` VARCHAR(127) NOT NULL,
+  `app_id` SMALLINT NOT NULL COMMENT 'application id of the namespace',
+  `namespace` VARCHAR(127) COMMENT 'the namespace of the user',
+  `owner_type` VARCHAR(127) COMMENT 'Producer, Consumer, Stakeholder',
+  `owner_sub_type` VARCHAR(127) COMMENT 'DWH, UMP, BA, etc',
+  `owner_id_type` VARCHAR(127) COMMENT 'user, group, service, or urn',
+  `owner_source`  VARCHAR(127) COMMENT 'where the owner info is extracted: JIRA,RB,DB,FS,AUDIT',
+  `db_ids` VARCHAR(127) COMMENT 'comma separated database ids',
+  `is_group` CHAR(1) COMMENT 'if owner is a group',
+  `is_active` CHAR(1) COMMENT 'if owner is active',
+  `is_deleted` CHAR(1) COMMENT 'if owner has been removed from the dataset',
+  `sort_id` SMALLINT COMMENT '0 = primary owner, order by priority/importance',
+  `source_time` INT UNSIGNED COMMENT 'the source time in epoch',
+  `created_time` INT UNSIGNED COMMENT 'the create time in epoch',
+  `modified_time` INT UNSIGNED COMMENT 'the modified time in epoch',
+  `confirmed_by` VARCHAR(127) NULL,
+  `confirmed_on` INT UNSIGNED,
+  wh_etl_exec_id BIGINT COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`dataset_id`, `owner_id`, `app_id`),
+  UNIQUE KEY (`dataset_urn`, `owner_id`, `app_id`)
+);
+
+CREATE TABLE IF NOT EXISTS stg_dataset_owner (
+  `dataset_id` INT COMMENT 'dataset_id',
+  `dataset_urn` VARCHAR(200) NOT NULL,
+  `owner_id` VARCHAR(127) NOT NULL,
+  `sort_id` SMALLINT COMMENT '0 = primary owner, order by priority/importance',
+  `app_id` INT COMMENT 'application id of the namesapce',
+  `namespace` VARCHAR(127) COMMENT 'the namespace of the user',
+  `owner_type` VARCHAR(127) COMMENT 'Producer, Consumer, Stakeholder',
+  `owner_sub_type` VARCHAR(127) COMMENT 'DWH, UMP, BA, etc',
+  `owner_id_type` VARCHAR(127) COMMENT 'user, group, service, or urn',
+  `owner_source`  VARCHAR(127) COMMENT 'where the owner info is extracted: JIRA,RB,DB,FS,AUDIT',
+  `is_group` CHAR(1) COMMENT 'if owner is a group',
+  `db_name` VARCHAR(127) COMMENT 'database name',
+  `db_id` INT COMMENT 'database id',
+  `is_active` CHAR(1) COMMENT 'if owner is active',
+  `source_time` INT UNSIGNED COMMENT 'the source event time in epoch',
+  `is_parent_urn` CHAR(1) DEFAULT 'N' COMMENT 'if the urn is a directory for datasets',
+  KEY (dataset_urn, owner_id, namespace, db_name),
+  KEY dataset_index (dataset_urn),
+  KEY db_name_index (db_name)
+);
+
+CREATE TABLE IF NOT EXISTS stg_dataset_owner_unmatched (
+  `dataset_urn` VARCHAR(200) NOT NULL,
+  `owner_id` VARCHAR(127) NOT NULL,
+  `sort_id` SMALLINT COMMENT '0 = primary owner, order by priority/importance',
+  `app_id` INT COMMENT 'application id of the namesapce',
+  `namespace` VARCHAR(127) COMMENT 'the namespace of the user',
+  `owner_type` VARCHAR(127) COMMENT 'Producer, Consumer, Stakeholder',
+  `owner_sub_type` VARCHAR(127) COMMENT 'DWH, UMP, BA, etc',
+  `owner_id_type` VARCHAR(127) COMMENT 'user, group, role, service, or urn',
+  `owner_source`  VARCHAR(127) COMMENT 'where the owner info is extracted: JIRA,RB,DB,FS,AUDIT',
+  `is_group` CHAR(1) COMMENT 'if owner is a group',
+  `db_name` VARCHAR(127) COMMENT 'database name',
+  `db_id` INT COMMENT 'database id',
+  `is_active` CHAR(1) COMMENT 'if owner is active',
+  `source_time` INT UNSIGNED COMMENT 'the source event time in epoch',
+  KEY (dataset_urn, owner_id, namespace, db_name),
+  KEY dataset_index (dataset_urn),
+  KEY db_name_index (db_name)
+);
+
+CREATE TABLE IF NOT EXISTS `dir_external_user_info` (
+  `app_id` smallint(5) unsigned NOT NULL,
+  `user_id` varchar(50) NOT NULL,
+  `urn` varchar(200) DEFAULT NULL,
+  `full_name` varchar(200) DEFAULT NULL,
+  `display_name` varchar(200) DEFAULT NULL,
+  `title` varchar(200) DEFAULT NULL,
+  `employee_number` int(10) unsigned DEFAULT NULL,
+  `manager_urn` varchar(200) DEFAULT NULL,
+  `manager_user_id` varchar(50) DEFAULT NULL,
+  `manager_employee_number` int(10) unsigned DEFAULT NULL,
+  `default_group_name` varchar(100) DEFAULT NULL,
+  `email` varchar(200) DEFAULT NULL,
+  `department_id` int(10) unsigned DEFAULT '0',
+  `department_name` varchar(200) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `mobile_phone` varchar(50) DEFAULT NULL,
+  `is_active` char(1) DEFAULT 'Y',
+  `org_hierarchy` varchar(500) DEFAULT NULL,
+  `org_hierarchy_depth` tinyint(3) unsigned DEFAULT NULL,
+  `created_time` int(10) unsigned DEFAULT NULL COMMENT 'the create time in epoch',
+  `modified_time` int(10) unsigned DEFAULT NULL COMMENT 'the modified time in epoch',
+  `wh_etl_exec_id` bigint(20) DEFAULT NULL COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`user_id`,`app_id`),
+  KEY `email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `dir_external_group_user_map` (
+  `app_id` smallint(5) unsigned NOT NULL,
+  `group_id` varchar(50) NOT NULL,
+  `sort_id` smallint(6) NOT NULL,
+  `user_app_id` smallint(5) unsigned NOT NULL,
+  `user_id` varchar(50) NOT NULL,
+  `created_time` int(10) unsigned DEFAULT NULL COMMENT 'the create time in epoch',
+  `modified_time` int(10) unsigned DEFAULT NULL COMMENT 'the modified time in epoch',
+  `wh_etl_exec_id` bigint(20) DEFAULT NULL COMMENT 'wherehows etl execution id that modified this record',
+  PRIMARY KEY (`app_id`,`group_id`,`user_app_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docker/mysql/ETL_DDL/patterns.sql
+++ b/docker/mysql/ETL_DDL/patterns.sql
@@ -1,0 +1,83 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+
+-- file name pattern to abstract from file level to directory level
+CREATE TABLE IF NOT EXISTS filename_pattern
+(
+  filename_pattern_id INT(11) NOT NULL AUTO_INCREMENT,
+  regex               VARCHAR(100),
+  PRIMARY KEY (filename_pattern_id)
+);
+
+-- partitions pattern to abstract from partition level to dataset level
+CREATE TABLE IF NOT EXISTS `dataset_partition_layout_pattern` (
+  `layout_id`               INT(11) NOT NULL AUTO_INCREMENT,
+  `regex`                   VARCHAR(50)      DEFAULT NULL,
+  `mask`                    VARCHAR(50)      DEFAULT NULL,
+  `leading_path_index`      SMALLINT(6)      DEFAULT NULL,
+  `partition_index`         SMALLINT(6)      DEFAULT NULL,
+  `second_partition_index`  SMALLINT(6)      DEFAULT NULL,
+  `sort_id`                 INT(11)          DEFAULT NULL,
+  `comments`                VARCHAR(200)     DEFAULT NULL,
+  `partition_pattern_group` VARCHAR(50)      DEFAULT NULL,
+  PRIMARY KEY (`layout_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+-- log lineage pattern to extract lineage from logs
+CREATE TABLE IF NOT EXISTS `log_lineage_pattern` (
+  `pattern_id`          INT(11)      NOT NULL AUTO_INCREMENT,
+  `pattern_type`        VARCHAR(20)              DEFAULT NULL
+  COMMENT 'type of job that have this log pattern',
+  `regex`               VARCHAR(200) NOT NULL,
+  `database_type`       VARCHAR(20)              DEFAULT NULL
+  COMMENT 'database type input by user, e.g. hdfs, voldermont...',
+  `database_name_index` INT(11)                  DEFAULT NULL,
+  `dataset_index`       INT(11)      NOT NULL
+  COMMENT 'the group id of dataset part in the regex',
+  `operation_type`      VARCHAR(20)              DEFAULT NULL
+  COMMENT 'read/write, input by user',
+  `record_count_index`  INT(20)                  DEFAULT NULL
+  COMMENT 'all operations count',
+  `record_byte_index`   INT(20)                  DEFAULT NULL,
+  `insert_count_index`  INT(20)                  DEFAULT NULL,
+  `insert_byte_index`   INT(20)                  DEFAULT NULL,
+  `delete_count_index`  INT(20)                  DEFAULT NULL,
+  `delete_byte_index`   INT(20)                  DEFAULT NULL,
+  `update_count_index`  INT(20)                  DEFAULT NULL,
+  `update_byte_index`   INT(20)                  DEFAULT NULL,
+  `comments`            VARCHAR(200)             DEFAULT NULL,
+  `source_target_type`  ENUM('source', 'target') DEFAULT NULL,
+  PRIMARY KEY (`pattern_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+-- patterns used to discover the hadoop id inside log
+CREATE TABLE IF NOT EXISTS `log_reference_job_id_pattern` (
+  `pattern_id`             INT(11)      NOT NULL AUTO_INCREMENT,
+  `pattern_type`           VARCHAR(20)  DEFAULT NULL
+  COMMENT 'type of job that have this log pattern',
+  `regex`                  VARCHAR(200) NOT NULL,
+  `reference_job_id_index` INT(11)      NOT NULL,
+  `is_active`              TINYINT(1)   DEFAULT '0',
+  `comments`               VARCHAR(200) DEFAULT NULL,
+  PRIMARY KEY (`pattern_id`)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+

--- a/docker/mysql/WEB_DDL/track.sql
+++ b/docker/mysql/WEB_DDL/track.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- tracking user access
+CREATE TABLE IF NOT EXISTS track_object_access_log (
+  `access_unixtime` BIGINT(20) UNSIGNED                                                                                                  NOT NULL,
+  `login_id`        INT(10) UNSIGNED                                                                                                     NOT NULL,
+  `object_type`     ENUM('dataset', 'metric', 'glossary', 'flow', 'lineage:data', 'lineage:flow', 'lineage:metric', 'lineage:metricJob') NOT NULL DEFAULT 'dataset',
+  `object_id`       BIGINT(20)                                                                                                           NULL,
+  `object_name`     VARCHAR(500)                                                                                                         NULL,
+  `parameters`      VARCHAR(500)                                                                                                         NULL,
+  PRIMARY KEY (access_unixtime, login_id, object_type)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0

--- a/docker/mysql/WEB_DDL/users.sql
+++ b/docker/mysql/WEB_DDL/users.sql
@@ -1,0 +1,78 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+-- create statement for users related tables :
+-- users, user_settings, watch
+
+CREATE TABLE IF NOT EXISTS users (
+  id                       INT(11) AUTO_INCREMENT      NOT NULL,
+  name                     VARCHAR(100)                NOT NULL,
+  email                    VARCHAR(200)                NOT NULL,
+  username                 VARCHAR(20)                 NOT NULL,
+  department_number        INT(11)                     NULL,
+  password_digest          VARCHAR(256)                NULL,
+  password_digest_type     ENUM('SHA1', 'SHA2', 'MD5') NULL DEFAULT 'SHA1',
+  ext_directory_ref_app_id SMALLINT UNSIGNED,
+  authentication_type      VARCHAR(20),
+  PRIMARY KEY (id)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = utf8;
+
+CREATE INDEX idx_users__username USING BTREE ON users(username);
+
+CREATE TABLE IF NOT EXISTS user_settings (
+  user_id             INT(11)                           NOT NULL,
+  detail_default_view VARCHAR(20)                       NULL,
+  default_watch       ENUM('monthly', 'weekly', 'daily', 'hourly') NULL DEFAULT 'weekly',
+  PRIMARY KEY (user_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS watch (
+  id                BIGINT(20) AUTO_INCREMENT                                 NOT NULL,
+  user_id           INT(11)                                                   NOT NULL,
+  item_id           INT(11)                                                   NULL,
+  urn               VARCHAR(200)                                              NULL,
+  item_type         ENUM('dataset', 'dataset_field', 'metric', 'flow', 'urn') NOT NULL DEFAULT 'dataset',
+  notification_type ENUM('monthly', 'weekly', 'hourly', 'daily')              NULL     DEFAULT 'weekly',
+  created           TIMESTAMP                                                 NULL     DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+)
+  ENGINE = InnoDB
+  AUTO_INCREMENT = 0
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS favorites (
+  user_id    INT(11)   NOT NULL,
+  dataset_id INT(11)   NOT NULL,
+  created    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, dataset_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS user_login_history (
+  log_id              INT(11) AUTO_INCREMENT NOT NULL,
+  username            VARCHAR(20)            NOT NULL,
+  authentication_type VARCHAR(20)            NOT NULL,
+  `status`            VARCHAR(20)            NOT NULL,
+  message             TEXT                            DEFAULT NULL,
+  login_time          TIMESTAMP              NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (log_id)
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;

--- a/docker/mysql/binary/async-init.sh
+++ b/docker/mysql/binary/async-init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Wait for the server to be completely up before initializing it.
+while [ -z "$(mysqladmin --password=$MYSQL_ROOT_PASSWORD ping 2> /dev/null | grep 'alive')" ]; do sleep 1; done
+
+# must be in the right directory so the create tables script finds the files it sources.
+cd /usr/local/wherehows
+
+mysql --password=$MYSQL_ROOT_PASSWORD < /usr/local/wherehows/init.sql &> /var/log/mysql/create-accounts.log
+mysql --password=$MYSQL_ROOT_PASSWORD -hlocalhost -uwherehows -Dwherehows < /usr/local/wherehows/create_all_tables_wrapper.sql &> /var/log/mysql/create-tables.log

--- a/docker/mysql/binary/create_all_tables_wrapper.sql
+++ b/docker/mysql/binary/create_all_tables_wrapper.sql
@@ -1,0 +1,32 @@
+--
+-- Copyright 2015 LinkedIn Corp. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--
+
+/* wrapper sql to call all individual DDL */
+-- use wherehows;
+
+source ETL_DDL/dataset_metadata.sql;
+source ETL_DDL/etl_configure_tables.sql;
+source ETL_DDL/executor_metadata.sql;
+source ETL_DDL/git_metadata.sql;
+source ETL_DDL/lineage_metadata.sql;
+source ETL_DDL/metric_metadata.sql;
+source ETL_DDL/owner_metadata.sql;
+source ETL_DDL/patterns.sql;
+source ETL_DDL/kafka_tracking.sql;
+source ETL_DDL/dataset_info_metadata.sql;
+
+source WEB_DDL/track.sql;
+source WEB_DDL/users.sql;
+
+show tables;

--- a/docker/mysql/binary/init.sql
+++ b/docker/mysql/binary/init.sql
@@ -1,0 +1,20 @@
+
+-- note that this may be resuming from a previous run, only do commands if things do not already exist.
+CREATE DATABASE IF NOT EXISTS wherehows
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
+
+CREATE USER IF NOT EXISTS 'wherehows'@'localhost' IDENTIFIED BY 'wherehows';
+CREATE USER IF NOT EXISTS 'wherehows'@'%' IDENTIFIED BY 'wherehows';
+
+CREATE USER IF NOT EXISTS 'wherehows_ro'@'localhost' IDENTIFIED BY 'readmetadata';
+CREATE USER IF NOT EXISTS 'wherehows_ro'@'%' IDENTIFIED BY 'readmetadata';
+
+FLUSH PRIVILEGES;
+
+GRANT ALL ON wherehows.* TO 'wherehows'@'localhost';
+GRANT ALL ON wherehows.* TO 'wherehows'@'%';
+GRANT SELECT ON wherehows.* TO 'wherehows_ro'@'localhost';
+GRANT SELECT ON wherehows.* TO 'wherehows_ro'@'%';
+
+FLUSH PRIVILEGES;

--- a/docker/mysql/binary/run-for-wherehows.sh
+++ b/docker/mysql/binary/run-for-wherehows.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+  echo "You must set MYSQL_ROOT_PASSWORD"
+  exit
+fi
+
+ARG="$@"
+if [ -z "$ARG" ]; then
+  echo "No default argument was provided, using mysqld"
+  ARG='mysqld'
+fi
+
+./usr/local/bin/async-init.sh &
+
+# run the normal start up.
+# note that mysqld is the default argument, provided by the original docker image.
+./entrypoint.sh $ARG | tee /var/log/mysql/entrypoint.log

--- a/docker/mysql/build-docker.sh
+++ b/docker/mysql/build-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  VERSION=1
+fi
+
+docker build -t wherehows/mysql-wherehows:$VERSION .

--- a/docker/mysql/copy-ddl.sh
+++ b/docker/mysql/copy-ddl.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copies over the ddl files
+
+if [ -z "$WORKSPACE" ]; then
+  echo "You must set the WORKSPACE environment variable for this to work."
+  exit
+fi
+
+rm -rf *_DDL
+rm bin/create_all_tables_wrapper.sql
+
+DDL_DIR=$WORKSPACE/WhereHows/data-model/DDL
+cp $DDL_DIR/create_all_tables_wrapper.sql bin
+cp -r $DDL_DIR/*_DDL .
+
+# Unfortunately these scripts may be executed multiple times.
+# The data directory is mounted as a volume, meaning that these scripts could run twice for the 
+# same directory.  Change schema to just create tables if they do not already exist.
+sed -i "" -e "s/CREATE TABLE/CREATE TABLE IF NOT EXISTS/g" *_DDL/*
+
+# In some places we just doubled up on IF NOT EXISTS
+sed -i "" -e "s/IF NOT EXISTS IF NOT EXISTS/IF NOT EXISTS/g" *_DDL/*
+

--- a/docker/mysql/run-base.sh
+++ b/docker/mysql/run-base.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -e MYSQL_ROOT_PASSWORD=wherehows mysql:8.0.0 

--- a/docker/mysql/run-mysql-wherehows-docker.sh
+++ b/docker/mysql/run-mysql-wherehows-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  VERSION=1
+fi
+
+docker run --name mysql-wherehows -d -e MYSQL_ROOT_PASSWORD=wherehows -p 3306:3306 wherehows/mysql-wherehows:$VERSION

--- a/docker/mysql/run-root.sh
+++ b/docker/mysql/run-root.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  VERSION=1
+fi
+
+docker run -it -e MYSQL_ROOT_PASSWORD=wherehows -p 3306:3306 --entrypoint /bin/bash wherehows/mysql-wherehows:$VERSION

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.10
+
+RUN mkdir /application;
+
+WORKDIR /application
+
+ADD archives/jdk-8u101-linux-x64.tar.gz /application
+ADD archives/web.tar.gz /application
+
+RUN ln -s jdk1.8.0_101 jdk8;
+
+WORKDIR /application/wherehows
+
+ENV JAVA_HOME=/application/jdk8; \
+    PATH=/application/jdk8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+CMD bin/wherehows

--- a/prepare-docker-archives.sh
+++ b/prepare-docker-archives.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# assumption: docker is already installed
+
+# ensure the SBT opts are sufficient so the application will build
+if [ -z "SBT_OPTS" ]; then
+  export SBT_OPTS='-Xms1G -Xmx1G -Xss2M'
+fi
+
+if [ -d "web/target" ]; then
+  # sometimes this directory causes problems if it exists when the build starts.
+  rm -rf web/target
+fi
+
+# build the application's distribution zip
+./gradlew dist
+
+# move those to a directory where we will work on them more.
+mv backend-service/target/universal/*.zip docker/archive-factory/originals/backend.zip
+mv web/target/universal/*.zip docker/archive-factory/originals/web.zip
+
+cd docker/archive-factory
+
+# unfortunately those zip files are not quite what we want to start with in docker,
+# run these other scripts that will revise them.
+./build-backend.sh
+./build-web.sh
+
+# build the docker images
+cd ../mysql
+docker build -t wherehows/mysql .
+cd ../backend-service
+docker build -t wherehows/backend .
+cd ../web
+docker build -t wherehows/web .
+
+cd ..
+echo "now run this to start the application:"
+echo "docker-compose up"
+echo "you may need to edit the .env file first."


### PR DESCRIPTION
This is my second attempt at dockerizing WhereHows.  This time I used distributable archives in the docker images.  I also separated the backend-service and web docker images so people can deploy/scale/manage them separately.  I wrote a docker-compose file that launches all three applications simultaneously.  

This may not be suitable for every way people may run WhereHows, but it should at least be a good starting point.  It should make it much easier for people to start running WhereHows and experimenting with it.  People can extend the docker images and customize them as well.

See docker/README.md to understand how to use this.

Users will also need to copy the jdk to appropriate directories.  Please place "jdk-8u101-linux-x64.tar.gz" in docker/backend-service/archives and docker/web-archives before you build docker images, before you run "prepare-docker-archives.sh".  These archives are ignored by git but required for the docker build to work.

Please note that before you run "prepare-docker-archives.sh" make sure you have docker installed and the user is a member of the "docker" group or is the root user.  If you just add a user to the "docker" group, they may need to log out/in again before that is recognized.  

Also one known problem I still have is with mysql volumes.  We want the data to be persistent but I have been struggling to get the volume mount to work.  I'm not sure why but I think we can fix it in a follow up.

I may not have much time to support this in the future (I'm doing this on my own personal time), beyond answering questions.  If you find only small problems, but you think you could fix them, then please accept the commit.
