### PR TITLE
Fix Kerberos authentication so that HIVE_DATASET_METADATA_ETL jobs can run in non-grid cluster

### DIFF
--- a/metadata-etl/src/main/java/metadata/etl/dataset/hive/HiveMetadataEtl.java
+++ b/metadata-etl/src/main/java/metadata/etl/dataset/hive/HiveMetadataEtl.java
@@ -16,6 +16,7 @@ package metadata.etl.dataset.hive;
 import java.io.InputStream;
 import java.util.Properties;
 import metadata.etl.EtlJob;
+import wherehows.common.Constant;
 
 
 /**
@@ -37,6 +38,10 @@ public class HiveMetadataEtl extends EtlJob {
   public void extract()
     throws Exception {
     logger.info("In Hive metadata ETL, launch extract jython scripts");
+
+    System.setProperty("java.security.krb5.realm", prop.getProperty(Constant.KRB5_REALM));
+    System.setProperty("java.security.krb5.kdc", prop.getProperty(Constant.KRB5_KDC));
+
     InputStream inputStream = classLoader.getResourceAsStream("jython/HiveExtract.py");
     //logger.info("before call scripts " + interpreter.getSystemState().argv);
     interpreter.execfile(inputStream);

--- a/metadata-etl/src/main/java/metadata/etl/lineage/HadoopJobHistoryNodeExtractor.java
+++ b/metadata-etl/src/main/java/metadata/etl/lineage/HadoopJobHistoryNodeExtractor.java
@@ -83,8 +83,8 @@ public class HadoopJobHistoryNodeExtractor {
     }
     System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
 
-    System.setProperty("java.security.krb5.realm", prop.getProperty("krb5.realm"));
-    System.setProperty("java.security.krb5.kdc", prop.getProperty("krb5.kdc"));
+    System.setProperty("java.security.krb5.realm", prop.getProperty(Constant.KRB5_REALM));
+    System.setProperty("java.security.krb5.kdc", prop.getProperty(Constant.KRB5_KDC));
 
     PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
     cm.setMaxTotal(200);

--- a/metadata-etl/src/main/resources/jython/HiveExtract.py
+++ b/metadata-etl/src/main/resources/jython/HiveExtract.py
@@ -332,6 +332,7 @@ class HiveExtract:
         kerberos_auth = False
       else:
         kerberos_auth = True
+
     self.schema_url_helper = SchemaUrlHelper.SchemaUrlHelper(hdfs_namenode_ipc_uri, kerberos_auth, kerberos_principal, keytab_file)
 
     for database_name in self.databases:
@@ -520,15 +521,19 @@ if __name__ == "__main__":
   e = HiveExtract()
   e.conn_hms = zxJDBC.connect(jdbc_url, username, password, jdbc_driver)
 
+  keytab_file = args[Constant.KERBEROS_KEYTAB_FILE_KEY]
+  krb5_dir = os.getenv("WHZ_KRB5_DIR")
+  if keytab_file and krb5_dir:
+    keytab_file = os.path.join(krb5_dir, keytab_file)
+
   try:
     e.databases = e.get_all_databases(database_white_list, database_black_list)
-    e.run(args[Constant.HIVE_SCHEMA_JSON_FILE_KEY], \
-          None, \
-          args[Constant.HIVE_HDFS_MAP_CSV_FILE_KEY], \
-          args[Constant.HDFS_NAMENODE_IPC_URI_KEY], \
-          args[Constant.KERBEROS_AUTH_KEY], \
-          args[Constant.KERBEROS_PRINCIPAL_KEY], \
-          args[Constant.KERBEROS_KEYTAB_FILE_KEY]
-          )
+    e.run(args[Constant.HIVE_SCHEMA_JSON_FILE_KEY],
+          None,
+          args[Constant.HIVE_HDFS_MAP_CSV_FILE_KEY],
+          args[Constant.HDFS_NAMENODE_IPC_URI_KEY],
+          args[Constant.KERBEROS_AUTH_KEY],
+          args[Constant.KERBEROS_PRINCIPAL_KEY],
+          keytab_file)
   finally:
     e.conn_hms.close()

--- a/wherehows-common/src/main/java/wherehows/common/Constant.java
+++ b/wherehows-common/src/main/java/wherehows/common/Constant.java
@@ -254,4 +254,8 @@ public class Constant {
 
   // metadata-store restli server
   public static final String WH_RESTLI_SERVER_URL = "wherehows.restli.server.url";
+
+  // kerberos
+  public static final String KRB5_REALM = "krb5.realm";
+  public static final String KRB5_KDC = "krb5.kdc";
 }


### PR DESCRIPTION
This requires setting the additional krb5.kdc & krb5.realm job properties.