### PR TITLE
Fix url encoding for Dataset url.

### DIFF
--- a/web/app/dao/DatasetsDAO.java
+++ b/web/app/dao/DatasetsDAO.java
@@ -26,6 +26,8 @@ import java.text.SimpleDateFormat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.codec.EncoderException;
+import org.apache.commons.codec.net.URLCodec;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -1997,7 +1999,15 @@ public class DatasetsDAO extends AbstractMySQLOpenSourceDAO
 			}
 			else
 			{
-				node.nodeUrl = "#/datasets/name/" + node.nodeName + "/page/1?urn=" + nodeUrn;
+				try {
+					URLCodec codec = new URLCodec("UTF-8");
+					node.nodeUrl =
+							"#/datasets/name/" + codec.encode(node.nodeName) + "/page/1?urn=" + codec.encode(nodeUrn);
+				} catch (EncoderException e) {
+					Logger.error("Dataset url encoding failed");
+					Logger.error("Exception = " + e.getMessage());
+				}
+
 			}
 			nodes.add(node);
 		}


### PR DESCRIPTION
I found a small bug on the web module. It's missing encoding for Dataset urls.

![wherehows](https://cloud.githubusercontent.com/assets/6133458/25835022/980e8848-34b6-11e7-8084-b727cf830cd2.png)

![wherehows](https://cloud.githubusercontent.com/assets/6133458/25835212/dd1d6f5c-34b7-11e7-82cd-24f4afe97263.png)

---

Fixed version.

![wherehows](https://cloud.githubusercontent.com/assets/6133458/25835168/947f91b2-34b7-11e7-9f85-512fd879ff5f.png)

