### PR TITLE
Fix KeyError: static_boosting_score

### DIFF
--- a/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/metadata-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -148,7 +148,14 @@ class ElasticSearchIndex():
   def update_dataset(self, last_unixtime=None):
     if last_unixtime:
         sql = """
-          SELECT * FROM dict_dataset WHERE from_unixtime(modified_time) >= DATE_SUB(from_unixtime(%f), INTERVAL 1 HOUR)
+          SELECT d.*,
+              COALESCE(s.static_boosting_score,1) as static_boosting_score
+          FROM dict_dataset d
+          LEFT JOIN cfg_search_score_boost s
+          ON d.id = s.id
+          WHERE d.urn not like "hive:///dev_foundation_tables%%"
+          and d.urn not like "hive:///dev_foundation_views%%"
+          and from_unixtime(d.modified_time) >= DATE_SUB(from_unixtime(%f), INTERVAL 1 HOUR)
           """ % last_unixtime
     else:
         sql = """


### PR DESCRIPTION
I got a following exception when use Elasticsearch.

`KeyError: static_boosting_score`

```
[ERROR] [05/15/2017 06:21:33.455] [WhereHowsETLService-akka.actor.default-dispatcher-65] [akka://WhereHowsETLService/user/TreeBuilderActor] null
Traceback (most recent call last):
  File "<iostream>", line 95, in <module>
  File "<iostream>", line 90, in saveTreeInElasticSearchIfApplicable
  File "__pyclasspath__/jython/ElasticSearchIndex.py", line 223, in update_dataset
KeyError: static_boosting_score

  at org.python.core.Py.KeyError(Py.java:249)
  at org.python.core.PyObject.__getitem__(PyObject.java:738)
  at jython.ElasticSearchIndex$py.update_dataset$7(__pyclasspath__/jython/ElasticSearchIndex.py:248)
  at jython.ElasticSearchIndex$py.call_function(__pyclasspath__/jython/ElasticSearchIndex.py)
  at org.python.core.PyTableCode.call(PyTableCode.java:167)
  at org.python.core.PyBaseCode.call(PyBaseCode.java:153)
  at org.python.core.PyFunction.__call__(PyFunction.java:423)
  at org.python.core.PyMethod.__call__(PyMethod.java:141)
  at org.python.pycode._pyx132.saveTreeInElasticSearchIfApplicable$7(<iostream>:90)
  at org.python.pycode._pyx132.call_function(<iostream>)
  at org.python.core.PyTableCode.call(PyTableCode.java:167)
  at org.python.core.PyBaseCode.call(PyBaseCode.java:138)
  at org.python.core.PyFunction.__call__(PyFunction.java:413)
  at org.python.pycode._pyx132.f$0(<iostream>:95)
  at org.python.pycode._pyx132.call_function(<iostream>)
  at org.python.core.PyTableCode.call(PyTableCode.java:167)
  at org.python.core.PyCode.call(PyCode.java:18)
  at org.python.core.Py.runCode(Py.java:1386)
  at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:296)
  at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:291)
  at actors.TreeBuilderActor.onReceive(TreeBuilderActor.java:62)
  at akka.actor.UntypedActor$$anonfun$receive$1.applyOrElse(UntypedActor.scala:167)
  at akka.actor.Actor$class.aroundReceive(Actor.scala:467)
  at akka.actor.UntypedActor.aroundReceive(UntypedActor.scala:97)
  at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516)
  at akka.actor.ActorCell.invoke(ActorCell.scala:487)
  at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:238)
  at akka.dispatch.Mailbox.run(Mailbox.scala:220)
  at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
  at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
  at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
  at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
  at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```
