### PR TITLE
Call the correct method to create connection instead of buliding the …

### DIFF
--- a/wherehows-etl/src/main/java/metadata/etl/lineage/AzLineageMetadataEtl.java
+++ b/wherehows-etl/src/main/java/metadata/etl/lineage/AzLineageMetadataEtl.java
@@ -65,11 +65,10 @@ public class AzLineageMetadataEtl extends EtlJob {
 
   public void setUp()
     throws SQLException {
-    String wherehowsHost = this.prop.getProperty(Constant.WH_DB_URL_KEY);
+    String wherehowsUrl = this.prop.getProperty(Constant.WH_DB_URL_KEY);
     String wherehowsUserName = this.prop.getProperty(Constant.WH_DB_USERNAME_KEY);
     String wherehowsPassWord = this.prop.getProperty(Constant.WH_DB_PASSWORD_KEY);
-    conn =
-      DriverManager.getConnection(wherehowsHost + "?" + "user=" + wherehowsUserName + "&password=" + wherehowsPassWord);
+    conn = DriverManager.getConnection(wherehowsUrl, wherehowsUserName, wherehowsPassWord);
   }
 
   @Override


### PR DESCRIPTION
…connection string manually.