### PR TITLE
Do not automatically kick off all jobs that yet have an entry in wh_etl_job_schedule table.

### DIFF
--- a/wherehows-backend/app/actors/ActorRegistry.java
+++ b/wherehows-backend/app/actors/ActorRegistry.java
@@ -18,6 +18,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.actor.Scheduler;
 import akka.routing.SmallestMailboxPool;
+import play.Play;
 import scala.concurrent.ExecutionContext;
 
 
@@ -25,6 +26,9 @@ import scala.concurrent.ExecutionContext;
  * Created by zechen on 9/4/15.
  */
 public class ActorRegistry {
+
+  private static final int ETL_POOL_SIZE = Play.application().configuration().getInt("etl.max.concurrent.jobs");
+
   private static ActorSystem actorSystem = ActorSystem.create("WhereHowsETLService");
 
   public static ExecutionContext dispatcher = actorSystem.dispatcher();
@@ -34,9 +38,10 @@ public class ActorRegistry {
   public static ActorRef schedulerActor = actorSystem.actorOf(Props.create(SchedulerActor.class), "SchedulerActor");
 
   public static ActorRef etlJobActor =
-      actorSystem.actorOf(new SmallestMailboxPool(10).props(Props.create(EtlJobActor.class)), "EtlJobActor");
+      actorSystem.actorOf(new SmallestMailboxPool(ETL_POOL_SIZE).props(Props.create(EtlJobActor.class)), "EtlJobActor");
 
-  public static ActorRef treeBuilderActor = actorSystem.actorOf(Props.create(TreeBuilderActor.class), "TreeBuilderActor");
+  public static ActorRef treeBuilderActor =
+      actorSystem.actorOf(Props.create(TreeBuilderActor.class), "TreeBuilderActor");
 
   public static ActorRef kafkaConsumerMaster =
       actorSystem.actorOf(Props.create(KafkaConsumerMaster.class), "KafkaMaster");

--- a/wherehows-backend/app/actors/SchedulerActor.java
+++ b/wherehows-backend/app/actors/SchedulerActor.java
@@ -66,11 +66,6 @@ public class SchedulerActor extends UntypedActor {
     long now = System.currentTimeMillis() / 1000;
     for (Map.Entry<String, Properties> entry : enabledJobs.entrySet()) {
       String etlJobName = entry.getKey();
-      if (scheduledJobs.getOrDefault(etlJobName, 0L) > now) {
-        continue;
-      }
-
-      Logger.info("Running job: {}", etlJobName);
       Properties properties = entry.getValue();
       EtlJobMessage etlMsg = new EtlJobMessage(etlJobName, properties);
 
@@ -79,6 +74,12 @@ public class SchedulerActor extends UntypedActor {
       if (cronExpr != null) {
         EtlJobDao.updateNextRun(etlMsg.getEtlJobName(), cronExpr, new Date());
       }
+
+      if (scheduledJobs.getOrDefault(etlJobName, Long.MAX_VALUE) > now) {
+        continue;
+      }
+
+      Logger.info("Running job: {}", etlJobName);
 
       Long whExecId = EtlJobDao.insertNewRun(etlJobName);
       etlMsg.setWhEtlExecId(whExecId);

--- a/wherehows-backend/conf/application.conf
+++ b/wherehows-backend/conf/application.conf
@@ -64,3 +64,4 @@ scheduler.check.interval = 5
 
 etl.jobs.dir = ${WHZ_ETL_JOBS_DIR}
 etl.temp.dir = ${WHZ_ETL_TEMP_DIR}
+etl.max.concurrent.jobs = 2


### PR DESCRIPTION
Instead simply schedule an entry and wait for its time to come.