### PR TITLE
Fix DBstring Util to handle Java Boolean type

### DIFF
--- a/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
+++ b/wherehows-common/src/main/java/wherehows/common/utils/StringUtil.java
@@ -27,11 +27,13 @@ import wherehows.common.schemas.Record;
 public class StringUtil {
 
   public static String toDbString(Object object) {
-    if (object != null) {
-      return "'" + object.toString().replace("\\", "\\\\").replace("\'", "\\\'").replace("\"", "\\\"") + "'";
-    } else {
+    if (object == null) {
       return "null";
     }
+    if (object instanceof Boolean) {
+      return (Boolean) object ? "true" : "false";
+    }
+    return "'" + object.toString().replace("\\", "\\\\").replace("\'", "\\\'").replace("\"", "\\\"") + "'";
   }
 
   public static String toCsvString(Object object) {


### PR DESCRIPTION
Temporary fix on legacy code. Tested on one kafka message.
Should not manually generate string for saving to DB at the first place. 