### PR TITLE
fix: fix bug that hive etl cannot load utf8 encoded comments

### DIFF
--- a/wherehows-data-model/DDL/ETL_DDL/dataset_metadata.sql
+++ b/wherehows-data-model/DDL/ETL_DDL/dataset_metadata.sql
@@ -151,7 +151,7 @@ CREATE TABLE `stg_dict_field_detail` (
   PRIMARY KEY (`urn`, `sort_id`, `db_id`)
 )
   ENGINE = InnoDB
-  DEFAULT CHARSET = latin1
+  DEFAULT CHARSET = utf8
   PARTITION BY HASH(db_id)
   PARTITIONS 8;
 

--- a/wherehows-etl/src/main/resources/jython/HiveLoad.py
+++ b/wherehows-etl/src/main/resources/jython/HiveLoad.py
@@ -111,6 +111,7 @@ class HiveLoad:
 
         LOAD DATA LOCAL INFILE '{source_file}'
         INTO TABLE stg_dict_field_detail
+        CHARACTER SET utf8
         FIELDS TERMINATED BY '\Z'
         (urn, sort_id, parent_sort_id, parent_path, field_name, data_type,
          @is_nullable, @default_value, @data_size, @namespace, @description)


### PR DESCRIPTION
Cannot load non-english comments from hive because `stg_dict_field_detail` is not encoded in utf8. Not sure this change is suitable for you.