### PR TITLE
introduce customized analyzer for wherehows es index

### DIFF
--- a/wherehows-data-model/ELASTICSEARCH/index_mapping.json
+++ b/wherehows-data-model/ELASTICSEARCH/index_mapping.json
@@ -1,4 +1,17 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "keyword_analyzer": {
+          "type": "custom",
+          "tokenizer": "keyword",
+          "filter": [
+            "lowercase"
+          ]
+        }
+      }
+    }
+  },
   "mappings": {
     "metric": {
       "properties": {
@@ -81,7 +94,7 @@
         "tags": {
           "type": "string"
         },
-        "urn": {
+        "metric_urn": {
           "type": "string"
         },
         "wiki_url": {
@@ -120,7 +133,8 @@
           "type": "string"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "analyzer": "keyword_analyzer"
         },
         "name_suggest": {
           "type": "completion",
@@ -145,7 +159,8 @@
           "type": "long"
         },
         "urn": {
-          "type": "string"
+          "type": "string",
+          "analyzer": "keyword_analyzer"
         }
       }
     },


### PR DESCRIPTION
Introduced customized keyword analyzer 
- To support URN search
- Less irrelevant Name field search result. 
- If Name field still uses standard analyzer, URN search score is always lower 
- If both use not_analyzed, we lose scoring 
- If making other fields such as schema/properties using keyword analyzer, then query performs drops 10X more
- The keyword analyzer basically make search non-case sensitive, but do not tokenize as much as standard analyzer
