### PR TITLE
 adds explicit flags on compliance component for compliance policy and

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.js
+++ b/wherehows-web/app/components/dataset-compliance.js
@@ -739,10 +739,10 @@ export default Component.extend({
     },
 
     /**
-     * Sets the flag to show all member potential member data fields that may be contained in this dataset
+     * Toggles the flag to show all member potential member data fields that may be contained in this dataset
      */
     onShowAllDatasetMemberData() {
-      return set(this, 'showAllDatasetMemberData', true);
+      return this.toggleProperty('showAllDatasetMemberData');
     },
 
     /**

--- a/wherehows-web/app/components/dataset-compliance.js
+++ b/wherehows-web/app/components/dataset-compliance.js
@@ -100,6 +100,8 @@ export default Component.extend({
   helpText,
   fieldIdentifierOptions,
   hiddenTrackingFields: hiddenTrackingFieldsMsg,
+  isEditingDatasetClassification: false,
+  isEditingCompliancePolicy: false,
   classNames: ['compliance-container'],
   classNameBindings: ['isEditing:compliance-container--edit-mode'],
   /**
@@ -195,6 +197,7 @@ export default Component.extend({
 
   didReceiveAttrs() {
     this._super(...Array.from(arguments));
+    this.resetEdit();
     // Perform validation step on the received component attributes
     this.validateAttrs();
   },
@@ -269,6 +272,14 @@ export default Component.extend({
   },
 
   /**
+   * Resets the editable state of the component, defaults to state returned in isEditing,
+   * currently driven by `isNewComplianceInfo` flag
+   */
+  resetEdit() {
+    return setProperties(this, { isEditingCompliancePolicy: false, isEditingDatasetClassification: false });
+  },
+
+  /**
    * Ensure that props received from on this component
    * are valid, otherwise flag
    */
@@ -337,10 +348,21 @@ export default Component.extend({
   }),
 
   /**
+   * Checks if any of the attributes on the dataset classification is false
+   * @type {Ember.ComputedProperty}
+   * @return {boolean}
+   */
+  excludesSomeMemberData: computed(datasetClassificationKey, function() {
+    const sourceDatasetClassification = get(this, datasetClassificationKey) || {};
+
+    return Object.values(sourceDatasetClassification).some(hasMemberData => !hasMemberData);
+  }),
+
+  /**
    * Determines if all member data fields should be shown in the member data table i.e. show only fields contained in
    * this dataset or otherwise
    */
-  isShowingAllMemberData: computed.or('showAllDatasetMemberData', 'isEditing'),
+  shouldShowAllMemberData: computed.or('showAllDatasetMemberData', 'isEditing'),
 
   /**
    * Determines if the save feature is allowed for the current dataset, otherwise e.g. interface should be disabled
@@ -430,8 +452,7 @@ export default Component.extend({
    * @type {Ember.computed}
    */
   columnIdFieldsToCurrentPrivacyPolicy: computed(
-    'truncatedColumnFields',
-    `${policyComplianceEntitiesKey}.[]`,
+    `{truncatedColumnFields,${policyComplianceEntitiesKey}.[]}`,
     function() {
       // Truncated list of Dataset field names and data types currently returned from the column endpoint
       const columnFieldProps = get(this, 'truncatedColumnFields').map(({ fieldName, dataType }) => ({

--- a/wherehows-web/app/styles/components/dataset-compliance/_compliance-container.scss
+++ b/wherehows-web/app/styles/components/dataset-compliance/_compliance-container.scss
@@ -22,6 +22,14 @@
     align-items: center;
     justify-content: flex-end;
   }
+
+  &__empty#{&}__empty#{&}__empty {
+    background-color: transparent;
+
+    td {
+      border: 0;
+    }
+  }
 }
 
 /// Default visual state for dataset-field-value selector

--- a/wherehows-web/app/styles/components/dataset-compliance/_compliance-table.scss
+++ b/wherehows-web/app/styles/components/dataset-compliance/_compliance-table.scss
@@ -11,7 +11,7 @@
   }
 
   &__classification-column {
-    width: 17%;
+    width: 20%;
   }
 
   &__tall-cell#{&}__tall-cell {

--- a/wherehows-web/app/styles/components/nacho/_nacho-select.scss
+++ b/wherehows-web/app/styles/components/nacho/_nacho-select.scss
@@ -67,4 +67,17 @@ $default-border: (1px solid shade($color, 20%));
       visibility: hidden;
     }
   }
+
+  &--pre-wrap {
+    height: item-spacing(7);
+
+    &::after {
+      margin-bottom: 15px;
+    }
+
+    select {
+      white-space: pre-wrap;
+      margin-bottom: 15px;
+    }
+  }
 }

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
@@ -42,7 +42,7 @@
   {{/table.head}}
 
   {{#table.body as |body|}}
-    {{#each (if isShowingAllMemberData table.data (filter-by "value" true table.data)) as |classification|}}
+    {{#each (if shouldShowAllMemberData table.data (filter-by "value" true table.data)) as |classification|}}
       {{#body.row as |row|}}
         {{#row.cell class="dataset-field-content__prompt"}}
           <span class="dataset-tag-container">
@@ -108,22 +108,26 @@
     {{/each}}
   {{/table.body}}
 
-  {{#table.foot}}
-    <td colspan="2" class="text-center">
-      <button
-        {{action "onShowAllDatasetMemberData"}}
-        class="nacho-button--large nacho-button--tertiary">
-        {{#if isShowingAllMemberData}}
+  {{#if (and excludesSomeMemberData (not isEditing))}}
 
-          See Less <span class="fa fa-caret-up" aria-label="See Less Dataset Member Data"></span>
+    {{#table.foot}}
+      <td colspan="2" class="text-center">
+        <button
+          {{action "onShowAllDatasetMemberData"}}
+          class="nacho-button--large nacho-button--tertiary">
+          {{#if shouldShowAllMemberData}}
 
-        {{else}}
+            See Less <span class="fa fa-caret-up" aria-label="See Less Dataset Member Data"></span>
 
-          See More <span class="fa fa-caret-down" aria-label="See More Dataset Member Data"></span>
+          {{else}}
 
-        {{/if}}
-      </button>
-    </td>
-  {{/table.foot}}
+            See More <span class="fa fa-caret-down" aria-label="See More Dataset Member Data"></span>
+
+          {{/if}}
+        </button>
+      </td>
+    {{/table.foot}}
+
+  {{/if}}
 
 {{/dataset-table}}

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
@@ -94,6 +94,17 @@
             {{/radio-button-composer}}
           </span>{{/row.cell}}
       {{/body.row}}
+    {{else}}
+
+      <tr class="dataset-field-content__empty dataset-field-content__empty dataset-field-content__empty">
+        <td class="text-center" colspan="2">
+          {{empty-state
+            heading="Dataset has not been marked as containing Member data"
+            subHead="Click 'See More' below to view all available types of dataset member data"
+          }}
+        </td>
+      </tr>
+
     {{/each}}
   {{/table.body}}
 

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
@@ -108,16 +108,22 @@
     {{/each}}
   {{/table.body}}
 
-  {{#unless isShowingAllMemberData}}
-    {{#table.foot}}
-      <td colspan="2" class="text-center">
-        <button
-          {{action "onShowAllDatasetMemberData"}}
-          class="nacho-button--large nacho-button--tertiary">
-          See More <span class="caret" aria-label="See More Dataset Member Data"></span>
-        </button>
-      </td>
-    {{/table.foot}}
-  {{/unless}}
+  {{#table.foot}}
+    <td colspan="2" class="text-center">
+      <button
+        {{action "onShowAllDatasetMemberData"}}
+        class="nacho-button--large nacho-button--tertiary">
+        {{#if isShowingAllMemberData}}
+
+          See Less <span class="fa fa-caret-up" aria-label="See Less Dataset Member Data"></span>
+
+        {{else}}
+
+          See More <span class="fa fa-caret-down" aria-label="See More Dataset Member Data"></span>
+
+        {{/if}}
+      </button>
+    </td>
+  {{/table.foot}}
 
 {{/dataset-table}}

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
@@ -189,9 +189,9 @@
             {{/if}}
           {{/row.cell}}
 
-          {{#row.cell}}
+          {{#row.cell class="dataset-compliance-fields__tall-cell dataset-compliance-fields__tall-cell"}}
             {{ember-selector
-              class="nacho-select--hidden-state"
+              class="nacho-select--hidden-state nacho-select--pre-wrap"
               values=classifiers
               selected=row.classification
               disabled=(or (not isEditing) (not row.logicalType))


### PR DESCRIPTION
dataset classification edit modes. adds reset edit mode function to reset the aforementioned flags to initial state of false. renames isShowingAllMemberData to shouldShowAllMemberData. hides seeMore/Less button in edit mode. adds derived indicator value for datasets marked as excluding member data
adds the option to view less dataset level fields
adds empty state for dataset level fields. increases classification column width and creates --pre-wrap modifier for select component to wrap text.