### PR TITLE
modify elastic search ETL to adapt to newly set up es server and vers…

### DIFF
--- a/wherehows-common/src/main/java/wherehows/common/Constant.java
+++ b/wherehows-common/src/main/java/wherehows/common/Constant.java
@@ -276,4 +276,9 @@ public class Constant {
   public static final String KAFKA_CONSUMER_TOPIC_KEY = "kafka.consumer.topic";
   public static final String KAFKA_PRODUCER_TOPIC_KEY = "kafka.producer.topic";
   public static final String KAFKA_PROCESSOR_KEY = "kafka.processor";
+
+  // add more configuration settings for elastic search ETL
+  public static final String ELASTICSEARCH_BULK_INSERT_SIZE = "elasticsearch.bulk.insert.size";
+  public static final String ELASTICSEARCH_URL_REQUEST_TIMEOUT = "elasticsearch.url.request.timeout";
+  public static final String WH_DB_MAX_RETRY_TIMES = "wh.db.max.retry.times";
 }

--- a/wherehows-etl/src/main/resources/jython/ElasticSearchIndex.py
+++ b/wherehows-etl/src/main/resources/jython/ElasticSearchIndex.py
@@ -17,137 +17,165 @@ from com.ziclix.python.sql import zxJDBC
 from org.slf4j import LoggerFactory
 import sys, json
 import urllib2
+import time
 
 
 class ElasticSearchIndex():
-  def __init__(self, args):
-    self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
-    self.elasticsearch_index_url = args[Constant.ELASTICSEARCH_URL_KEY]
-    self.elasticsearch_port = args[Constant.ELASTICSEARCH_PORT_KEY]
+    def __init__(self, args):
+        self.logger = LoggerFactory.getLogger('jython script : ' + self.__class__.__name__)
+        self.elasticsearch_index_url = args[Constant.ELASTICSEARCH_URL_KEY]
+        self.elasticsearch_port = args[Constant.ELASTICSEARCH_PORT_KEY]
 
-    if Constant.ELASTICSEARCH_INDEX_KEY not in args:
-        self.elasticsearch_index = "wherehows"
-    else:
-        self.elasticsearch_index = args[Constant.ELASTICSEARCH_INDEX_KEY]
+        if Constant.ELASTICSEARCH_INDEX_KEY not in args:
+            self.elasticsearch_index = "wherehows"
+        else:
+            self.elasticsearch_index = args[Constant.ELASTICSEARCH_INDEX_KEY]
 
+        self.bulk_chunk_size = int(args[Constant.ELASTICSEARCH_BULK_INSERT_SIZE]) # bulk insert size to elastic search engine
+        self.es_url_request_timeout = int(args[Constant.ELASTICSEARCH_URL_REQUEST_TIMEOUT]) # url to post data to elastic search engine request time out
+        self.max_retry_times = int(args[Constant.WH_DB_MAX_RETRY_TIMES]) # max times for db re-connection when lost during fetching source data
 
-    self.wh_con = zxJDBC.connect(args[Constant.WH_DB_URL_KEY],
-                                 args[Constant.WH_DB_USERNAME_KEY],
-                                 args[Constant.WH_DB_PASSWORD_KEY],
-                                 args[Constant.WH_DB_DRIVER_KEY])
-    self.wh_cursor = self.wh_con.cursor(1)
+        self.databaseConnect(args)
 
-  def bulk_insert(self, params, url):
-    try:
-      req = urllib2.Request(url=url)
-      req.add_header('Content-type', 'application/json')
-      req.get_method = lambda: "PUT"
-      req.add_data('\n'.join(params) + '\n')
-      self.logger.info(url)
-      response = urllib2.urlopen(req)
-      data = json.load(response)
-      if str(data['errors']) != 'False':
-        self.logger.info(str(data))
-    except urllib2.HTTPError as e:
-      self.logger.error(str(e.code))
-      self.logger.error(e.read())
+    def databaseConnect(self, args):
+        self.wh_con = zxJDBC.connect(args[Constant.WH_DB_URL_KEY],
+                                     args[Constant.WH_DB_USERNAME_KEY],
+                                     args[Constant.WH_DB_PASSWORD_KEY],
+                                     args[Constant.WH_DB_DRIVER_KEY])
+        self.wh_cursor = self.wh_con.cursor(1)
 
-  def update_dataset_field(self, last_time=None):
-      if last_time:
-          sql = """
+    def bulk_insert(self, params, url):
+        try:
+            req = urllib2.Request(url=url)
+            req.add_header('Content-type', 'application/json')
+            req.get_method = lambda: "PUT"
+            req.add_data('\n'.join(params) + '\n')
+            self.logger.info(url)
+            response = urllib2.urlopen(req, timeout=self.es_url_request_timeout)
+            data = json.load(response)
+            if str(data['errors']) != 'False':
+                self.logger.info(str(data))
+        except urllib2.HTTPError as e:
+            self.logger.error(str(e.code))
+            self.logger.error(e.read())
+        except Exception as e:
+            self.logger.error(str(e))
+
+    def update_dataset_field(self, last_time=None):
+        if last_time:
+            sql = """
             SELECT * FROM dict_field_detail WHERE modified >= DATE_SUB(%s, INTERVAL 1 HOUR)
             """ % last_time
-      else:
-          sql = """
+        else:
+            sql = """
             SELECT * FROM dict_field_detail
           """
 
-      comment_query = """
+        comment_query = """
         SELECT d.field_id, d.dataset_id, f.comment FROM dict_dataset_field_comment d
         LEFT JOIN field_comments f ON d.comment_id = f.id WHERE d.field_id = %d
         """
-      url = self.elasticsearch_index_url + ':' + str(self.elasticsearch_port)  + '/' + self.elasticsearch_index + '/field/_bulk'
-      params = []
-      self.wh_cursor.execute(sql)
-      comment_cursor = self.wh_con.cursor(1)
-      description = [x[0] for x in self.wh_cursor.description]
-      row_count = 1
-      result = self.wh_cursor.fetchone()
-      while result:
-          row = dict(zip(description, result))
-          comment_cursor.execute(comment_query % long(row['field_id']))
-          comments = []
-          comment_description = [x[0] for x in comment_cursor.description]
-          comment_result = comment_cursor.fetchone()
-          while comment_result:
-            comment_row = dict(zip(comment_description, comment_result))
-            comments.append(comment_row['comment'])
-            comment_result = comment_cursor.fetchone()
-          params.append('{ "index": { "_id": ' +
-                        str(row['field_id']) + ', "parent": ' + str(row['dataset_id']) + '  }}')
-          comments_detail = {
-              'comments': comments,
-              'dataset_id': row['dataset_id'],
-              'sort_id': row['sort_id'],
-              'field_name': row['field_name'],
-              'parent_path': row['parent_path']
-          }
-          params.append(json.dumps(comments_detail))
+        url = self.elasticsearch_index_url + ':' + str(
+            self.elasticsearch_port) + '/' + self.elasticsearch_index + '/field/_bulk'
+        params = []
+        attempts = 0
+        while attempts < self.max_retry_times:
+            try:
+                self.wh_cursor.execute(sql)
+                comment_cursor = self.wh_con.cursor(1)
+                description = [x[0] for x in self.wh_cursor.description]
+                row_count = 1
+                result = self.wh_cursor.fetchone()
+                while result:
+                    row = dict(zip(description, result))
+                    comment_cursor.execute(comment_query % long(row['field_id']))
+                    comments = []
+                    comment_description = [x[0] for x in comment_cursor.description]
+                    comment_result = comment_cursor.fetchone()
+                    while comment_result:
+                        comment_row = dict(zip(comment_description, comment_result))
+                        comments.append(comment_row['comment'])
+                        comment_result = comment_cursor.fetchone()
+                    params.append('{ "index": { "_id": ' +
+                                  str(row['field_id']) + ', "parent": ' + str(row['dataset_id']) + '  }}')
+                    comments_detail = {
+                        'comments': comments,
+                        'dataset_id': row['dataset_id'],
+                        'sort_id': row['sort_id'],
+                        'field_name': row['field_name'],
+                        'parent_path': row['parent_path']
+                    }
+                    params.append(json.dumps(comments_detail))
 
-          if row_count % 1000 == 0:
-              self.bulk_insert(params, url)
-              self.logger.info('dataset field ' + str(row_count))
-              params = []
-          row_count += 1
-          result = self.wh_cursor.fetchone()
-      if len(params) > 0:
-          self.bulk_insert(params, url)
-          self.logger.info('dataset field ' + str(len(params)))
+                    if row_count % self.bulk_chunk_size == 0:
+                        self.bulk_insert(params, url)
+                        self.logger.info('dataset field ' + str(row_count))
+                        self.wh_con.commit()  # commit regularly to avoid long open transaction
+                        params = []
+                    row_count += 1
+                    result = self.wh_cursor.fetchone()
+                if len(params) > 0:
+                    self.bulk_insert(params, url)
+                    self.logger.info('final chunk of dataset field ' + str(len(params)))
+                    self.wh_con.commit()
 
-      comment_cursor.close()
+                comment_cursor.close()
+                break
+            except Exception as e:
+                self.logger.error(str(e))
+                attempts += 1
+                self.logger.error("JDBC error in update dataset fields, retry: {}".format(attempts))
+                if self.wh_cursor:
+                    self.wh_cursor.close()
+                if self.wh_con:
+                    self.wh_con.close()
+                self.databaseConnect(args)  # reconnect
 
-  def update_comment(self, last_time=None):
-    if last_time:
-        sql = """
+    def update_comment(self, last_time=None):
+        if last_time:
+            sql = """
           SELECT * FROM comments WHERE modified >= DATE_SUB(%s, INTERVAL 1 HOUR)
           """ % last_time
-    else:
-        sql = """
+        else:
+            sql = """
           SELECT * FROM comments
           """
 
-    url = self.elasticsearch_index_url + ':' + str(self.elasticsearch_port)  + '/' + self.elasticsearch_index + '/comment/_bulk'
-
-    params = []
-    self.wh_cursor.execute(sql)
-    row_count = 1
-    description = [x[0] for x in self.wh_cursor.description]
-    result = self.wh_cursor.fetchone()
-    while result:
-      row = dict(zip(description, result))
-      params.append('{ "index": { "_id": ' + str(row['id']) + ', "parent": ' + str(row['dataset_id']) + '  }}')
-
-      text_detail = {
-          'text': row['text'],
-          'user_id': row['user_id'],
-          'dataset_id': row['dataset_id'],
-          'comment_type': row['comment_type']
-      }
-      params.append(json.dumps(text_detail))
-
-      if row_count % 1000 == 0:
-        self.bulk_insert(params, url)
-        self.logger.info('comment ' + str(row_count))
+        url = self.elasticsearch_index_url + ':' + str(
+            self.elasticsearch_port) + '/' + self.elasticsearch_index + '/comment/_bulk'
         params = []
-      row_count += 1
-      result = self.wh_cursor.fetchone()
-    if len(params) > 0:
-      self.bulk_insert(params, url)
-      self.logger.info('comment ' + str(len(params)))
+        self.wh_cursor.execute(sql)
+        row_count = 1
+        description = [x[0] for x in self.wh_cursor.description]
+        result = self.wh_cursor.fetchone()
+        while result:
+            row = dict(zip(description, result))
+            params.append(
+                '{ "index": { "_id": ' + str(row['id']) + ', "parent": ' + str(row['dataset_id']) + '  }}')
 
-  def update_dataset(self, last_unixtime=None):
-    if last_unixtime:
-        sql = """
+            text_detail = {
+                'text': row['text'],
+                'user_id': row['user_id'],
+                'dataset_id': row['dataset_id'],
+                'comment_type': row['comment_type']
+            }
+            params.append(json.dumps(text_detail))
+
+            if row_count % self.bulk_chunk_size == 0:
+                self.bulk_insert(params, url)
+                self.logger.info('comment ' + str(row_count))
+                self.wh_con.commit()
+                params = []
+            row_count += 1
+            result = self.wh_cursor.fetchone()
+        if len(params) > 0:
+            self.bulk_insert(params, url)
+            self.logger.info('comment ' + str(len(params)))
+            self.wh_con.commit()
+
+    def update_dataset(self, last_unixtime=None):
+        if last_unixtime:
+            sql = """
           SELECT d.*,
               COALESCE(s.static_boosting_score,1) as static_boosting_score
           FROM dict_dataset d
@@ -157,8 +185,8 @@ class ElasticSearchIndex():
           and d.urn not like "hive:///dev_foundation_views%%"
           and from_unixtime(d.modified_time) >= DATE_SUB(from_unixtime(%f), INTERVAL 1 HOUR)
           """ % last_unixtime
-    else:
-        sql = """
+        else:
+            sql = """
           INSERT IGNORE INTO cfg_search_score_boost
           (id, static_boosting_score)
           SELECT id, 80 FROM dict_dataset
@@ -214,67 +242,72 @@ class ElasticSearchIndex():
           and d.urn not like "hive:///dev_foundation_views%"
           """
 
-    self.execute_commands(sql)
+        self.execute_commands(sql)
 
-    description = [x[0] for x in self.wh_cursor.description]
+        description = [x[0] for x in self.wh_cursor.description]
 
-    row_count = 1
-    result = self.wh_cursor.fetchone()
-
-    url = self.elasticsearch_index_url + ':' + str(self.elasticsearch_port)  + '/' + self.elasticsearch_index + '/dataset/_bulk'
-    params = []
-
-    while result:
-        row = dict(zip(description, result))
-
-        name_suggest_info = {
-            'input' : [row['name']]
-        }
-        dataset_detail = {
-            'name': row['name'],
-            'source': row['source'],
-            'urn': row['urn'],
-            'location_prefix': row['location_prefix'],
-            'parent_name': row['parent_name'],
-            'schema_type': row['schema_type'],
-            'properties': row['properties'],
-            'schema': row['schema'],
-            'fields': row['fields'],
-            'static_boosting_score': row['static_boosting_score'],
-            'name_suggest': name_suggest_info
-        }
-
-        params.append('{ "index": { "_id": ' + str(row['id']) + ' }}')
-        params.append(json.dumps(dataset_detail))
-
-        if row_count % 1000 == 0:
-            self.bulk_insert(params, url)
-            self.logger.info('dataset ' + str(row_count))
-            params = []
-        row_count += 1
+        row_count = 1
         result = self.wh_cursor.fetchone()
-    self.logger.info('total dataset row count is: ' + str(row_count))
-    if len(params) > 0:
-        self.bulk_insert(params, url)
-        self.logger.info('dataset ' + str(len(params)))
 
-  def update_metric(self):
-      sql = """
+        url = self.elasticsearch_index_url + ':' + str(
+            self.elasticsearch_port) + '/' + self.elasticsearch_index + '/dataset/_bulk'
+        params = []
+
+        while result:
+            row = dict(zip(description, result))
+
+            name_suggest_info = {
+                'input': [row['name']]
+            }
+            dataset_detail = {
+                'name': row['name'],
+                'source': row['source'],
+                'urn': row['urn'],
+                'location_prefix': row['location_prefix'],
+                'parent_name': row['parent_name'],
+                'schema_type': row['schema_type'],
+                'properties': row['properties'],
+                'schema': row['schema'],
+                'fields': row['fields'],
+                'static_boosting_score': row['static_boosting_score'],
+                'name_suggest': name_suggest_info
+            }
+
+            params.append('{ "index": { "_id": ' + str(row['id']) + ' }}')
+            params.append(json.dumps(dataset_detail))
+
+            if row_count % self.bulk_chunk_size == 0:
+                self.bulk_insert(params, url)
+                self.logger.info('dataset ' + str(row_count))
+                self.wh_con.commit()
+
+            params = []
+            row_count += 1
+            result = self.wh_cursor.fetchone()
+        self.logger.info('total dataset row count is: ' + str(row_count))
+        if len(params) > 0:
+            self.bulk_insert(params, url)
+            self.logger.info('dataset ' + str(len(params)))
+            self.wh_con.commit()
+
+    def update_metric(self):
+        sql = """
         SELECT * FROM dict_business_metric
         """
 
-      url = self.elasticsearch_index_url + ':' + str(self.elasticsearch_port)  + '/' + self.elasticsearch_index + '/metric/_bulk'
-      params = []
-      self.wh_cursor.execute(sql)
-      description = [x[0] for x in self.wh_cursor.description]
-      row_count = 1
-      result = self.wh_cursor.fetchone()
-      while result:
-          row = dict(zip(description, result))
-          metric_name_suggest_info = {
-              'input' : [row['metric_name']]
-          }
-          metric_detail = {
+        url = self.elasticsearch_index_url + ':' + str(
+            self.elasticsearch_port) + '/' + self.elasticsearch_index + '/metric/_bulk'
+        params = []
+        self.wh_cursor.execute(sql)
+        description = [x[0] for x in self.wh_cursor.description]
+        row_count = 1
+        result = self.wh_cursor.fetchone()
+        while result:
+            row = dict(zip(description, result))
+            metric_name_suggest_info = {
+                'input': [row['metric_name']]
+            }
+            metric_detail = {
                 'metric_id': row['metric_id'],
                 'metric_name': row['metric_name'],
                 'metric_description': row['metric_description'],
@@ -303,122 +336,156 @@ class ElasticSearchIndex():
                 'wiki_url': row['wiki_url'],
                 'scm_url': row['scm_url'],
                 'metric_name_suggest': metric_name_suggest_info
-          }
-          params.append('{ "index": { "_id": ' + str(row['metric_id']) + '  }}')
-          params.append(json.dumps(metric_detail))
+            }
+            params.append('{ "index": { "_id": ' + str(row['metric_id']) + '  }}')
+            params.append(json.dumps(metric_detail))
 
-          if row_count % 1000 == 0:
-            self.bulk_insert(params, url)
-            self.logger.info('metric ' + str(row_count))
+            if row_count % self.bulk_chunk_size == 0:
+                self.bulk_insert(params, url)
+                self.logger.info('metric ' + str(row_count))
+                self.wh_con.commit()
+
             params = []
-          row_count += 1
-          result = self.wh_cursor.fetchone()
-      if len(params) > 0:
-          self.bulk_insert(params, url)
-          self.logger.info('metric ' + str(len(params)))
+            row_count += 1
+            result = self.wh_cursor.fetchone()
+        if len(params) > 0:
+            self.bulk_insert(params, url)
+            self.logger.info('metric ' + str(len(params)))
+            self.wh_con.commit()
 
-  def update_flow_jobs(self, last_unixtime=None):
-      if last_unixtime:
-          flow_sql = """
+    def update_flow_jobs(self, last_unixtime=None):
+        if last_unixtime:
+            flow_sql = """
             SELECT a.app_code, f.* FROM flow f JOIN cfg_application a on f.app_id = a.app_id
             WHERE from_unixtime(modified_time) >= DATE_SUB(from_unixtime(%f), INTERVAL 1 HOUR)
             """ % last_unixtime
-      else:
-          flow_sql = """
+        else:
+            flow_sql = """
             SELECT a.app_code, f.* FROM flow f JOIN cfg_application a on f.app_id = a.app_id
             """
-      job_sql = """
+        job_sql = """
         SELECT * FROM flow_job WHERE app_id = %d and flow_id = %d
         """
 
-      url = self.elasticsearch_index_url + ':' + str(self.elasticsearch_port)  + '/' + self.elasticsearch_index + '/flow_jobs/_bulk'
+        url = self.elasticsearch_index_url + ':' + str(
+            self.elasticsearch_port) + '/' + self.elasticsearch_index + '/flow_jobs/_bulk'
 
-      params = []
-      self.wh_cursor.execute(flow_sql)
-      job_cursor = self.wh_con.cursor(1)
-      description = [x[0] for x in self.wh_cursor.description]
-      row_count = 1
-      result = self.wh_cursor.fetchone()
-      while result:
-          row = dict(zip(description, result))
-          job_cursor.execute(job_sql %(long(row['app_id']), long(row['flow_id'])))
-          jobs_info = []
-          job_description = [x[0] for x in job_cursor.description]
-          job_result = job_cursor.fetchone()
-          while job_result:
-              job_row = dict(zip(job_description, job_result))
-              flow_name_suggest_info = {
-                  'input' : [row['flow_name']]
-              }
-              job_name_suggest_info = {
-                  'input' : [job_row['job_name']]
-              }
-              jobs_row_detail = {
-                  'app_id': job_row['app_id'],
-                  'flow_id': job_row['flow_id'],
-                  'job_id': job_row['job_id'],
-                  'job_name': job_row['job_name'],
-                  'job_path': job_row['job_path'],
-                  'job_type_id': job_row['job_type_id'],
-                  'job_type': job_row['job_type'],
-                  'pre_jobs': job_row['pre_jobs'],
-                  'post_jobs': job_row['post_jobs'],
-                  'is_current': job_row['is_current'],
-                  'is_first': job_row['is_first'],
-                  'is_last': job_row['is_last'],
-                  'job_name_suggest': job_name_suggest_info
-               }
-              jobs_info.append(jobs_row_detail)
-              job_result = job_cursor.fetchone()
+        params = []
+        self.wh_cursor.execute(flow_sql)
+        job_cursor = self.wh_con.cursor(1)
+        description = [x[0] for x in self.wh_cursor.description]
+        row_count = 1
+        result = self.wh_cursor.fetchone()
+        while result:
+            row = dict(zip(description, result))
+            job_cursor.execute(job_sql % (long(row['app_id']), long(row['flow_id'])))
+            jobs_info = []
+            job_description = [x[0] for x in job_cursor.description]
+            job_result = job_cursor.fetchone()
+            while job_result:
+                job_row = dict(zip(job_description, job_result))
+                flow_name_suggest_info = {
+                    'input': [row['flow_name']]
+                }
+                job_name_suggest_info = {
+                    'input': [job_row['job_name']]
+                }
+                jobs_row_detail = {
+                    'app_id': job_row['app_id'],
+                    'flow_id': job_row['flow_id'],
+                    'job_id': job_row['job_id'],
+                    'job_name': job_row['job_name'],
+                    'job_path': job_row['job_path'],
+                    'job_type_id': job_row['job_type_id'],
+                    'job_type': job_row['job_type'],
+                    'pre_jobs': job_row['pre_jobs'],
+                    'post_jobs': job_row['post_jobs'],
+                    'is_current': job_row['is_current'],
+                    'is_first': job_row['is_first'],
+                    'is_last': job_row['is_last'],
+                    'job_name_suggest': job_name_suggest_info
+                }
+                jobs_info.append(jobs_row_detail)
+                job_result = job_cursor.fetchone()
 
-          params.append('{ "index": { "_id": ' + str(long(row['flow_id'])*10000 + long(row['app_id'])) + '  }}')
-          jobs_detail = {
-              'app_id': row['app_id'],
-              'flow_id': row['flow_id'],
-              'app_code': row['app_code'],
-              'flow_name': row['flow_name'],
-              'flow_group': row['flow_group'],
-              'flow_path': row['flow_path'],
-              'flow_level': row['flow_level'],
-              'is_active': row['is_active'],
-              'is_scheduled': row['is_scheduled'],
-              'pre_flows': row['pre_flows'],
-              'jobs': jobs_info,
-              'flow_name_suggest': flow_name_suggest_info
-          }
-          params.append(json.dumps(jobs_detail))
+            params.append('{ "index": { "_id": ' + str(long(row['flow_id']) * 10000 + long(row['app_id'])) + '  }}')
+            jobs_detail = {
+                'app_id': row['app_id'],
+                'flow_id': row['flow_id'],
+                'app_code': row['app_code'],
+                'flow_name': row['flow_name'],
+                'flow_group': row['flow_group'],
+                'flow_path': row['flow_path'],
+                'flow_level': row['flow_level'],
+                'is_active': row['is_active'],
+                'is_scheduled': row['is_scheduled'],
+                'pre_flows': row['pre_flows'],
+                'jobs': jobs_info,
+                'flow_name_suggest': flow_name_suggest_info
+            }
+            params.append(json.dumps(jobs_detail))
 
-          if row_count % 1000 == 0:
-              self.bulk_insert(params, url)
-              self.logger.info('flow jobs ' + str(row_count))
-              params = []
-          row_count += 1
-          result = self.wh_cursor.fetchone()
-      if len(params) > 0:
-          self.logger.info('flow_jobs ' + str(len(params)))
-          self.bulk_insert(params, url)
+            if row_count % self.bulk_chunk_size == 0:
+                self.bulk_insert(params, url)
+                self.logger.info('flow jobs ' + str(row_count))
+                self.wh_con.commit()
+                params = []
 
-      job_cursor.close()
+            row_count += 1
+            result = self.wh_cursor.fetchone()
 
-  def execute_commands(self, commands):
-      for cmd in commands.split(";"):
-          self.logger.info(cmd)
-          self.wh_cursor.execute(cmd)
-          self.wh_con.commit()
+        if len(params) > 0:
+            self.logger.info('flow_jobs ' + str(len(params)))
+            self.bulk_insert(params, url)
+            self.wh_con.commit()
 
-  def run(self):
+        job_cursor.close()
 
-    try:
-      self.update_dataset()
-      self.update_comment()
-      self.update_dataset_field()
-      self.update_flow_jobs()
-      self.update_metric()
-    finally:
-      self.wh_cursor.close()
-      self.wh_con.close()
+    def execute_commands(self, commands):
+        for cmd in commands.split(";"):
+            self.logger.info(cmd)
+            self.wh_cursor.execute(cmd)
+            self.wh_con.commit()
+
+    def run(self):
+
+        try:
+            start_dataset_time = time.time()
+            self.update_dataset()
+            end_time = time.time()
+            self.logger.info('Performance Log update_dataset takes time:  ' + str(end_time - start_dataset_time))
+
+            start_time = time.time()
+            self.update_comment()
+            end_time = time.time()
+            self.logger.info('Performance Log update_comment takes time:  ' + str(end_time - start_time))
+
+            start_time = time.time()
+            self.update_dataset_field()
+            end_time = time.time()
+            self.logger.info('Performance Log update_dataset_field takes time:  ' + str(end_time - start_time))
+
+            start_time = time.time()
+            self.update_flow_jobs()
+            end_time = time.time()
+            self.logger.info('Performance Log update_flow_jobs takes time:  ' + str(end_time - start_time))
+
+            start_time = time.time()
+            self.update_metric()
+            end_time = time.time()
+            self.logger.info('Performance Log update_metric takes time:  ' + str(end_time - start_time))
+
+            self.logger.info(
+                'Performance Log ELASTIC_SEARCH_ETL job takes time:  ' + str(time.time() - start_dataset_time))
+
+        except Exception as e:
+            self.logger.error(str(e))
+        finally:
+            self.wh_cursor.close()
+            self.wh_con.close()
+
 
 if __name__ == "__main__":
-   props = sys.argv[1]
-   esi = ElasticSearchIndex(props)
-   esi.run()
+    args = sys.argv[1]
+    esi = ElasticSearchIndex(args)
+    esi.run()


### PR DESCRIPTION
1, Add retry logic for update dataset field, where db connection might be lost.  It takes 75% of total time for this ETL job.  
2, Add explicit wh commit, every 1000 statements. To avoid commit every statement, while not having long open transactions
3,  Adding configurations settings to control the bulk insert size, url request timeout, and max retry times for db. 
elasticsearch.bulk.insert.size=1000
elasticsearch.url.request.timeout=60
wh.db.max.retry.times=3

These are recommended settings in the job template. 
4, Added performance log for future performance tuning 
5, Refactoring coding format