### PR TITLE
support elasticsearch auto re-index with zero downtime via alias switch

### DIFF
--- a/wherehows-backend/build.gradle
+++ b/wherehows-backend/build.gradle
@@ -26,6 +26,9 @@ model {
                 from("jobs") {
                     into "jobs"
                 }
+                from("../wherehows-data-model/ELASTICSEARCH") {
+                    into "ELASTICSEARCH"
+                }
             }
         }
     }

--- a/wherehows-backend/jobs/templates/ELASTIC_SEARCH_ETL.job
+++ b/wherehows-backend/jobs/templates/ELASTIC_SEARCH_ETL.job
@@ -1,6 +1,6 @@
 # Push metadata to Elastic search server
 job.class=metadata.etl.JythonEtlJob
-job.cron.expr=0 0 0/6 1/1 * ? *
+job.cron.expr=0 0 0/12 1/1 * ? *
 job.timeout=10000
 #job.cmd.params=
 job.disabled=1
@@ -12,3 +12,7 @@ job.jython.load=jython/ElasticSearchIndex.py
 elasticsearch.url=your_es_url
 elasticsearch.port=your_es_port
 elasticsearch.index=your_es_index
+elasticsearch.bulk.insert.size=your_bulk_insert_chunk_size
+elasticsearch.url.request.timeout=your_es_url_request_timeout
+wh.db.max.retry.times=your_db_max_retry_times
+wh.elasticsearch.index.mapping.file=your_index_mapping_file

--- a/wherehows-common/src/main/java/wherehows/common/Constant.java
+++ b/wherehows-common/src/main/java/wherehows/common/Constant.java
@@ -282,4 +282,6 @@ public class Constant {
   public static final String ELASTICSEARCH_BULK_INSERT_SIZE = "elasticsearch.bulk.insert.size";
   public static final String ELASTICSEARCH_URL_REQUEST_TIMEOUT = "elasticsearch.url.request.timeout";
   public static final String WH_DB_MAX_RETRY_TIMES = "wh.db.max.retry.times";
+  public static final String WH_ELASTICSEARCH_INDEX_MAPPING_FILE = "wh.elasticsearch.index.mapping.file";
+
 }

--- a/wherehows-data-model/ELASTICSEARCH/index_mapping.json
+++ b/wherehows-data-model/ELASTICSEARCH/index_mapping.json
@@ -13,92 +13,43 @@
     }
   },
   "mappings": {
-    "metric": {
+    "dataset": {
       "properties": {
-        "dashboard_name": {
-          "type": "string"
+        "fields": {
+          "type": "text"
         },
-        "dimensions": {
-          "type": "string"
+        "location_prefix": {
+          "type": "text"
         },
-        "metric_additive_type": {
-          "type": "string"
+        "name": {
+          "type": "text",
+          "analyzer": "keyword_analyzer"
         },
-        "metric_category": {
-          "type": "string"
-        },
-        "metric_description": {
-          "type": "string"
-        },
-        "metric_display_factor": {
-          "type": "double"
-        },
-        "metric_display_factor_sym": {
-          "type": "string"
-        },
-        "metric_formula": {
-          "type": "string"
-        },
-        "metric_good_direction": {
-          "type": "string"
-        },
-        "metric_grain": {
-          "type": "string"
-        },
-        "metric_group": {
-          "type": "string"
-        },
-        "metric_id": {
-          "type": "long"
-        },
-        "metric_level": {
-          "type": "string"
-        },
-        "metric_name": {
-          "type": "string"
-        },
-        "metric_name_suggest": {
+        "name_suggest": {
           "type": "completion",
           "analyzer": "standard"
         },
-        "metric_ref_id": {
-          "type": "string"
+        "parent_name": {
+          "type": "text"
         },
-        "metric_ref_id_type": {
-          "type": "string"
+        "properties": {
+          "type": "text"
         },
-        "metric_source": {
-          "type": "string"
+        "schema": {
+          "type": "text"
         },
-        "metric_source_dataset_id": {
+        "schema_type": {
+          "type": "text"
+        },
+        "source": {
+          "type": "text"
+        },
+        "static_boosting_score": {
           "type": "long"
         },
-        "metric_source_type": {
-          "type": "string"
-        },
-        "metric_sub_category": {
-          "type": "string"
-        },
-        "metric_type": {
-          "type": "string"
-        },
-        "metric_url": {
-          "type": "string"
-        },
-        "owners": {
-          "type": "string"
-        },
-        "scm_url": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "string"
-        },
-        "metric_urn": {
-          "type": "string"
-        },
-        "wiki_url": {
-          "type": "string"
+        "urn": {
+          "type": "text",
+          "analyzer": "keyword_analyzer"
         }
       }
     },
@@ -111,56 +62,99 @@
       },
       "properties": {
         "comment_type": {
-          "type": "string"
+          "type": "text"
         },
         "dataset_id": {
           "type": "long"
         },
         "text": {
-          "type": "string"
+          "type": "text"
         },
         "user_id": {
           "type": "long"
         }
       }
     },
-    "dataset": {
+    "flow_jobs": {
       "properties": {
-        "fields": {
-          "type": "string"
+        "app_code": {
+          "type": "text"
         },
-        "location_prefix": {
-          "type": "string"
+        "app_id": {
+          "type": "long"
         },
-        "name": {
-          "type": "string",
-          "analyzer": "keyword_analyzer"
+        "flow_group": {
+          "type": "text"
         },
-        "name_suggest": {
+        "flow_id": {
+          "type": "long"
+        },
+        "flow_level": {
+          "type": "long"
+        },
+        "flow_name": {
+          "type": "text"
+        },
+        "flow_name_suggest": {
           "type": "completion",
           "analyzer": "standard"
         },
-        "parent_name": {
-          "type": "string"
+        "flow_path": {
+          "type": "text"
         },
-        "properties": {
-          "type": "string"
+        "is_active": {
+          "type": "text"
         },
-        "schema": {
-          "type": "string"
+        "is_scheduled": {
+          "type": "text"
         },
-        "schema_type": {
-          "type": "string"
+        "jobs": {
+          "type": "nested",
+          "properties": {
+            "app_id": {
+              "type": "short"
+            },
+            "flow_id": {
+              "type": "long"
+            },
+            "is_current": {
+              "type": "text"
+            },
+            "is_first": {
+              "type": "text"
+            },
+            "is_last": {
+              "type": "text"
+            },
+            "job_id": {
+              "type": "long"
+            },
+            "job_name": {
+              "type": "text"
+            },
+            "job_name_suggest": {
+              "type": "completion",
+              "analyzer": "standard"
+            },
+            "job_path": {
+              "type": "text"
+            },
+            "job_type": {
+              "type": "text"
+            },
+            "job_type_id": {
+              "type": "short"
+            },
+            "post_jobs": {
+              "type": "text"
+            },
+            "pre_jobs": {
+              "type": "text"
+            }
+          }
         },
-        "source": {
-          "type": "string"
-        },
-        "static_boosting_score": {
-          "type": "long"
-        },
-        "urn": {
-          "type": "string",
-          "analyzer": "keyword_analyzer"
+        "pre_flows": {
+          "type": "text"
         }
       }
     },
@@ -173,102 +167,108 @@
       },
       "properties": {
         "comments": {
-          "type": "string"
+          "type": "text"
         },
         "dataset_id": {
           "type": "long"
         },
         "field_name": {
-          "type": "string"
+          "type": "text"
         },
         "parent_path": {
-          "type": "string"
+          "type": "text"
         },
         "sort_id": {
           "type": "long"
         }
       }
     },
-    "flow_jobs": {
+    "metric": {
       "properties": {
-        "app_code": {
-          "type": "string"
+        "dashboard_name": {
+          "type": "text"
         },
-        "app_id": {
+        "dimensions": {
+          "type": "text"
+        },
+        "metric_additive_type": {
+          "type": "text"
+        },
+        "metric_category": {
+          "type": "text"
+        },
+        "metric_description": {
+          "type": "text"
+        },
+        "metric_display_factor": {
+          "type": "double"
+        },
+        "metric_display_factor_sym": {
+          "type": "text"
+        },
+        "metric_formula": {
+          "type": "text"
+        },
+        "metric_good_direction": {
+          "type": "text"
+        },
+        "metric_grain": {
+          "type": "text"
+        },
+        "metric_group": {
+          "type": "text"
+        },
+        "metric_id": {
           "type": "long"
         },
-        "flow_group": {
-          "type": "string"
+        "metric_level": {
+          "type": "text"
         },
-        "flow_id": {
-          "type": "long"
+        "metric_name": {
+          "type": "text"
         },
-        "flow_level": {
-          "type": "long"
-        },
-        "flow_name": {
-          "type": "string"
-        },
-        "flow_name_suggest": {
+        "metric_name_suggest": {
           "type": "completion",
           "analyzer": "standard"
         },
-        "flow_path": {
-          "type": "string"
+        "metric_ref_id": {
+          "type": "text"
         },
-        "is_active": {
-          "type": "string"
+        "metric_ref_id_type": {
+          "type": "text"
         },
-        "is_scheduled": {
-          "type": "string"
+        "metric_source": {
+          "type": "text"
         },
-        "jobs": {
-          "type": "nested",
-          "properties": {
-            "app_id": {
-              "type": "short"
-            },
-            "flow_id": {
-              "type": "long"
-            },
-            "is_current": {
-              "type": "string"
-            },
-            "is_first": {
-              "type": "string"
-            },
-            "is_last": {
-              "type": "string"
-            },
-            "job_id": {
-              "type": "long"
-            },
-            "job_name": {
-              "type": "string"
-            },
-            "job_name_suggest": {
-              "type": "completion",
-              "analyzer": "standard"
-            },
-            "job_path": {
-              "type": "string"
-            },
-            "job_type": {
-              "type": "string"
-            },
-            "job_type_id": {
-              "type": "short"
-            },
-            "post_jobs": {
-              "type": "string"
-            },
-            "pre_jobs": {
-              "type": "string"
-            }
-          }
+        "metric_source_dataset_id": {
+          "type": "long"
         },
-        "pre_flows": {
-          "type": "string"
+        "metric_source_type": {
+          "type": "text"
+        },
+        "metric_sub_category": {
+          "type": "text"
+        },
+        "metric_type": {
+          "type": "text"
+        },
+        "metric_url": {
+          "type": "text"
+        },
+        "metric_urn": {
+          "type": "text"
+        },
+        "owners": {
+          "type": "text"
+        },
+        "scm_url": {
+          "type": "text"
+        },
+        "tags": {
+          "type": "text"
+        },
+        "wiki_url": {
+          "type": "text"
         }
       }
     }


### PR DESCRIPTION

* Support elastic search auto-re-index
* Use alias switch to achieve zero down time. 
* If it is first time index created or alias does not exist yet, create new alias for the first time
* The job will be schedule running ever 12hrs, so our search data can be kept up-to-date. In the past, this was manually done every few weeks
* The index alias name can be defined in elastic search ETL job configuration file
* The index mapping data model changes for 5.5
* The index mapping file location needs to be specified in job configuration file via env variables 
