### PR TITLE
adds code coverage support to ci: uses code-cov for static analysis, …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 
 script:
 - ./gradlew check assemble
-- ./gradlew jacocoFullReport coveralls && ./gradlew wherehows-frontend:emberCoverage
+- ./gradlew jacocoFullReport coveralls && ./gradlew emberCoverage
 - (cd wherehows-docker && ./build.sh latest)
 - (cd wherehows-docker && docker-compose config)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
   - oraclejdk8
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.14.0
+  - DOCKER_COMPOSE_VERSION=1.14.0 WHEREHOWS_DIR=wherehows-web
 
 services:
   - docker
@@ -28,6 +28,15 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 
+  # Repo for newer Node.js versions
+  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  # https://yarnpkg.com/en/docs/install-ci#travis-tab
+  # Repo for Yarn
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -38,3 +47,7 @@ script:
 - ./gradlew jacocoFullReport coveralls
 - (cd wherehows-docker && ./build.sh latest)
 - (cd wherehows-docker && docker-compose config)
+- (cd $WHEREHOWS_DIR && yarn install --non-interactive && node_modules/bower/bin/bower install && npm run-script coverage)
+
+after_script:
+  - rm -rf $WHEREHOWS_DIR/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,6 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 
-  # Repo for newer Node.js versions
-  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-  # https://yarnpkg.com/en/docs/install-ci#travis-tab
-  # Repo for Yarn
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
   - oraclejdk8
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.14.0 WHEREHOWS_DIR=wherehows-web
+  - DOCKER_COMPOSE_VERSION=1.14.0
 
 services:
   - docker
@@ -44,10 +44,9 @@ cache:
 
 script:
 - ./gradlew check assemble
-- ./gradlew jacocoFullReport coveralls
+- ./gradlew jacocoFullReport coveralls && ./gradlew wherehows-frontend:emberCoverage
 - (cd wherehows-docker && ./build.sh latest)
 - (cd wherehows-docker && docker-compose config)
-- (cd $WHEREHOWS_DIR && yarn install --non-interactive && node_modules/bower/bin/bower install && npm run-script coverage)
 
 after_script:
   - rm -rf $WHEREHOWS_DIR/coverage

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     classpath 'gradle.plugin.com.palantir:jacoco-coverage:0.3.0'
     classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1'
     classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
-    classpath 'com.moowork.gradle:gradle-node-plugin:1.1.1'
+    classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
   }
 }
 

--- a/gradle/scripts/ember.gradle
+++ b/gradle/scripts/ember.gradle
@@ -43,7 +43,7 @@ task emberTest(type: NodeTask, dependsOn: bowerInstall) {
 }
 
 task emberCoverage(type: NodeTask, dependsOn: emberTest) {
-  script = file('./node_modules/.bin/codecov')
+  script = file('node_modules/codecov/bin/codecov')
   args = ['-f', 'coverage/coverage-final.json']
 }
 

--- a/gradle/scripts/ember.gradle
+++ b/gradle/scripts/ember.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.moowork.node"
 
 node {
   // Version of node to use.
-  version = '7.10.1'
+  version = '8.9.1'
 
   // Base URL for fetching node distributions (change if you have a mirror).
   distBaseUrl = 'https://nodejs.org/dist'

--- a/gradle/scripts/ember.gradle
+++ b/gradle/scripts/ember.gradle
@@ -4,9 +4,6 @@ node {
   // Version of node to use.
   version = '7.10.1'
 
-  // Version of yarn to use.
-  yarnVersion = '0.27.5'
-
   // Base URL for fetching node distributions (change if you have a mirror).
   distBaseUrl = 'https://nodejs.org/dist'
 
@@ -40,8 +37,14 @@ task emberBuild(type: NodeTask, dependsOn: bowerInstall) {
 }
 
 task emberTest(type: NodeTask, dependsOn: bowerInstall) {
+  environment = ['COVERAGE': 'true']
   script = file('node_modules/ember-cli/bin/ember')
-  args = ['test']
+  args = ['test', '--launch', 'Chrome']
+}
+
+task emberCoverage(type: NodeTask, dependsOn: emberTest) {
+  script = file('./node_modules/.bin/codecov')
+  args = ['-f', 'coverage/coverage-final.json']
 }
 
 clean {

--- a/wherehows-web/app/utils/api/fetcher.ts
+++ b/wherehows-web/app/utils/api/fetcher.ts
@@ -10,9 +10,8 @@ interface FetchConfig {
 }
 
 /**
- * 
- * 
- * @param {FetchConfig} config 
+ * Augments the user supplied headers with the default accept and content-type headers
+ * @param {FetchConfig.headers} headers
  */
 const baseFetchHeaders = (headers: FetchConfig['headers']) => ({
   headers: {
@@ -23,10 +22,9 @@ const baseFetchHeaders = (headers: FetchConfig['headers']) => ({
 });
 
 /**
- * 
- * 
- * @template T 
- * @param {string} url 
+ * Sends a HTTP request and resolves with the JSON response
+ * @template T
+ * @param {string} url the url for the endpoint to request a response from
  * @param {object} fetchConfig 
  * @returns {Promise<T>} 
  */
@@ -35,6 +33,7 @@ const json = <T>(url: string, fetchConfig: object): Promise<T> =>
 
 /**
  * Conveniently gets a JSON response using the fetch api
+ * @template T
  * @param {FetchConfig} config
  * @return {Promise<T>}
  */
@@ -45,9 +44,8 @@ const getJSON = <T>(config: FetchConfig): Promise<T> => {
 };
 
 /**
- * 
- * 
- * @template T 
+ * Initiates a POST request using the Fetch api
+ * @template T
  * @param {FetchConfig} config 
  * @returns {Promise<T>} 
  */
@@ -61,6 +59,12 @@ const postJSON = <T>(config: FetchConfig): Promise<T> => {
   return json<T>(config.url, fetchConfig);
 };
 
+/**
+ * Initiates a DELETE request using the Fetch api
+ * @template T
+ * @param {FetchConfig} config
+ * @return {Promise<T>}
+ */
 const deleteJSON = <T>(config: FetchConfig): Promise<T> => {
   const fetchConfig = Object.assign(
     config.data && { body: JSON.stringify(config.data) },
@@ -71,6 +75,12 @@ const deleteJSON = <T>(config: FetchConfig): Promise<T> => {
   return json<T>(config.url, fetchConfig);
 };
 
+/**
+ * Initiates a PUT request using the Fetch api
+ * @template T
+ * @param {FetchConfig} config
+ * @return {Promise<T>}
+ */
 const putJSON = <T>(config: FetchConfig): Promise<T> => {
   const fetchConfig = Object.assign(
     config.data && { body: JSON.stringify(config.data) },
@@ -84,7 +94,7 @@ const putJSON = <T>(config: FetchConfig): Promise<T> => {
 /**
  * Requests the headers from a resource endpoint
  * @param {FetchConfig} config
- * @return {Promise<Headers>>}
+ * @return {Promise<Headers>}
  */
 const getHeaders = async (config: FetchConfig): Promise<Headers> => {
   const fetchConfig = {
@@ -100,4 +110,20 @@ const getHeaders = async (config: FetchConfig): Promise<Headers> => {
   throw new Error(statusText);
 };
 
-export { getJSON, postJSON, deleteJSON, putJSON, getHeaders };
+/**
+ * Wraps a request Promise, passthrough response if successful, otherwise handle the error and rethrow if not api error
+ * @param {Promise<T>} fetcher the api request to wrap
+ * @param {K} defaultValue
+ * @return {Promise<K | T>}
+ */
+const fetchAndHandleIfApiError = async <T, K>(fetcher: Promise<T>, defaultValue: K): Promise<T | K | null> => {
+  let result: T | K | null = typeof defaultValue === 'undefined' ? null : defaultValue;
+  try {
+    result = await fetcher;
+  } catch (e) {
+    //handle error
+  }
+  return result;
+};
+
+export { getJSON, postJSON, deleteJSON, putJSON, getHeaders, fetchAndHandleIfApiError };

--- a/wherehows-web/bower.json
+++ b/wherehows-web/bower.json
@@ -8,7 +8,6 @@
     "jquery-jsonview": "jsonview#^1.2.3",
     "jquery-treegrid": "^0.3.0",
     "jquery-ui": "^1.12.1",
-    "jquery.fancytree": "fancytree#^2.21.0",
     "jquery.scrollTo": "^2.1.2",
     "json-human": "^0.1.1",
     "jsondiffpatch": "^0.2.4",

--- a/wherehows-web/config/coverage.js
+++ b/wherehows-web/config/coverage.js
@@ -7,5 +7,7 @@ module.exports = {
     'babel-plugin-transform-object-rest-spread',
     'babel-plugin-transform-class-properties'
   ],
+  includeTranspiledSources: ['ts'],
+  reporters: ['lcov', 'html', 'json'],
   excludes: ['*/mirage/**/*', '*/tests/**/*', '*/config/**/*', '*/public/**/*', '*/vendor/**/*', '*/app/actions/**']
 };

--- a/wherehows-web/ember-cli-build.js
+++ b/wherehows-web/ember-cli-build.js
@@ -89,14 +89,12 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
 
   app.import('bower_components/jquery-ui/themes/base/jquery-ui.css');
-  // app.import('bower_components/jquery.fancytree/dist/skin-win8/ui.fancytree.min.css');
   app.import('vendor/fancytree/src/skin-wherehows/ui.wherehows.css');
   app.import('bower_components/font-awesome/css/font-awesome.min.css');
   app.import('bower_components/json-human/css/json.human.css');
   app.import('bower_components/jquery-treegrid/css/jquery.treegrid.css');
   app.import('bower_components/toastr/toastr.min.css');
   app.import('bower_components/jquery-jsonview/dist/jquery.jsonview.css');
-  // app.import('bower_components/bootstrap/dist/css/bootstrap.min.css');
   app.import('bower_components/jsondiffpatch/public/formatters-styles/html.css');
   app.import('bower_components/jsondiffpatch/public/formatters-styles/annotated.css');
   app.import('bower_components/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css');
@@ -122,8 +120,6 @@ module.exports = function(defaults) {
   app.import('vendor/dagre-d3/js/tipsy.js');
   app.import('vendor/dagre-d3/js/jquery.contextMenu.js');
   app.import('vendor/d3pie-0.18/d3pie-customized.js');
-  // app.import('bower_components/jquery.fancytree/dist/jquery.fancytree.min.js');
-  // app.import('bower_components/jquery.fancytree/dist/src/jquery.fancytree.filter.js');
   app.import('bower_components/jquery.scrollTo/jquery.scrollTo.min.js');
   app.import('bower_components/jquery-treegrid/js/jquery.treegrid.js');
   app.import('bower_components/json-human/src/json.human.js');

--- a/wherehows-web/ember-cli-build.js
+++ b/wherehows-web/ember-cli-build.js
@@ -89,7 +89,7 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
 
   app.import('bower_components/jquery-ui/themes/base/jquery-ui.css');
-  app.import('bower_components/jquery.fancytree/dist/skin-win8/ui.fancytree.min.css');
+  // app.import('bower_components/jquery.fancytree/dist/skin-win8/ui.fancytree.min.css');
   app.import('vendor/fancytree/src/skin-wherehows/ui.wherehows.css');
   app.import('bower_components/font-awesome/css/font-awesome.min.css');
   app.import('bower_components/json-human/css/json.human.css');
@@ -122,8 +122,8 @@ module.exports = function(defaults) {
   app.import('vendor/dagre-d3/js/tipsy.js');
   app.import('vendor/dagre-d3/js/jquery.contextMenu.js');
   app.import('vendor/d3pie-0.18/d3pie-customized.js');
-  app.import('bower_components/jquery.fancytree/dist/jquery.fancytree.min.js');
-  app.import('bower_components/jquery.fancytree/dist/src/jquery.fancytree.filter.js');
+  // app.import('bower_components/jquery.fancytree/dist/jquery.fancytree.min.js');
+  // app.import('bower_components/jquery.fancytree/dist/src/jquery.fancytree.filter.js');
   app.import('bower_components/jquery.scrollTo/jquery.scrollTo.min.js');
   app.import('bower_components/jquery-treegrid/js/jquery.treegrid.js');
   app.import('bower_components/json-human/src/json.human.js');

--- a/wherehows-web/package.json
+++ b/wherehows-web/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember test --launch Chrome",
+    "test": "./node_modules/.bin/ember test --launch Chrome",
     "precommit": "lint-staged",
-    "coverage": "COVERAGE=true npm run test",
+    "coverage": "COVERAGE=true npm run test && ./node_modules/.bin/codecov -f coverage/coverage-final.json",
     "eslint-check-prettier-conflict": "./node_modules/.bin/eslint --print-config .eslintrc.js | ./node_modules/.bin/eslint-config-prettier-check"
   },
   "devDependencies": {
@@ -33,12 +33,13 @@
     "broccoli-asset-rev": "^2.6.0",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
+    "codecov": "^3.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
     "ember-cli-app-version": "^3.1.0",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-bootstrap-sassy": "^0.5.6",
-    "ember-cli-code-coverage": "kategengler/ember-cli-code-coverage",
+    "ember-cli-code-coverage": "theseyi/ember-cli-code-coverage",
     "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-eyeglass": "^3.3.1",
     "ember-cli-htmlbars": "^2.0.3",

--- a/wherehows-web/yarn.lock
+++ b/wherehows-web/yarn.lock
@@ -328,6 +328,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -2041,6 +2045,14 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+codecov@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.0.tgz#c273b8c4f12945723e8dc9d25803d89343e5f28e"
+  dependencies:
+    argv "0.0.2"
+    request "2.81.0"
+    urlgrey "0.4.4"
+
 coffee-script@^1.10.0:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
@@ -2555,9 +2567,9 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     rsvp "^3.0.18"
     sane "^1.1.1"
 
-ember-cli-code-coverage@kategengler/ember-cli-code-coverage:
+ember-cli-code-coverage@theseyi/ember-cli-code-coverage:
   version "0.4.2"
-  resolved "https://codeload.github.com/kategengler/ember-cli-code-coverage/tar.gz/be5b69899968c6e96a7da269c5cf26bf88de68e5"
+  resolved "https://codeload.github.com/theseyi/ember-cli-code-coverage/tar.gz/75acde3febdbf7da87153d98e12343b54115b3f4"
   dependencies:
     babel-core "^6.24.1"
     babel-plugin-transform-async-to-generator "^6.24.1"
@@ -7543,6 +7555,10 @@ untildify@^2.1.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
   dependencies:
     os-homedir "^1.0.0"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 user-home@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
…adds forked version for e-c-code-coverage with support for transpiled sources. updates gradle build to run ember test with coverage. removes custom yarn version. removes broken fancy tree dep. minor refactor to WIP fetch wrapper: adds doc and exports