### PR TITLE
Changing from int to str

### DIFF
--- a/wherehows-etl/src/main/resources/jython/OozieExtract.py
+++ b/wherehows-etl/src/main/resources/jython/OozieExtract.py
@@ -162,7 +162,7 @@ class OozieExtract:
       schedule_record = OozieFlowScheduleRecord(self.app_id,
                                                 row['app_path'],
                                                 row['time_unit'],
-                                                int(row['frequency']),
+                                                str(row['frequency']),
                                                 None,
                                                 row['start_time'],
                                                 row['end_time'],


### PR DESCRIPTION
Changing from int to str since the OozieFlowScheduleRecord class itself is already expecting a str.

```public class OozieFlowScheduleRecord extends AzkabanFlowScheduleRecord {
  public OozieFlowScheduleRecord(Integer appId, String flowPath, String frequency, Integer interval,
    String cronExpression, Long effectiveStartTime, Long effectiveEndTime, String refId, Long whExecId) {
    super(appId, flowPath, frequency, interval, cronExpression, effectiveStartTime, effectiveEndTime, refId, whExecId);
  }
}
```

This is causing issue: https://github.com/linkedin/WhereHows/issues/903