### PR TITLE
 transitions to complianceDataTypes mid tier api for default security classification

### DIFF
--- a/wherehows-web/app/constants/datasets/compliance.ts
+++ b/wherehows-web/app/constants/datasets/compliance.ts
@@ -10,9 +10,9 @@ enum SuggestionIntent {
  * Defines the string values that are allowed for a classification
  */
 enum Classification {
-  Confidential = 'confidential',
-  LimitedDistribution = 'limitedDistribution',
-  HighlyConfidential = 'highlyConfidential'
+  Confidential = 'CONFIDENTIAL',
+  LimitedDistribution = 'LIMITED_DISTRIBUTION',
+  HighlyConfidential = 'HIGHLY_CONFIDENTIAL'
 }
 
 /**
@@ -100,7 +100,7 @@ interface INonIdLogicalTypesSignature {
 interface IComplianceField {
   identifierType: ComplianceFieldIdValue;
   logicalType: IdLogicalType | null;
-  classification: Classification;
+  classification: Classification | null;
   privacyPolicyExists: boolean;
   isDirty: boolean;
   suggestion?: {

--- a/wherehows-web/app/styles/components/nacho/_nacho-select.scss
+++ b/wherehows-web/app/styles/components/nacho/_nacho-select.scss
@@ -67,17 +67,4 @@ $default-border: (1px solid shade($color, 20%));
       visibility: hidden;
     }
   }
-
-  &--pre-wrap {
-    height: item-spacing(7);
-
-    &::after {
-      margin-bottom: 15px;
-    }
-
-    select {
-      white-space: pre-wrap;
-      margin-bottom: 15px;
-    }
-  }
 }

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
@@ -1,7 +1,9 @@
 <section class="metadata-prompt">
   <header class="metadata-prompt__header">
     <p>
-      {{if isEditing "Does any field in the schema contain an IDs (e.g. Member ID, Enterprise Profile ID etc) or other PII information?" "IDs and PII in the schema"}}
+      {{if isEditing
+           "Does any field in the schema contain an IDs (e.g. Member ID, Enterprise Profile ID etc) or other PII information?"
+           "IDs and PII in the schema"}}
       <a
         target="_blank"
         href="http://go/gdpr-pii">
@@ -53,7 +55,7 @@
         System Suggestion Confidence
       {{/head.column}}
       {{#head.column class="nacho-table-cell-wrapped"}}
-        ID Type
+        Compliance Information
         <a
           target="_blank"
           href="http://go/metadata_acquisition#ProjectOverview-compliance">
@@ -65,25 +67,11 @@
           </sup>
         </a>
       {{/head.column}}
-      {{#head.column class="nacho-table-cell-wrapped dataset-compliance-fields__classification-column"}}
-        Security Classification
-        <sup>
-          <span
-            class="glyphicon glyphicon-question-sign"
-            title={{helpText.classification}}>
-            {{tooltip-on-component
-              event="click"
-              hideOn="click"
-              text=helpText.classification
-            }}
-          </span>
-        </sup>
-      {{/head.column}}
     {{/table.head}}
 
     <tr>
       <th></th>
-      <th colspan="5">
+      <th colspan="4">
         {{disable-bubble-input
           title="Search field names"
           placeholder="Search field names"
@@ -187,16 +175,31 @@
                 <p class="dataset-compliance-fields__current-value">Current: {{row.logicalTypeBeforeSuggestion}}</p>
               {{/if}}
             </div>
-          {{/row.cell}}
 
-          {{#row.cell class="dataset-compliance-fields__tall-cell"}}
-            {{ember-selector
-              class="nacho-select--hidden-state nacho-select--pre-wrap"
-              values=classifiers
-              selected=row.classification
-              disabled=(or (not isEditing) (not row.logicalType))
-              selectionDidChange=(action row.onFieldClassificationChange)
-            }}
+            <div>
+              <span>
+                Security Classification
+                <sup>
+                  <span
+                    class="glyphicon glyphicon-question-sign"
+                    title={{helpText.classification}}>
+                    {{tooltip-on-element
+                      event="click"
+                      hideOn="click"
+                      text=helpText.classification
+                    }}
+                  </span>
+                </sup>
+              </span>
+
+              {{ember-selector
+                class="nacho-select--hidden-state"
+                disabled=(not isEditing)
+                values=classifiers
+                selected=row.classification
+                selectionDidChange=(action row.onFieldClassificationChange)
+              }}
+            </div>
           {{/row.cell}}
         {{/body.row}}
       {{/each}}

--- a/wherehows-web/app/utils/array.ts
+++ b/wherehows-web/app/utils/array.ts
@@ -16,6 +16,7 @@ const arrayFilter = <T>(filtrationFunction: (param: T) => boolean): ((array: Arr
 
 /**
  * Composable reducer abstraction, curries a reducing iteratee and returns a reducing function that takes a list
+ * @template U
  * @param {(acc: U) => U} iteratee
  * @param {U} init the initial value in the reduction sequence
  * @return {(arr: Array<T>) => U}
@@ -27,6 +28,7 @@ const arrayReduce = <T, U>(
 
 /**
  * Duplicate check using every to short-circuit iteration
+ * @template T
  * @param {Array<T>} [list = []] list to check for dupes
  * @return {boolean} true is unique
  */
@@ -34,6 +36,7 @@ const isListUnique = <T>(list: Array<T> = []): boolean => new Set(list).size ===
 
 /**
  * Extracts all non falsey values from a list.
+ * @template T
  * @param {Array<T>} list the list of items to compact
  * @return {Array<T>}
  */

--- a/wherehows-web/tests/unit/utils/datasets/metadata-acquisition-test.js
+++ b/wherehows-web/tests/unit/utils/datasets/metadata-acquisition-test.js
@@ -1,7 +1,6 @@
 import {
   lastSeenSuggestionInterval,
   lowQualitySuggestionConfidenceThreshold,
-  defaultFieldDataTypeClassification,
   logicalTypeValueLabel,
   formatAsCapitalizedStringWithSpaces
 } from 'wherehows-web/constants/metadata-acquisition';
@@ -54,12 +53,6 @@ test('lowQualitySuggestionConfidenceThreshold is a number', function(assert) {
   assert.ok(typeof lowQualitySuggestionConfidenceThreshold === 'number');
 });
 
-test('defaultFieldDataTypeClassification has classification values in classification enum', function(assert) {
-  Object.values(defaultFieldDataTypeClassification).forEach(classification => {
-    assert.ok(classificationStrings.includes(classification));
-  });
-});
-
 test('logicalTypeValueLabel generates correct labels for generic types', function(assert) {
   const labels = logicalTypeValueLabel('generic');
   labels.forEach(({ label, value }) => {
@@ -85,9 +78,9 @@ test('logicalTypeValueLabel generates correct labels for id types', function(ass
 
 test('formatAsCapitalizedStringWithSpaces generates the correct display string', function(assert) {
   [
-    ['confidential', 'Confidential'],
-    ['limitedDistribution', 'Limited Distribution'],
-    ['highlyConfidential', 'Highly Confidential']
+    ['CONFIDENTIAL', 'Confidential'],
+    ['LIMITED_DISTRIBUTION', 'Limited distribution'],
+    ['HIGHLY_CONFIDENTIAL', 'Highly confidential']
   ].forEach(([source, target]) => {
     assert.equal(formatAsCapitalizedStringWithSpaces(source), target, `correctly converts ${source}`);
   });

--- a/wherehows-web/tests/unit/utils/datasets/metadata-acquisition-test.js
+++ b/wherehows-web/tests/unit/utils/datasets/metadata-acquisition-test.js
@@ -4,21 +4,10 @@ import {
   logicalTypeValueLabel,
   formatAsCapitalizedStringWithSpaces
 } from 'wherehows-web/constants/metadata-acquisition';
-import {
-  Classification,
-  nonIdFieldLogicalTypes,
-  NonIdLogicalType,
-  IdLogicalType
-} from 'wherehows-web/constants/datasets/compliance';
+import { nonIdFieldLogicalTypes, NonIdLogicalType, IdLogicalType } from 'wherehows-web/constants/datasets/compliance';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | datasets/metadata acquisition');
-
-/**
- * A list of classification strings for a dataset field
- * @type {Array<Classification>}
- */
-const classificationStrings = Object.values(Classification);
 
 /**
  * A list of display string for non-id field logical types


### PR DESCRIPTION
- removes obsolete tests. updates compliance table to render all user updatable compliance info in single column
- removes unused import in test: metadata-acquisition