### PR TITLE
Route after auth

### DIFF
--- a/wherehows-web/app/routes/application.js
+++ b/wherehows-web/app/routes/application.js
@@ -77,7 +77,11 @@ export default Route.extend(ApplicationRouteMixin, {
    */
   sessionAuthenticated() {
     this._super(...arguments);
-    this._loadCurrentUser();
+    this._loadCurrentUser().then(() => {
+      // Will go to the route before the redirect to authenticate
+      // this.transitionTo(this.controllerFor('application').get('previousRouteName'));
+      this.transitionTo(undefined);
+    });
   },
 
   /**

--- a/wherehows-web/app/routes/application.js
+++ b/wherehows-web/app/routes/application.js
@@ -79,8 +79,7 @@ export default Route.extend(ApplicationRouteMixin, {
     this._super(...arguments);
     this._loadCurrentUser().then(() => {
       // Will go to the route before the redirect to authenticate
-      // this.transitionTo(this.controllerFor('application').get('previousRouteName'));
-      this.transitionTo(undefined);
+      this.transitionTo(this.controllerFor('application').get('previousRouteName'));
     });
   },
 

--- a/wherehows-web/tests/acceptance/login-test.js
+++ b/wherehows-web/tests/acceptance/login-test.js
@@ -6,7 +6,9 @@ import {
   authenticationUrl,
   invalidCredentials,
   testUser,
-  testPasswordInvalid
+  testPassword,
+  testPasswordInvalid,
+  protectedRoute
 } from 'wherehows-web/tests/helpers/login/constants';
 import {
   loginUserInput,
@@ -64,4 +66,18 @@ test('should display invalid password message with invalid password entered', as
     'Invalid Password',
     'displays invalid password message in error message container'
   );
+});
+
+test('should return to previous url after login', async function(assert) {
+  assert.expect(3);
+  assert.equal(currentURL(), authenticationUrl, `the current url is ${authenticationUrl}`);
+  await visit(protectedRoute);
+
+  assert.equal(currentURL(), authenticationUrl, 'Redirects to auth url when reaching protected route');
+  // Expected to be a successful login
+  await fillIn(loginUserInput, testUser);
+  await fillIn(loginPasswordInput, testPassword);
+  await click(loginSubmitButton);
+
+  assert.equal(currentURL(), protectedRoute, 'After login will redirect to previous route');
 });

--- a/wherehows-web/tests/helpers/login/constants.ts
+++ b/wherehows-web/tests/helpers/login/constants.ts
@@ -28,5 +28,10 @@ const testPassword = 'validPassword';
  * @type {string}
  */
 const testPasswordInvalid = 'invalidPassword';
+/**
+ * Example of a protected route to test whether we are redirected to the authentication route
+ * @type {string}
+ */
+const protectedRoute = '/schemas/page/1';
 
-export { loginContainer, authenticationUrl, invalidCredentials, testUser, testPassword, testPasswordInvalid };
+export { loginContainer, authenticationUrl, invalidCredentials, testUser, testPassword, testPasswordInvalid, protectedRoute };


### PR DESCRIPTION
Helps to ensure that the route transitioned into after authentication is the route the user tried to reach before needing a redirect to the authentication route.

Testing results:
```
just ember test
ok 58 Chrome 65.0 - Acceptance | login: should return to previous url after login
...
1..348
# tests 348
# pass  341
# skip  7
# fail  0

# ok
```