### PR TITLE
fix ownership checking bug

### DIFF
--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -81,7 +81,7 @@ export default class DatasetAuthors extends Component {
    * @type {ComputedProperty<boolean>}
    * @memberof DatasetAuthors
    */
-  requiredMinNotConfirmed: ComputedProperty<boolean> = computed('confirmedOwners.length', function(
+  requiredMinNotConfirmed: ComputedProperty<boolean> = computed('confirmedOwners.@each.type', function(
     this: DatasetAuthors
   ) {
     return isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));

--- a/wherehows-web/app/utils/api/datasets/owners.ts
+++ b/wherehows-web/app/utils/api/datasets/owners.ts
@@ -25,7 +25,7 @@ enum OwnerIdType {
  * @type {string}
  */
 enum OwnerType {
-  Owner = 'Owner',
+  Owner = 'DataOwner',
   Consumer = 'Consumer',
   Delegate = 'Delegate',
   Producer = 'Producer',

--- a/wherehows-web/mirage/fixtures/owners.ts
+++ b/wherehows-web/mirage/fixtures/owners.ts
@@ -1,5 +1,5 @@
 import { IOwner } from 'wherehows-web/typings/api/datasets/owners';
-import { OwnerSource, OwnerIdType, OwnerUrnNamespace } from 'wherehows-web/utils/api/datasets/owners';
+import { OwnerSource, OwnerIdType, OwnerUrnNamespace, OwnerType } from 'wherehows-web/utils/api/datasets/owners';
 
 export default <Array<IOwner>>[
   {
@@ -14,7 +14,7 @@ export default <Array<IOwner>>[
     namespace: OwnerUrnNamespace.corpUser,
     source: OwnerSource.Ui,
     subType: null,
-    type: 'DataOwner'
+    type: OwnerType.Owner
   },
   {
     confirmedBy: '',
@@ -28,6 +28,6 @@ export default <Array<IOwner>>[
     namespace: OwnerUrnNamespace.corpUser,
     source: OwnerSource.Nuage,
     subType: null,
-    type: 'DataOwner'
+    type: OwnerType.Owner
   }
 ];

--- a/wherehows-web/mirage/fixtures/owners.ts
+++ b/wherehows-web/mirage/fixtures/owners.ts
@@ -14,7 +14,7 @@ export default <Array<IOwner>>[
     namespace: OwnerUrnNamespace.corpUser,
     source: OwnerSource.Ui,
     subType: null,
-    type: 'Owner'
+    type: 'DataOwner'
   },
   {
     confirmedBy: '',
@@ -28,6 +28,6 @@ export default <Array<IOwner>>[
     namespace: OwnerUrnNamespace.corpUser,
     source: OwnerSource.Nuage,
     subType: null,
-    type: 'Owner'
+    type: 'DataOwner'
   }
 ];


### PR DESCRIPTION
Match mapping on frontend with mapping on backend as `DataOnwer` instead of `Owner`. Check for confirmed owners using `@each.type` to rerun check when type is changed by user, not just when owners are added or removed. 

Testing done:

`just ember test` results:

```
ok 1 Chrome 65.0 - ESLint | mirage: mirage/factories/access.js
ok 2 Chrome 65.0 - ESLint | mirage: mirage/factories/column.js
...
ok 347 Chrome 65.0 - Unit | Utility | validators/urn: buildLiUrn
ok 348 Chrome 65.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..348
# tests 348
# pass  342
# skip  6
# fail  0

# ok
```