### PR TITLE
Dataset owner selection revamp

### DIFF
--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -106,6 +106,16 @@ export default class DatasetAuthors extends Component {
   confirmedOwners: ComputedProperty<Array<IOwner>> = filter('owners', isConfirmedOwner);
 
   /**
+   * Boolean that determines whether the user is currently using the typeahead box to add an
+   * owner. This is triggered to true when the user clicks on Add an Owner in the table and
+   * returns to false at the end of the addOwner action
+   * @type {boolean}
+   * @default false
+   * @memberof DatasetAuthors
+   */
+  isAddingOwner = false;
+
+  /**
    * Intersection of confirmed owners and suggested owners
    * @type {ComputedProperty<Array<IOwner>>}
    * @memberof DatasetAuthors

--- a/wherehows-web/app/routes/datasets/dataset.ts
+++ b/wherehows-web/app/routes/datasets/dataset.ts
@@ -106,7 +106,7 @@ export default class DatasetRoute extends Route {
     setProperties(controller, {
       isInternal: !!isInternal,
       jitAclAccessWhitelist: jitAclAccessWhitelist || [],
-      showOwnership
+      showOwnership: 'show' || showOwnership
     });
   }
 

--- a/wherehows-web/app/routes/datasets/dataset.ts
+++ b/wherehows-web/app/routes/datasets/dataset.ts
@@ -106,7 +106,7 @@ export default class DatasetRoute extends Route {
     setProperties(controller, {
       isInternal: !!isInternal,
       jitAclAccessWhitelist: jitAclAccessWhitelist || [],
-      showOwnership: 'show' || showOwnership
+      showOwnership: showOwnership || 'hide'
     });
   }
 

--- a/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
@@ -54,3 +54,17 @@
     margin-left: item-spacing(4);
   }
 }
+
+.dataset-authors-save {
+  float: right;
+}
+
+.dataset-authors-save-error {
+  float: right;
+  padding-top: 10px;
+  margin-right: 64px;
+
+  &__icon {
+    color: set-color(red, red5);
+  }
+}

--- a/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
@@ -65,7 +65,7 @@
   margin-right: 64px;
 
   &__icon {
-    color: set-color(red, red5);
+    color: get-color(red5);
     margin-right: 8px;
   }
 }

--- a/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
@@ -66,5 +66,6 @@
 
   &__icon {
     color: set-color(red, red5);
+    margin-right: 8px;
   }
 }

--- a/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_dataset-author.scss
@@ -29,8 +29,9 @@
     }
 
     &--inactive {
-      background-color: set-color(red, maroonflush);
+      background-color: set-color(red, red5);
       pointer-events: none;
+      margin-left: 8px;
     }
   }
 }

--- a/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
@@ -57,6 +57,10 @@ $user-name-width: 170px;
   &--narrow {
     width: 9%;
   }
+
+  &--extra-wide {
+    width: 28%;
+  }
 }
 
 .dataset-owner-table {
@@ -75,6 +79,33 @@ $user-name-width: 170px;
 
   &#{&} &--wrap {
     white-space: normal;
+  }
+
+  &__add-owner {
+    height: 84px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 0 24px;
+
+    .twitter-typeahead {
+      width: 142px;
+    }
+  }
+
+  &__trigger {
+    cursor: pointer;
+  }
+
+  .remove-dataset-author {
+    color: set-color(grey, mid);
+    background-color: transparent;
+    float: right;
+
+    &:hover {
+      background-color: transparent;
+      color: set-color(grey, dark);
+    }
   }
 }
 

--- a/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
@@ -94,7 +94,7 @@ $user-name-width: 170px;
   }
 
   &__trigger {
-    color: rgba(0, 132, 191, 1);
+    color: get-color(blue6);
     font-weight: 600;
     cursor: pointer;
   }

--- a/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_owner-table.scss
@@ -94,6 +94,8 @@ $user-name-width: 170px;
   }
 
   &__trigger {
+    color: rgba(0, 132, 191, 1);
+    font-weight: 600;
     cursor: pointer;
   }
 

--- a/wherehows-web/app/styles/components/user-lookup/_user-lookup.scss
+++ b/wherehows-web/app/styles/components/user-lookup/_user-lookup.scss
@@ -3,11 +3,12 @@
   position: relative;
 
   &::after {
-    content: '\e003';
+    content: '\2b';
     position: absolute;
     top: item-spacing(3);
-    right: item-spacing(2);
+    left: item-spacing(2);
     z-index: z(default);
+    color: rgba(0, 0, 0, 0.5);
     display: inline-block;
     font-family: 'Glyphicons Halflings';
     font-style: normal;
@@ -21,7 +22,7 @@
     outline: none;
     border-radius: 0;
     border: 1px solid set-color(grey, light);
-    padding: item-spacing(2 5 2 3);
+    padding: item-spacing(2 5 2 6);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     transition: box-shadow ease-in-out 0.15s;
     line-height: 1.428;

--- a/wherehows-web/app/templates/components/dataset-author.hbs
+++ b/wherehows-web/app/templates/components/dataset-author.hbs
@@ -31,6 +31,21 @@
 
 {{/unless}}
 
+{{#unless (eq showOwnership "show")}}
+  <td>
+    {{#if owner.modifiedTime}}
+      {{moment-calendar owner.modifiedTime sameElse="MMM Do YYYY, h:mm a"}}
+    {{else}}
+
+      <span
+        class="nacho-button nacho-button--small dataset-author-record__indicator--disabled">
+        Not Saved
+      </span>
+
+    {{/if}}
+  </td>
+{{/unless}}
+
 <td>
   {{ember-selector
     class=(unless isOwnerMutable "nacho-select--hidden-state")

--- a/wherehows-web/app/templates/components/dataset-author.hbs
+++ b/wherehows-web/app/templates/components/dataset-author.hbs
@@ -7,7 +7,6 @@
 
   {{#if isOwnerInActive}}
 
-    <br>
     <span class="nacho-button nacho-button--small dataset-author-record__indicator--inactive">
       Inactive
     </span>
@@ -31,20 +30,6 @@
   </td>
 
 {{/unless}}
-
-<td>
-  {{#if owner.modifiedTime}}
-    {{moment-calendar owner.modifiedTime sameElse="MMM Do YYYY, h:mm a"}}
-  {{else}}
-
-    <span
-      class="nacho-button nacho-button--small dataset-author-record__indicator--disabled">
-      Not Saved
-    </span>
-
-  {{/if}}
-</td>
-
 
 <td>
   {{ember-selector

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -12,14 +12,16 @@
   </section>
 {{/if}}
 
-<p class="dataset-author__required-count">
-  {{#if requiredMinNotConfirmed}}
+{{#if (eq showOwnership "hide")}}
+  <p class="dataset-author__required-count">
+    {{#if requiredMinNotConfirmed}}
 
-    Add <strong>{{ownersRequiredCount}}</strong> owner(s) with ID Type - <code>USER</code>
-    , Ownership Type - <code>Data Owner</code>, and who is also <code>Active</code>
+      Add <strong>{{ownersRequiredCount}}</strong> owner(s) with ID Type - <code>USER</code>
+      , Ownership Type - <code>Data Owner</code>, and who is also <code>Active</code>
 
-  {{/if}}
-</p>
+    {{/if}}
+  </p>
+{{/if}}
 
 {{#if (eq showOwnership "show")}}
 
@@ -226,9 +228,25 @@
 
     {{#if requiredMinNotConfirmed}}
       <div class="dataset-authors-save-error">
-        {{fa-icon "times-circle-o" class="dataset-authors-save-error__icon"}}
-        Add at least 2 owners.
+        <p>
+          {{fa-icon "times-circle-o" class="dataset-authors-save-error__icon"}}
+          {{#if (eq ownersRequiredCount 2)}}
+            Add at least 2 owners.
+          {{else}}
+            Add at least {{ownersRequiredCount}} more owner(s).
+          {{/if}}
+        </p>
       </div>
     {{/if}}
   </div>
 </section>
+
+
+  <p class="dataset-author__required-count">
+    {{#if requiredMinNotConfirmed}}
+
+      Add <strong>{{ownersRequiredCount}}</strong> owner(s) with ID Type - <code>USER</code>
+      , Ownership Type - <code>Data Owner</code>, and who is also <code>Active</code>
+
+    {{/if}}
+  </p>

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -26,11 +26,11 @@
   <section class="dataset-author">
     <header>
       <h2 class="dataset-author__header">
-        Owners Confirmed
+        Owners
       </h2>
 
       <p class="dataset-author__byline">
-        These are dataset ownership records that have been manually entered / confirmed by a human
+        Please add at least <strong>2</strong> owners.
       </p>
     </header>
 
@@ -211,7 +211,6 @@
 
 <section class="action-bar">
   <div class="container action-bar__content">
-
     <button
       class="nacho-button nacho-button--large-inverse action-bar__item dataset-authors-save"
       disabled={{requiredMinNotConfirmed}}
@@ -225,5 +224,11 @@
 
     </button>
 
+    {{#if requiredMinNotConfirmed}}
+      <div class="dataset-authors-save-error">
+        {{fa-icon "times-circle-o" class="dataset-authors-save-error__icon"}}
+        Add at least 2 owners.
+      </div>
+    {{/if}}
   </div>
 </section>

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -37,12 +37,12 @@
     <table class="nacho-table nacho-table--bordered dataset-owner-table">
       <thead>
       <tr>
-        <th class={{if (eq showOwnership "show") "dataset-author-column--extra-wide" "dataset-author-column--wide"}}>
+        <th class="dataset-author-column--extra-wide">
           LDAP Username
         </th>
-        <th class={{if (eq showOwnership "show") "dataset-author-column--extra-wide"}}>Full Name</th>
+        <th class="dataset-author-column--extra-wide">Full Name</th>
         <th class="dataset-author-column--narrow">ID Type</th>
-        <th class={{if (eq showOwnership "show") "dataset-author-column--wide"}}>
+        <th class="dataset-author-column--wide">
           Ownership Type
 
           <!--TODO: DSS-6716-->

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -240,13 +240,3 @@
     {{/if}}
   </div>
 </section>
-
-
-  <p class="dataset-author__required-count">
-    {{#if requiredMinNotConfirmed}}
-
-      Add <strong>{{ownersRequiredCount}}</strong> owner(s) with ID Type - <code>USER</code>
-      , Ownership Type - <code>Data Owner</code>, and who is also <code>Active</code>
-
-    {{/if}}
-  </p>

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -1,14 +1,16 @@
-<section class="dataset-author-user-lookup">
-  <header>
-    <h2 class="dataset-author-user-lookup__header">
-      Add an Owner
-    </h2>
-  </header>
+{{#if (eq showOwnership "hide")}}
+  <section class="dataset-author-user-lookup">
+    <header>
+      <h2 class="dataset-author-user-lookup__header">
+        Add an Owner
+      </h2>
+    </header>
 
-  <div class="dataset-author-user-lookup__container">
-    {{user-lookup didFindUser=(action "addOwner")}}
-  </div>
-</section>
+    <div class="dataset-author-user-lookup__container">
+      {{user-lookup didFindUser=(action "addOwner")}}
+    </div>
+  </section>
+{{/if}}
 
 <p class="dataset-author__required-count">
   {{#if requiredMinNotConfirmed}}
@@ -19,27 +21,28 @@
   {{/if}}
 </p>
 
-<section class="dataset-author">
-  <header>
-    <h2 class="dataset-author__header">
-      Owners Confirmed
-    </h2>
+{{#if (eq showOwnership "show")}}
 
-    <p class="dataset-author__byline">
-      These are dataset ownership records that have been manually entered / confirmed by a human
-    </p>
-  </header>
+  <section class="dataset-author">
+    <header>
+      <h2 class="dataset-author__header">
+        Owners Confirmed
+      </h2>
 
-  {{#if confirmedOwners.length}}
+      <p class="dataset-author__byline">
+        These are dataset ownership records that have been manually entered / confirmed by a human
+      </p>
+    </header>
 
     <table class="nacho-table nacho-table--bordered dataset-owner-table">
       <thead>
       <tr>
-        <th class="dataset-author-column--wide">LDAP Username</th>
-        <th>Full Name</th>
+        <th class={{if (eq showOwnership "show") "dataset-author-column--extra-wide" "dataset-author-column--wide"}}>
+          LDAP Username
+        </th>
+        <th class={{if (eq showOwnership "show") "dataset-author-column--extra-wide"}}>Full Name</th>
         <th class="dataset-author-column--narrow">ID Type</th>
-        <th>Last Modified</th>
-        <th>
+        <th class={{if (eq showOwnership "show") "dataset-author-column--wide"}}>
           Ownership Type
 
           <!--TODO: DSS-6716-->
@@ -53,34 +56,89 @@
             </sup>
           </a>
         </th>
-        <th>Remove Owner</th>
+        <th></th>
       </tr>
       </thead>
 
       {{#each confirmedOwners as |confirmedOwner|}}
-
         <tbody>
         {{dataset-author
           owner=confirmedOwner
           ownerTypes=ownerTypes
+          showOwnership=showOwnership
           removeOwner=(action "removeOwner")
           confirmSuggestedOwner=(action "confirmSuggestedOwner")
           updateOwnerType=(action "updateOwnerType")
         }}
         </tbody>
-      {{else}}
       {{/each}}
+
+      <tbody>
+        <tr>
+          <div class="dataset-owner-table__add-owner">
+            {{#if isAddingOwner}}
+              {{user-lookup didFindUser=(action "addOwner")}}
+            {{else}}
+              <span class="dataset-owner-table__trigger" {{action (mut isAddingOwner) true}}>
+                {{fa-icon "plus"}} Add an owner
+              </span>
+            {{/if}}
+          </div>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+{{else}}
+
+  <section class="dataset-author">
+    <header>
+      <h2 class="dataset-author__header">
+        Owners Confirmed
+      </h2>
+
+      <p class="dataset-author__byline">
+        These are dataset ownership records that have been manually entered / confirmed by a human
+      </p>
+    </header>
+
+    {{#if confirmedOwners.length}}
+
+    <table class="nacho-table nacho-table--bordered dataset-owner-table">
+      <thead>
+        <tr>
+          <th class="dataset-author-column--wide">LDAP Username</th>
+          <th>Full Name</th>
+          <th class="dataset-author-column--narrow">ID Type</th>
+          <th>Last Modified</th>
+          <th>
+            Ownership Type
+
+            <!--TODO: DSS-6716-->
+            <!-- DRY out with wrapper component that takes the link as an attribute-->
+            <a target="_blank" href="https://iwww.corp.linkedin.com/wiki/cf/display/DWH/Metadata+Acquisition#ProjectOverview-ownership">
+              <sup>
+                <span class="glyphicon glyphicon-question-sign" title="Link to more information"></span>
+              </sup>
+            </a>
+          </th>
+          <th>Remove Owner</th>
+        </tr>
+      </thead>
+
+      {{#each confirmedOwners as |confirmedOwner|}}
+
+      <tbody>
+        {{dataset-author owner=confirmedOwner ownerTypes=ownerTypes removeOwner=(action "removeOwner") confirmSuggestedOwner=(action
+        "confirmSuggestedOwner") updateOwnerType=(action "updateOwnerType") }}
+      </tbody>
+      {{else}} {{/each}}
     </table>
 
-  {{else}}
+    {{else}} {{empty-state heading="No Confirmed Owners" subHead="Search for users above to add to the list of owners" }} {{/if}}
+  </section>
 
-    {{empty-state
-      heading="No Confirmed Owners"
-      subHead="Search for users above to add to the list of owners"
-    }}
-
-  {{/if}}
-</section>
+{{/if}}
 
 {{#if systemGeneratedOwners}}
 

--- a/wherehows-web/app/templates/components/user-lookup.hbs
+++ b/wherehows-web/app/templates/components/user-lookup.hbs
@@ -5,6 +5,6 @@
   async=true
   limit=10
   minLength=2
-  placeholder="Find user by LDAP"
+  placeholder="Add an Owner"
   title="username"
   class="user-lookup__input"}}

--- a/wherehows-web/tests/integration/components/datasets/containers/dataset-ownership-test.js
+++ b/wherehows-web/tests/integration/components/datasets/containers/dataset-ownership-test.js
@@ -22,7 +22,7 @@ moduleForComponent(
 );
 
 test('it renders', async function(assert) {
-  const lookupClass = '.dataset-author-user-lookup';
+  const lookupClass = '.dataset-owner-table__add-owner';
   this.set('urn', urn);
   this.server.respondWith('GET', /\/api\/v2\/datasets.*/, [
     200,
@@ -35,12 +35,12 @@ test('it renders', async function(assert) {
     JSON.stringify([])
   ]);
 
-  this.render(hbs`{{datasets/containers/dataset-ownership urn=urn}}`);
+  this.render(hbs`{{datasets/containers/dataset-ownership urn=urn showOwnership="show"}}`);
 
   await waitUntil(() => find(lookupClass));
   assert.equal(
     document.querySelector(lookupClass).textContent.trim(),
-    'Add an Owner',
+    'Add an owner',
     'shows dataset authors component'
   );
 });


### PR DESCRIPTION
Modify ownership table to include the trigger to add owner and slight styling revamps to fit new UX

`ember test` results:
```
ok 1 Chrome 66.0 - ESLint | mirage: mirage/factories/access.js
ok 2 Chrome 66.0 - ESLint | mirage: mirage/factories/column.js
...
ok 351 Chrome 66.0 - Unit | Utility | validators/urn: buildLiUrn
ok 352 Chrome 66.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..352
# tests 352
# pass  346
# skip  6
# fail  0

# ok
```

<img width="1173" alt="screen shot 2018-04-22 at 11 34 06 pm" src="https://user-images.githubusercontent.com/16459843/39110367-c42d97ca-4685-11e8-9e9e-c21e1563f8d5.png">
<img width="1177" alt="screen shot 2018-04-22 at 11 34 25 pm" src="https://user-images.githubusercontent.com/16459843/39110368-c4485aec-4685-11e8-8ef6-7f1400402aea.png">
