### PR TITLE
Remove extra step to trigger typeahead search

### DIFF
--- a/wherehows-web/app/components/search-bar-form.js
+++ b/wherehows-web/app/components/search-bar-form.js
@@ -47,11 +47,23 @@ export default Component.extend({
     /**
      * When a search action is performed, invoke the parent search action with
      *   the user entered search value as keyword and the currentFilter
-     *   as category
+     *   as category. Triggered by clicking the search button
      */
     search() {
       get(this, 'didSearch')({
         keyword: get(this, 'search'),
+        category: get(this, 'currentFilter')
+      });
+    },
+
+    /**
+     * Triggers a search action by the user pressing enter on a typeahead suggestion
+     * @param {string} suggestion - suggestion text passed in from aupac-typeahead
+     */
+    selectedSuggestion(suggestion) {
+      set(this, 'search', suggestion);
+      get(this, 'didSearch')({
+        keyword: suggestion,
         category: get(this, 'currentFilter')
       });
     },

--- a/wherehows-web/app/components/search-bar-form.js
+++ b/wherehows-web/app/components/search-bar-form.js
@@ -60,12 +60,9 @@ export default Component.extend({
      * Triggers a search action by the user pressing enter on a typeahead suggestion
      * @param {string} suggestion - suggestion text passed in from aupac-typeahead
      */
-    selectedSuggestion(suggestion) {
+    onSelectedSuggestion(suggestion) {
       set(this, 'search', suggestion);
-      get(this, 'didSearch')({
-        keyword: suggestion,
-        category: get(this, 'currentFilter')
-      });
+      this.actions.search.call(this);
     },
 
     /**

--- a/wherehows-web/app/templates/components/search-bar-form.hbs
+++ b/wherehows-web/app/templates/components/search-bar-form.hbs
@@ -3,7 +3,7 @@
     <label for="search-input" class="sr-only">Search</label>
 
     {{aupac-typeahead
-      action=(action (mut search))
+      action=(action "selectedSuggestion")
       autoFocus=true
       allowFreeInput=true
       source=(action "onInput")

--- a/wherehows-web/app/templates/components/search-bar-form.hbs
+++ b/wherehows-web/app/templates/components/search-bar-form.hbs
@@ -3,7 +3,7 @@
     <label for="search-input" class="sr-only">Search</label>
 
     {{aupac-typeahead
-      action=(action "selectedSuggestion")
+      action=(action "onSelectedSuggestion")
       autoFocus=true
       allowFreeInput=true
       source=(action "onInput")


### PR DESCRIPTION
Hitting enter on a suggestion will also trigger a search with that autocomplete value as the keyword. Previously, hitting enter would only autocomplete, and the user would need to press enter again to trigger the search, leading to an awkward user experience.

Change is to create an action that muts the `search` value in `search-bar-form` component and also triggers a search instead of just muting `search`

`just ember test` results:
```
ok 1 Chrome 66.0 - ESLint | mirage: mirage/factories/access.js
ok 2 Chrome 66.0 - ESLint | mirage: mirage/factories/column.js
ok 3 Chrome 66.0 - ESLint | mirage: mirage/factories/comment.js
...
ok 352 Chrome 66.0 - Unit | Utility | validators/urn: buildLiUrn
ok 353 Chrome 66.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..353
# tests 353
# pass  347
# skip  6
# fail  0

# ok
```