### PR TITLE
Update package.json

### DIFF
--- a/wherehows-web/package.json
+++ b/wherehows-web/package.json
@@ -19,6 +19,7 @@
     "eslint-check-prettier-conflict": "./node_modules/.bin/eslint --print-config .eslintrc.js | ./node_modules/.bin/eslint-config-prettier-check"
   },
   "devDependencies": {
+    "@ember-decorators/babel-transforms": "^2.0.1",
     "@types/ember": "^2.8.7",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/lodash": "^4.14.83",

--- a/wherehows-web/yarn.lock
+++ b/wherehows-web/yarn.lock
@@ -74,6 +74,15 @@
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.0"
 
+"@ember-decorators/babel-transforms@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/babel-transforms/-/babel-transforms-2.0.1.tgz#75b668cfe996fa920c940ad723be015cddf904db"
+  dependencies:
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators-legacy "^1.3.4"
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.1.0"
+
 "@ember-decorators/utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-0.2.0.tgz#395362c75c4f85aa63aa7cbed77a6486fd6e5f22"
@@ -2924,8 +2933,6 @@ ember-cli-code-coverage@theseyi/ember-cli-code-coverage:
   version "0.5.0"
   resolved "https://codeload.github.com/theseyi/ember-cli-code-coverage/tar.gz/2d9bd45dd438413f0a15f1bc58090014b555f804"
   dependencies:
-    babel-core "^6.24.1"
-    babel-plugin-transform-async-to-generator "^6.24.1"
     body-parser "^1.15.0"
     broccoli-filter "^1.2.3"
     broccoli-funnel "^1.0.1"


### PR DESCRIPTION
Adding `@ember-decorators/babel-transforms` to fix Ember deprecated warning message.

```
WARNING: ember-decorators (used in wherehows-web): You have not installed @ember-decorators/babel-transforms. It has been extracted to a separate addon. See instructions for installation: https://github.com/ember-decorators/babel-transforms#readme
```
