### PR TITLE
Implement new user lookup with ember power select typeahead

### DIFF
--- a/wherehows-web/app/components/pwr-user-lookup.ts
+++ b/wherehows-web/app/components/pwr-user-lookup.ts
@@ -1,0 +1,165 @@
+import { get, set, setProperties } from '@ember/object';
+import { typeOf } from '@ember/utils';
+import { action } from 'ember-decorators/object';
+import UserLookup from 'wherehows-web/components/user-lookup';
+import { Keyboard } from 'wherehows-web/constants/keyboard';
+import { suggestionLimit } from 'wherehows-web/constants/typeahead';
+import { IPowerSelectAPI } from 'wherehows-web/typings/modules/power-select';
+import noop from 'wherehows-web/utils/noop';
+
+/**
+ * The stepMap is used for keyboard event translation where up arrows mean we are decreasing our position in
+ * the list and down arrows mean we are increasing our position in the list
+ * @type {Object}
+ */
+const stepMap: { [key: number]: number } = {
+  [Keyboard['ArrowUp']]: -1,
+  [Keyboard['ArrowDown']]: 1
+};
+
+export default class PowerUserLookup extends UserLookup {
+  constructor() {
+    super();
+    this.classNames = (this.classNames || []).concat('pwr-user-lookup');
+    this.classNameBindings = (this.classNameBindings || []).concat('showPlaceholder:pwr-user-lookup--focused');
+  }
+
+  /**
+   * The currently selected person from the dropdown by the user
+   */
+  selectedEntity: string;
+
+  /**
+   * In a separate vein than the actual typeahead, this property helps us create an "autocomplete"
+   * suggestion for the user based on their input
+   * @type {string}
+   */
+  suggestedText: string;
+
+  /**
+   * Suggestion options to be rendered in the dropdown for the typeahead
+   * @type {Array<string>}
+   */
+  suggestionOptions: Array<string> = [];
+
+  /**
+   * Whether or not we want to show the placeholder text in the typeahead box. When the user focuses in,
+   * we want to remove both the placeholder text and the "+" icon in the box
+   * @type {boolean}
+   */
+  showPlaceholder = true;
+
+  /**
+   * When the user focuses in on our component, we want to remove the placeholder text and the "+" icon in
+   * the typeahead box.
+   */
+  focusIn() {
+    set(this, 'showPlaceholder', false);
+  }
+
+  /**
+   * This hook is used to ensure overall component behavior is consistent with power-select behavior. Since
+   * the power select typeahead is cleared when input loses focus, we use this to clear our autosuggest
+   */
+  focusOut() {
+    setProperties(this, {
+      suggestedText: '',
+      showPlaceholder: true
+    });
+  }
+
+  /**
+   * Overwrites the basic highlight function inside the ember-power-select component (which the typeahead
+   * is a wrapper around) and allows us to ensure that the first option is selected everytime a new search
+   * was triggered by user input
+   * @param params - api object provided by ember-power-select component into this closure method
+   */
+  highlight(params: IPowerSelectAPI<string>) {
+    const { results, highlighted, selected, options } = params;
+    const selectionList = options || results;
+    // If we have a list of options, return the first item in that list to highlight. Otherwise, fallback to
+    // the already highlighted item (if any) or finally the item the typehead currently thinks is selected.
+    return typeOf(selectionList) === 'array' ? selectionList[0] : highlighted || selected;
+  }
+
+  /**
+   * On change of user input, conducts a search to find the corresponding typeahead suggestions list
+   * @param keyword - keyword entered by user passed from the power-select component
+   */
+  @action
+  onSearch(keyword: string) {
+    // Note: Property defined on base user-lookup component
+    const userNamesResolver = get(this, 'userNamesResolver');
+    // The async results retrieved from the resolver is what's used to populate our refreshed suggestions
+    userNamesResolver(keyword, noop, asyncResults => {
+      if (typeOf(asyncResults) === 'array') {
+        const newSuggestions = asyncResults.slice(0, suggestionLimit);
+        setProperties(this, {
+          suggestionOptions: newSuggestions,
+          suggestedText: newSuggestions[0]
+        });
+      }
+    });
+  }
+
+  /**
+   * Action that gets called from user keystroke event. The side effects of this action take place before
+   * the event is propogated to and handled by the power select component itself. This calculates whether
+   * the user has entered an arrow up or arrow down key and if so, changes the autocomplete text to the
+   * next value that will be highlighted based on the list position
+   * @param params - api object provided by the ember power select component
+   * @param keyboardEvent - event object created by the keypress
+   */
+  @action
+  onKeyPress(params: IPowerSelectAPI<string>, keyboardEvent: KeyboardEvent) {
+    const keyCode = keyboardEvent.keyCode;
+    // Helps determine the "next index" to check in the list of suggestions to attempt to highlight
+    const step = stepMap[keyCode] || 0;
+    const { highlighted, results, options } = params;
+
+    // Figure out where highlighted is in the options or results
+    if (highlighted && step) {
+      const stepList = options || results;
+      const currentHighlightedIdx = stepList.indexOf(highlighted);
+
+      let nextIdx = currentHighlightedIdx + step;
+      // Make sure the attempted "next" is still within the limits of the list
+      if (nextIdx < 0 || nextIdx >= stepList.length) {
+        nextIdx -= step;
+      }
+      // This modifies the secondary "autocomplete" to match with our next highlighted suggestion
+      set(this, 'suggestedText', stepList[nextIdx]);
+    }
+    // Prevents the tab key from skipping to next element and also autocompletes our text
+    if (keyCode === Keyboard['Tab']) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      set(this, 'selectedEntity', get(this, 'suggestedText'));
+      return false;
+    }
+    // Treats using the enter key the same as if the user had triggered a selection event
+    if (keyCode === Keyboard['Enter']) {
+      this.actions.onChangeSelection.call(this, get(this, 'selectedEntity'));
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Triggered when the user presses enter in the typeahead or clicks on a name in the typeahead suggestion
+   * list, will trigger a search for the specified person and call the didFindUser passed in handler for them
+   * @param selection - selected option in the dropdown list
+   */
+  @action
+  onChangeSelection(selection: string) {
+    if (typeOf(selection) === 'string') {
+      setProperties(this, {
+        selectedEntity: '',
+        suggestedText: ''
+      });
+      // Note: findUser is on the base UserLookup class
+      this.actions.findUser.call(this, selection);
+    }
+  }
+}

--- a/wherehows-web/app/constants/keyboard.ts
+++ b/wherehows-web/app/constants/keyboard.ts
@@ -1,3 +1,7 @@
 export enum Keyboard {
-  Escape = 27
+  Escape = 27,
+  ArrowUp = 38,
+  ArrowDown = 40,
+  Tab = 9,
+  Enter = 13
 }

--- a/wherehows-web/app/constants/typeahead.ts
+++ b/wherehows-web/app/constants/typeahead.ts
@@ -1,0 +1,4 @@
+/**
+ * Set our max number of suggestions we want to show per typeahead search result
+ */
+export const suggestionLimit = 10;

--- a/wherehows-web/app/styles/components/user-lookup/_all.scss
+++ b/wherehows-web/app/styles/components/user-lookup/_all.scss
@@ -1,1 +1,2 @@
 @import 'user-lookup';
+@import 'pwr-user-lookup';

--- a/wherehows-web/app/styles/components/user-lookup/_pwr-user-lookup.scss
+++ b/wherehows-web/app/styles/components/user-lookup/_pwr-user-lookup.scss
@@ -1,0 +1,60 @@
+.pwr-user-lookup {
+  &__auto-suggestion {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    .ember-power-select-typeahead-input {
+      color: get-color(black, 0.5);
+      border: none;
+      width: 178px;
+      box-sizing: border-box;
+    }
+  }
+
+  &__typeahead-container {
+    border: none;
+
+    .ember-power-select-typeahead-trigger {
+      background: transparent;
+
+      .ember-power-select-typeahead-input {
+        background: transparent;
+        border: none;
+        width: 178px;
+        box-sizing: border-box;
+
+        &:focus {
+          outline: none;
+        }
+      }
+    }
+  }
+
+  &--focused {
+    &::after {
+      content: '\2b';
+      position: absolute;
+      top: 10px;
+      left: item-spacing(2);
+      z-index: z(default);
+      color: rgba(0, 0, 0, 0.5);
+      display: inline-block;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: normal;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .ember-power-select-typeahead-input {
+      padding-left: 24px;
+    }
+  }
+
+  .ember-power-select-trigger {
+    &:before {
+      content: '';
+    }
+  }
+}

--- a/wherehows-web/app/styles/components/user-lookup/_user-lookup.scss
+++ b/wherehows-web/app/styles/components/user-lookup/_user-lookup.scss
@@ -2,21 +2,6 @@
   margin: item-spacing(4 0);
   position: relative;
 
-  &::after {
-    content: '\2b';
-    position: absolute;
-    top: item-spacing(3);
-    left: item-spacing(2);
-    z-index: z(default);
-    color: rgba(0, 0, 0, 0.5);
-    display: inline-block;
-    font-family: 'Glyphicons Halflings';
-    font-style: normal;
-    font-weight: normal;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-  }
-
   &__input {
     width: 100%;
     outline: none;

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -79,7 +79,7 @@
         <tr>
           <div class="dataset-owner-table__add-owner">
             {{#if isAddingOwner}}
-              {{user-lookup didFindUser=(action "addOwner")}}
+              {{pwr-user-lookup didFindUser=(action "addOwner")}}
             {{else}}
               <span class="dataset-owner-table__trigger" {{action (mut isAddingOwner) true}}>
                 {{fa-icon "plus"}} Add an owner
@@ -142,19 +142,21 @@
 
 {{/if}}
 
+{{#if (eq showOwnership "show")}}
+  <section class="dataset-author">
+    {{datasets/owners/suggested-owners
+      owners=systemGeneratedOwners
+      ownerTypes=ownerTypes
+      commonOwners=commonOwners
+      removeOwner=(action "removeOwner")
+      confirmSuggestedOwner=(action  "confirmSuggestedOwner")
+      updateOwnerType=(action "updateOwnerType")}}
+  </section>
+{{/if}}
+
 {{#if systemGeneratedOwners}}
 
-  {{#if (eq showOwnership "show")}}
-      <section class="dataset-author">
-        {{datasets/owners/suggested-owners
-          owners=systemGeneratedOwners
-          ownerTypes=ownerTypes
-          commonOwners=commonOwners
-          removeOwner=(action "removeOwner")
-          confirmSuggestedOwner=(action  "confirmSuggestedOwner")
-          updateOwnerType=(action "updateOwnerType")}}
-      </section>
-  {{else}}
+  {{#unless (eq showOwnership "show")}}
 
     <section class="dataset-author">
       <header>
@@ -208,7 +210,8 @@
 
       </table>
     </section>
-  {{/if}}
+
+  {{/unless}}
 {{/if}}
 
 <section class="action-bar">

--- a/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
+++ b/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
@@ -1,2 +1,2 @@
 The WhereHows search index isn't up to date. Until that gets fixed, there are two workarounds: <br>
-Search for your dataset on the CMON app (go/cmon), then click on the browse in WhereHows link OR use the browse view in WhereHows to navigate the tree of datasets and paginate to your dataset.
+Search for your dataset on CMON (go/cmon) and click on the browse in WhereHows link OR use the browse view in Wherehows to navigate the dataset tree to your dataset.

--- a/wherehows-web/app/templates/components/pwr-user-lookup.hbs
+++ b/wherehows-web/app/templates/components/pwr-user-lookup.hbs
@@ -1,0 +1,22 @@
+<div class="ember-power-select-trigger ember-power-select-typeahead-trigger pwr-user-lookup__auto-suggestion">
+  {{input
+    type="search"
+    role="combobox"
+    autocomplete="off"
+    class="ember-power-select-typeahead-input ember-power-select-search-input pwr-user-lookup__auto-suggestion__input"
+    placeholder=(if showPlaceholder "Add an owner")
+    value=suggestedText}}
+</div>
+<div class="pwr-user-lookup__typeahead-container">
+  {{#power-select-typeahead
+    options=suggestionOptions
+    defaultHighlighted=highlight
+    search=(action "onSearch")
+    searchPlaceholder="Add an owner"
+    selected=selectedEntity
+    onchange=(action "onChangeSelection")
+    onkeydown=(action "onKeyPress")
+    as |name|}}
+    {{name}}
+  {{/power-select-typeahead}}
+</div>

--- a/wherehows-web/app/typings/modules/power-select.d.ts
+++ b/wherehows-web/app/typings/modules/power-select.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Object properties in params provided by the ember-power-select component to some passed in callbacks
+ */
+export interface IPowerSelectAPI<T> {
+  disabled: boolean; // Truthy if the component received `disabled=true`
+  highlighted: T; // Contains the currently highlighted option (if any)
+  isActive: boolean; // Truthy if the trigger is focused. Other subcomponents can mark it as active depending on other logic.
+  isOpen: boolean; // Truthy if the dropdown is open.
+  lastSearchedText: string; // Contains the text of the last finished search. In sync searches will match `searchText`. In async searches, it will match it if the current search is fulfilled
+  loading: boolean; // Truthy if there is a pending promise that will update the results
+  options: Array<T>; // Contains the regular array with the resolved collection of options.
+  results: Array<T>; // Contains the regular array with the active set of results.
+  resultsCount: number; // Contains the number of results incuding those nested/disabled
+  searchText: string; // Contains the text of the current search
+  selected: Array<T>; // Contains the resolved selected option (or options in multiple selects)
+  uniqueId: string; // Contains the unique of this instance of EmberPowerSelect. It's of the form `ember1234`.
+}

--- a/wherehows-web/package.json
+++ b/wherehows-web/package.json
@@ -67,6 +67,7 @@
     "ember-native-dom-helpers": "^0.5.10",
     "ember-pikaday": "^2.2.4",
     "ember-power-calendar": "^0.7.1",
+    "ember-power-select-typeahead": "^0.7.0",
     "ember-redux-shim": "^1.1.1",
     "ember-redux-thunk-shim": "^1.1.2",
     "ember-resolver": "^4.0.0",

--- a/wherehows-web/tests/integration/components/pwr-user-lookup-test.js
+++ b/wherehows-web/tests/integration/components/pwr-user-lookup-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { triggerEvent } from 'ember-native-dom-helpers';
+
+moduleForComponent('pwr-user-lookup', 'Integration | Component | pwr user lookup', {
+  integration: true
+});
+
+const autosuggestionClass = '.pwr-user-lookup__auto-suggestion__input';
+const typeaheadContainerClass = '.pwr-user-lookup__typeahead-container';
+const typeaheadTriggerClass = `${typeaheadContainerClass} .ember-power-select-typeahead-trigger`;
+const typeaheadInputClass = `${typeaheadTriggerClass} .ember-power-select-typeahead-input`;
+
+test('it renders', function(assert) {
+  this.render(hbs`{{pwr-user-lookup}}`);
+  assert.ok(this.$(), 'Renders without errors');
+  assert.equal(this.$(autosuggestionClass).length, 1, 'Renders suggestion component');
+  assert.equal(this.$(typeaheadInputClass).length, 1, 'Renders typeahead input component');
+});
+
+test('it properly triggers the findUser action', function(assert) {
+  let findUserActionCallCount = 0;
+  this.set('findUser', () => {
+    findUserActionCallCount++;
+    assert.equal(findUserActionCallCount, 1, 'findUser action is invoked when triggered');
+  });
+
+  this.render(hbs`{{pwr-user-lookup didFindUser=findUser}}`);
+
+  assert.equal(findUserActionCallCount, 0, 'findUser action is not invoked on instantiation');
+  triggerEvent(typeaheadInputClass, 'Pikachu');
+});

--- a/wherehows-web/yarn.lock
+++ b/wherehows-web/yarn.lock
@@ -2846,6 +2846,14 @@ ember-basic-dropdown@^0.34.0:
     ember-native-dom-helpers "^0.5.4"
     ember-wormhole "^0.5.2"
 
+ember-basic-dropdown@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.0.0.tgz#bbafcaab986ba86dfe8d02b0f8529984229bd738"
+  dependencies:
+    ember-cli-babel "^6.12.0"
+    ember-cli-htmlbars "^2.0.3"
+    ember-maybe-in-element "^0.1.3"
+
 ember-cli-app-version@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-app-version/-/ember-cli-app-version-3.1.3.tgz#26d25f5e653ff0106f0b39da6d75518ba8ed282d"
@@ -2881,7 +2889,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, e
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.11.0, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.8.2:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
   dependencies:
@@ -2924,8 +2932,6 @@ ember-cli-code-coverage@theseyi/ember-cli-code-coverage:
   version "0.5.0"
   resolved "https://codeload.github.com/theseyi/ember-cli-code-coverage/tar.gz/2d9bd45dd438413f0a15f1bc58090014b555f804"
   dependencies:
-    babel-core "^6.24.1"
-    babel-plugin-transform-async-to-generator "^6.24.1"
     body-parser "^1.15.0"
     broccoli-filter "^1.2.3"
     broccoli-funnel "^1.0.1"
@@ -3361,6 +3367,14 @@ ember-concurrency@^0.8.12, ember-concurrency@^0.8.15:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
+ember-concurrency@^0.8.18:
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.19.tgz#71b9c175ba077865310029cb4bdb880e17d5155e"
+  dependencies:
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.8.2"
+    ember-maybe-import-regenerator "^0.1.5"
+
 ember-cookies@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.1.2.tgz#f652efcb289534cdc1425832ed3c77aeb432ef72"
@@ -3518,6 +3532,12 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-maybe-in-element@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
+  dependencies:
+    ember-cli-babel "^6.11.0"
+
 ember-metrics@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
@@ -3574,6 +3594,14 @@ ember-power-calendar@^0.7.1:
     ember-moment "^7.5.0"
     ember-native-dom-helpers "^0.5.10"
 
+ember-power-select-typeahead@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ember-power-select-typeahead/-/ember-power-select-typeahead-0.7.0.tgz#c79d9b7c698f1f2f7278d2200825eb2ab73af5c2"
+  dependencies:
+    ember-cli-babel "^6.12.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-power-select "^2.0.0-beta.5"
+
 ember-power-select@^1.10.4:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.10.4.tgz#7f0bb8c55279375391f2d97591ed65f727061579"
@@ -3582,6 +3610,17 @@ ember-power-select@^1.10.4:
     ember-cli-babel "^6.10.0"
     ember-cli-htmlbars "^2.0.1"
     ember-concurrency "^0.8.12"
+    ember-text-measurer "^0.4.0"
+    ember-truth-helpers "^2.0.0"
+
+ember-power-select@^2.0.0-beta.5:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.0.0.tgz#f36e113f77006a939a62a2c6e4bcff83aebfe6c3"
+  dependencies:
+    ember-basic-dropdown "^1.0.0"
+    ember-cli-babel "^6.11.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-concurrency "^0.8.18"
     ember-text-measurer "^0.4.0"
     ember-truth-helpers "^2.0.0"
 


### PR DESCRIPTION
## FIrst Draft

#### Details
- Minor change to show suggested owners box even if # system suggested owners is 0
- Install `ember-power-select-typeahead` and leverage it to build a `pwr-user-lookup` component that revamps the old typeahead UX
- Using arrow keys or mouse to click on suggestions remains the same behavior as before
- Using enter key now automatically confirms a selection for the autocompleted value
- Using tab key now autocompletes the text without an official selection
- Fixes an issue with the "+" icon being confusing - it now disappears when user focuses on typeahead box to not seem like a button
- After a selection, typeahead now properly clears the current entry

`ember test` results:
```
ok 1 Chrome 66.0 - ESLint | mirage: mirage/factories/access.js
ok 2 Chrome 66.0 - ESLint | mirage: mirage/factories/column.js
...
ok 221 Chrome 66.0 - Integration | Component | pwr user lookup: it renders
ok 222 Chrome 66.0 - Integration | Component | pwr user lookup: it properly triggers the findUser action
...
ok 363 Chrome 66.0 - Unit | Utility | validators/urn: buildLiUrn
ok 364 Chrome 66.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..364
# tests 364
# pass  358
# skip  6
# fail  0

# ok
```
#### Screenshot after add owner component is showing
![screen shot 2018-05-07 at 2 36 57 pm](https://user-images.githubusercontent.com/16459843/39726800-28e3bf3e-5205-11e8-9fdc-e8c927320114.png)
#### Typeahead in action
![screen shot 2018-05-07 at 2 37 10 pm](https://user-images.githubusercontent.com/16459843/39726801-28f97cde-5205-11e8-80b8-95ccec2be625.png)
