### PR TITLE
On ownership tab, disables save button when no changes have been made…

### DIFF
--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -70,7 +70,7 @@ export default class DatasetAuthors extends Component {
    * If there are no changes to the ownership tab, we want to keep the save button disabled. Rather than
    * try to compare two sets of prev vs new data, we just have a flag here that short stops the validation
    * function.
-   * Note: hasChanged has 3 states:
+   * Note: changedState has 3 states:
    * -1   Component hasn't completed initialization yet, and no changes have been made. When
    *      requiredMinNotConfirmed is run on init/render, this gets incremented to its neutral state at 0
    * 0    No changes have been made yet
@@ -78,7 +78,7 @@ export default class DatasetAuthors extends Component {
    * @type {number}
    * @memberof DatasetAuthors
    */
-  hasChanged: Comparator = -1;
+  changedState: Comparator = -1;
 
   /**
    * Reference to the userNamesResolver function to asynchronously match userNames
@@ -102,14 +102,14 @@ export default class DatasetAuthors extends Component {
   requiredMinNotConfirmed: ComputedProperty<boolean> = computed('confirmedOwners.@each.type', function(
     this: DatasetAuthors
   ) {
-    const hasChanged = get(this, 'hasChanged');
+    const changedState = get(this, 'changedState');
 
-    if (hasChanged < 1) {
-      set(this, 'hasChanged', <Comparator>(hasChanged + 1));
+    if (changedState < 1) {
+      set(this, 'changedState', <Comparator>(changedState + 1));
     }
     // If there have been no changes, then we want to automatically set true in order to disable save button
     // when no changes have been made
-    return hasChanged === -1 ? true : isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
+    return changedState === -1 ? true : isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
   });
 
   /**

--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -21,6 +21,8 @@ import {
 import { OwnerSource, OwnerType } from 'wherehows-web/utils/api/datasets/owners';
 import Notifications, { NotificationEvent } from 'wherehows-web/services/notifications';
 
+type Comparator = -1 | 0 | 1;
+
 /**
  * Defines properties for the component that renders a list of owners and provides functionality for
  * interacting with the list items or the list as whole
@@ -65,6 +67,20 @@ export default class DatasetAuthors extends Component {
   userLookup: ComputedProperty<UserLookup> = inject();
 
   /**
+   * If there are no changes to the ownership tab, we want to keep the save button disabled. Rather than
+   * try to compare two sets of prev vs new data, we just have a flag here that short stops the validation
+   * function.
+   * Note: hasChanged has 3 states:
+   * -1   Component hasn't completed initialization yet, and no changes have been made. When
+   *      requiredMinNotConfirmed is run on init/render, this gets incremented to its neutral state at 0
+   * 0    No changes have been made yet
+   * 1    At least one change has been made
+   * @type {number}
+   * @memberof DatasetAuthors
+   */
+  hasChanged: Comparator = -1;
+
+  /**
    * Reference to the userNamesResolver function to asynchronously match userNames
    * @type {UserLookup.userNamesResolver}
    * @memberof DatasetAuthors
@@ -86,7 +102,14 @@ export default class DatasetAuthors extends Component {
   requiredMinNotConfirmed: ComputedProperty<boolean> = computed('confirmedOwners.@each.type', function(
     this: DatasetAuthors
   ) {
-    return isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
+    const hasChanged = get(this, 'hasChanged');
+
+    if (hasChanged < 1) {
+      set(this, 'hasChanged', <Comparator>(hasChanged + 1));
+    }
+    // If there have been no changes, then we want to automatically set true in order to disable save button
+    // when no changes have been made
+    return hasChanged === -1 ? true : isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
   });
 
   /**
@@ -94,7 +117,9 @@ export default class DatasetAuthors extends Component {
    * @type {ComputedProperty<number>}
    * @memberof DatasetAuthors
    */
-  ownersRequiredCount: ComputedProperty<number> = computed('confirmedOwners.[]', function(this: DatasetAuthors) {
+  ownersRequiredCount: ComputedProperty<number> = computed('confirmedOwners.@each.type', function(
+    this: DatasetAuthors
+  ) {
     return minRequiredConfirmedOwners - validConfirmedOwners(get(this, 'confirmedOwners')).length;
   });
 
@@ -180,7 +205,7 @@ export default class DatasetAuthors extends Component {
       }
 
       const { userName } = get(get(this, 'currentUser'), 'currentUser');
-      const updatedOwners = [newOwner, ...owners];
+      const updatedOwners = [...owners, newOwner];
       confirmOwner(newOwner, userName);
 
       return owners.setObjects(updatedOwners);

--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -233,11 +233,15 @@
       <div class="dataset-authors-save-error">
         <p>
           {{fa-icon "times-circle-o" class="dataset-authors-save-error__icon"}}
-          {{#if (eq ownersRequiredCount 2)}}
-            Add at least 2 DataOwners.
+          {{#unless hasChanged}}
+            Please make changes to save.
           {{else}}
-            Add at least {{ownersRequiredCount}} more DataOwner(s).
-          {{/if}}
+            {{#if (eq ownersRequiredCount 2)}}
+              Add at least 2 DataOwners.
+            {{else}}
+              Add at least {{ownersRequiredCount}} more DataOwner(s).
+            {{/if}}
+          {{/unless}}
         </p>
       </div>
     {{/if}}


### PR DESCRIPTION
… and adds owners to bottom of table instead of top.

- Create a property to detect whether or not at least one change has been made
- Disables save if this property does not indicate a change
- Switch `addOwner` function to append a new owner entry to the end of the list instead of the beginning.

`ember test` results:
```
ok 1 Chrome 66.0 - ESLint | mirage: mirage/factories/access.js
ok 2 Chrome 66.0 - ESLint | mirage: mirage/factories/column.js
...
ok 363 Chrome 66.0 - Unit | Utility | validators/urn: buildLiUrn
ok 364 Chrome 66.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..364
# tests 364
# pass  358
# skip  6
# fail  0

# ok
```