### PR TITLE
Fix typo in dataset ownership tab that caused save error message to b…

### DIFF
--- a/wherehows-web/app/templates/components/dataset-authors.hbs
+++ b/wherehows-web/app/templates/components/dataset-authors.hbs
@@ -233,7 +233,7 @@
       <div class="dataset-authors-save-error">
         <p>
           {{fa-icon "times-circle-o" class="dataset-authors-save-error__icon"}}
-          {{#unless hasChanged}}
+          {{#unless (eq changedState 1)}}
             Please make changes to save.
           {{else}}
             {{#if (eq ownersRequiredCount 2)}}


### PR DESCRIPTION
…e incorrectly displayed

`ember test` results:
```
1..364
# tests 364
# pass  358
# skip  6
# fail  0

# ok
```