### PR TITLE
Minor bug fix for ownership tab change stale banner wording

### DIFF
--- a/wherehows-web/app/components/pwr-user-lookup.ts
+++ b/wherehows-web/app/components/pwr-user-lookup.ts
@@ -64,7 +64,7 @@ export default class PowerUserLookup extends UserLookup {
   focusOut() {
     setProperties(this, {
       suggestedText: '',
-      showPlaceholder: true
+      showPlaceholder: get(this, 'selectedEntity') ? false : true
     });
   }
 

--- a/wherehows-web/app/components/pwr-user-lookup.ts
+++ b/wherehows-web/app/components/pwr-user-lookup.ts
@@ -64,7 +64,7 @@ export default class PowerUserLookup extends UserLookup {
   focusOut() {
     setProperties(this, {
       suggestedText: '',
-      showPlaceholder: get(this, 'selectedEntity') ? false : true
+      showPlaceholder: !get(this, 'selectedEntity')
     });
   }
 

--- a/wherehows-web/app/styles/components/dataset-author/_suggested-owners.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_suggested-owners.scss
@@ -32,6 +32,7 @@
       width: 128px;
       display: flex;
       flex-wrap: wrap;
+      margin-right: 16px;
 
       &__avatar {
         box-sizing: border-box;
@@ -52,7 +53,10 @@
     &__description {
       width: 560px;
       word-wrap: wrap;
-      padding-left: 16px;
+
+      &--empty {
+        margin-bottom: 16px;
+      }
     }
 
     &__trigger {

--- a/wherehows-web/app/styles/components/notifications/_banner-alerts.scss
+++ b/wherehows-web/app/styles/components/notifications/_banner-alerts.scss
@@ -72,6 +72,15 @@
     &__content {
       width: 90vw;
       min-width: 1056px;
+
+      &__link {
+        color: get-color(white, 0.9);
+        text-decoration: underline;
+
+        &:hover {
+          color: get-color(black, 0.75);
+        }
+      }
     }
 
     &__dismiss {

--- a/wherehows-web/app/templates/components/datasets/owners/suggested-owners.hbs
+++ b/wherehows-web/app/templates/components/datasets/owners/suggested-owners.hbs
@@ -1,7 +1,7 @@
 <h4 class="dataset-authors-suggested__header">Suggestions</h4>
 
 {{#if isEmpty}}
-  <div class="dataset-authors-suggested__info__description">
+  <div class="dataset-authors-suggested__info__description dataset-authors-suggested__info__description--empty">
     We found no suggested owner(s) for this dataset, based on scanning different systems
   </div>
 {{else}}

--- a/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
+++ b/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
@@ -1,2 +1,9 @@
-The WhereHows search index isn't up to date. Until that gets fixed, there are two workarounds: <br>
-Search for your dataset on CMON (go/cmon) and click on the browse in WhereHows link OR use the browse view in Wherehows to navigate the dataset tree to your dataset.
+The WhereHows search index is currently out of date.<br>
+Please see
+<a
+ href="https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Metadata+Annotation+FAQs#MetadataAnnotationFAQs-stale-index"
+ target="_blank"
+ class="banner-alert__content__link">
+  https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Metadata+Annotation+FAQs#MetadataAnnotationFAQs-stale-index
+</a>
+for more details and workarounds.

--- a/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
+++ b/wherehows-web/app/templates/components/notifications/partials/_stale-search-alert.hbs
@@ -1,9 +1,10 @@
 The WhereHows search index is currently out of date.<br>
 Please see
+{{!-- TODO: Make into a config link to remove internal values from open source --}}
 <a
- href="https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Metadata+Annotation+FAQs#MetadataAnnotationFAQs-stale-index"
+ href="http://go/metadata/faq#MetadataAnnotationFAQs-stale-index"
  target="_blank"
  class="banner-alert__content__link">
-  https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Metadata+Annotation+FAQs#MetadataAnnotationFAQs-stale-index
+  go/metadata/faq#MetadataAnnotationFAQs-stale-index
 </a>
 for more details and workarounds.


### PR DESCRIPTION
Fix issue where typeahead in ownership tab losing focus would incorrectly display placeholder without a clear. Also fix padding issues on no owners suggested state for suggested owners box. Make change to wording banner for stale search.

`ember test` results:
```
1..364
# tests 364
# pass  358
# skip  6
# fail  0

# ok
```