### PR TITLE
remove client side redirection to https

### DIFF
--- a/wherehows-web/app/router.js
+++ b/wherehows-web/app/router.js
@@ -3,7 +3,6 @@ import { get, getWithDefault } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 import config from 'wherehows-web/config/environment';
-import { redirectToHttps } from 'wherehows-web/utils/build-url';
 
 const AppRouter = Router.extend({
   location: config.locationType,
@@ -11,17 +10,6 @@ const AppRouter = Router.extend({
   rootURL: config.rootURL,
 
   metrics: service(),
-
-  willTransition() {
-    const {
-      APP: { useSecureRedirect }
-    } = config;
-    this._super(...arguments);
-
-    if (useSecureRedirect) {
-      redirectToHttps(window.location);
-    }
-  },
 
   didTransition() {
     this._super(...arguments);

--- a/wherehows-web/app/utils/build-url.ts
+++ b/wherehows-web/app/utils/build-url.ts
@@ -39,15 +39,3 @@ export default (baseUrl: string, queryParam: string, queryValue: string): string
 
   return `${baseUrl}${separator}${queryParam}=${queryValue}`;
 };
-
-/**
- * Sets the href on a location object if the protocol is not https
- * @param {Location} { protocol, href }
- */
-export const redirectToHttps = ({ protocol, href, hostname }: Location): void => {
-  const secureProtocol = 'https:';
-
-  if (protocol !== secureProtocol && hostname !== 'localhost') {
-    window.location.replace(`${secureProtocol}${href.substring(protocol.length)}`);
-  }
-};


### PR DESCRIPTION
Redirection is handled on the play mid tier layer now that serves the page. Deletion only

`ember test` results:
```
1..457
# tests 457
# pass  451
# skip  6
# fail  0

# ok
```