### PR TITLE
Implement suggested owners api and 2fa banner change

### DIFF
--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -15,8 +15,7 @@ import {
   minRequiredConfirmedOwners,
   validConfirmedOwners,
   isRequiredMinOwnersNotConfirmed,
-  isConfirmedOwner,
-  isSystemGeneratedOwner
+  isConfirmedOwner
 } from 'wherehows-web/constants/datasets/owner';
 import { OwnerSource, OwnerType } from 'wherehows-web/utils/api/datasets/owners';
 import Notifications, { NotificationEvent } from 'wherehows-web/services/notifications';
@@ -44,6 +43,13 @@ export default class DatasetAuthors extends Component {
    * @memberof DatasetAuthors
    */
   owners: Array<IOwner>;
+
+  /**
+   * The list of suggested owners, used to populate the suggestions window below the owners table
+   * @type {Array<IOwner>}
+   * @memberof DatasetAuthors
+   */
+  suggestedOwners: Array<IOwner>;
 
   /**
    * Current user service
@@ -166,7 +172,11 @@ export default class DatasetAuthors extends Component {
    * @type {ComputedProperty<Array<IOwner>>}
    * @memberof DatasetAuthors
    */
-  systemGeneratedOwners: ComputedProperty<Array<IOwner>> = filter('owners', isSystemGeneratedOwner);
+  systemGeneratedOwners: ComputedProperty<Array<IOwner>> = computed('suggestedOwners', function() {
+    // Creates a copy of suggested owners since using it directly seems to invoke a "modified twice in the
+    // same render" error
+    return (get(this, 'suggestedOwners') || []).slice(0);
+  });
 
   /**
    * Invokes the external action as a dropping task

--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -15,7 +15,8 @@ import {
   minRequiredConfirmedOwners,
   validConfirmedOwners,
   isRequiredMinOwnersNotConfirmed,
-  isConfirmedOwner
+  isConfirmedOwner,
+  isSystemGeneratedOwner
 } from 'wherehows-web/constants/datasets/owner';
 import { OwnerSource, OwnerType } from 'wherehows-web/utils/api/datasets/owners';
 import Notifications, { NotificationEvent } from 'wherehows-web/services/notifications';
@@ -173,9 +174,12 @@ export default class DatasetAuthors extends Component {
    * @memberof DatasetAuthors
    */
   systemGeneratedOwners: ComputedProperty<Array<IOwner>> = computed('suggestedOwners', function() {
+    const showOwnership = get(this, 'showOwnership');
     // Creates a copy of suggested owners since using it directly seems to invoke a "modified twice in the
     // same render" error
-    return (get(this, 'suggestedOwners') || []).slice(0);
+    return showOwnership === 'show'
+      ? (get(this, 'suggestedOwners') || []).slice(0)
+      : get(this, 'owners').filter(isSystemGeneratedOwner);
   });
 
   /**

--- a/wherehows-web/app/components/datasets/containers/dataset-ownership.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-ownership.ts
@@ -10,6 +10,7 @@ import { IOwner, IOwnerResponse } from 'wherehows-web/typings/api/datasets/owner
 import {
   OwnerType,
   readDatasetOwnersByUrn,
+  readDatasetSuggestedOwnersByUrn,
   readDatasetOwnerTypesWithoutConsumer,
   updateDatasetOwnersByUrn
 } from 'wherehows-web/utils/api/datasets/owners';
@@ -26,6 +27,12 @@ export default class DatasetOwnershipContainer extends Component {
    * @type {Array<IOwner>}
    */
   owners: Array<IOwner>;
+
+  /**
+   * List of suggested owners for the dataset
+   * @type {Array<IOwner>}
+   */
+  suggestedOwners: Array<IOwner>;
 
   /**
    * List of types available for a dataset owner
@@ -64,7 +71,9 @@ export default class DatasetOwnershipContainer extends Component {
    * @type {Task<TaskInstance<Promise<any>>, (a?: any) => TaskInstance<TaskInstance<Promise<any>>>>}
    */
   getContainerDataTask = task(function*(this: DatasetOwnershipContainer): IterableIterator<TaskInstance<Promise<any>>> {
-    const tasks = Object.values(getProperties(this, ['getDatasetOwnersTask', 'getDatasetOwnerTypesTask']));
+    const tasks = Object.values(
+      getProperties(this, ['getDatasetOwnersTask', 'getSuggestedOwnersTask', 'getDatasetOwnerTypesTask'])
+    );
 
     yield* tasks.map(task => task.perform());
   });
@@ -77,6 +86,18 @@ export default class DatasetOwnershipContainer extends Component {
     const { owners = [], fromUpstream, datasetUrn }: IOwnerResponse = yield readDatasetOwnersByUrn(get(this, 'urn'));
 
     setProperties(this, { owners, fromUpstream, upstreamUrn: datasetUrn });
+  });
+
+  /**
+   * Fetches the suggested owners for this dataset
+   * @type {Task<Promise<Array<IOwner>>, (a?: any) => TaskInstance<Promise<IOwnerResponse>>>}
+   */
+  getSuggestedOwnersTask = task(function*(this: DatasetOwnershipContainer): IterableIterator<Promise<IOwnerResponse>> {
+    const { owners = [], fromUpstream, datasetUrn }: IOwnerResponse = yield readDatasetSuggestedOwnersByUrn(
+      get(this, 'urn')
+    );
+
+    setProperties(this, { suggestedOwners: owners, fromUpstream, upstreamUrn: datasetUrn });
   });
 
   /**

--- a/wherehows-web/app/controllers/login.ts
+++ b/wherehows-web/app/controllers/login.ts
@@ -49,12 +49,14 @@ export default class Login extends Controller {
     authenticateUser(this: Login): void {
       const { username, password, banners } = getProperties(this, ['username', 'password', 'banners']);
 
-      // Once user has chosen to authenticate, then we remove the login banner (if it exists) since it will
-      // no longer be relevant
-      banners.removeBanner(twoFABannerMessage, twoFABannerType);
-
       get(this, 'session')
         .authenticate('authenticator:custom-ldap', username, password)
+        .then(results => {
+          // Once user has chosen to authenticate, then we remove the login banner (if it exists) since it will
+          // no longer be relevant
+          banners.removeBanner(twoFABannerMessage, twoFABannerType);
+          return results;
+        })
         .catch(({ responseText = 'Bad Credentials' }) => setProperties(this, { errorMessage: responseText }));
     }
   };

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-ownership.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-ownership.hbs
@@ -32,6 +32,7 @@
 
       {{dataset-authors
         owners=owners
+        suggestedOwners=suggestedOwners
         ownerTypes=ownerTypes
         showOwnership=showOwnership
         save=(action "saveOwnerChanges")

--- a/wherehows-web/app/utils/api/datasets/owners.ts
+++ b/wherehows-web/app/utils/api/datasets/owners.ts
@@ -62,6 +62,12 @@ enum OwnerSource {
 const datasetOwnersUrlByUrn = (urn: string): string => `${datasetUrlByUrn(urn)}/owners`;
 
 /**
+ * Returns the url to fetch the suggested dataset owners by urn
+ * @param urn
+ */
+const datasetSuggestedOwnersUrlByUrn = (urn: string): string => `${datasetUrlByUrn(urn)}/owners/suggestion`;
+
+/**
  * Returns the party entities url
  * @type {string}
  */
@@ -101,6 +107,30 @@ const readDatasetOwnersByUrn = async (urn: string): Promise<IOwnerResponse> => {
 
   try {
     ({ owners = [], fromUpstream, datasetUrn } = await getJSON<IOwnerResponse>({ url: datasetOwnersUrlByUrn(urn) }));
+    return { owners: ownersWithModifiedTimeAsDate(owners), fromUpstream, datasetUrn };
+  } catch (e) {
+    if (notFoundApiError(e)) {
+      return { owners, fromUpstream, datasetUrn };
+    } else {
+      throw e;
+    }
+  }
+};
+
+/**
+ * For the specific dataset, fetches the system suggested owners for that dataset
+ * @param urn - unique identifier for the dataset
+ * @return {Promise<Array<IOwner>>}
+ */
+const readDatasetSuggestedOwnersByUrn = async (urn: string): Promise<IOwnerResponse> => {
+  let owners: Array<IOwner> = [],
+    fromUpstream = false,
+    datasetUrn = '';
+
+  try {
+    ({ owners = [], fromUpstream, datasetUrn } = await getJSON<IOwnerResponse>({
+      url: datasetSuggestedOwnersUrlByUrn(urn)
+    }));
     return { owners: ownersWithModifiedTimeAsDate(owners), fromUpstream, datasetUrn };
   } catch (e) {
     if (notFoundApiError(e)) {
@@ -228,6 +258,7 @@ const readPartyEntitiesMap = (partyEntities: Array<IPartyEntity>): IUserEntityMa
 
 export {
   readDatasetOwnersByUrn,
+  readDatasetSuggestedOwnersByUrn,
   updateDatasetOwnersByUrn,
   readDatasetOwnerTypesWithoutConsumer,
   readPartyEntities,


### PR DESCRIPTION
Uses owners/suggestion api to get suggested owners rather than using frontend filtering. Also, changes timing so that 2FA notice banner alert won't be prematurely removed if login is not successful.

`ember test` results:
```
ok 1 Chrome 67.0 - ESLint | mirage: mirage/data/schema.js
ok 2 Chrome 67.0 - ESLint | mirage: mirage/factories/access.js
...
ok 462 Chrome 67.0 - Unit | Utility | validators/urn: buildLiUrn
ok 463 Chrome 67.0 - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..463
# tests 463
# pass  457
# skip  6
# fail  0

# ok
```