### PR TITLE
Point to the correct link of architecture design

### DIFF
--- a/wherehows-backend/README.md
+++ b/wherehows-backend/README.md
@@ -25,7 +25,7 @@ Folder:	/opt/wherehows
 
 ## Key notes
 Please become familiar with these pages:
-- https://github.com/linkedin/WhereHows/wiki/Architecture (Nice tech overview)
+- https://github.com/linkedin/WhereHows/blob/master/wherehows-docs/architecture.md (Nice tech overview)
 - https://github.com/linkedin/WhereHows
 - https://github.com/linkedin/WhereHows/blob/master/wherehows-docs/getting-started.md
 


### PR DESCRIPTION
The original link is broken, changing to the relevant one.