### PR TITLE
 removes title attribute from more-info tags. clears out sticky params on browse/:entity route on exit

### DIFF
--- a/wherehows-web/app/components/browser/containers/data-systems.ts
+++ b/wherehows-web/app/components/browser/containers/data-systems.ts
@@ -70,7 +70,7 @@ export default class DataSystemsContainer extends Component {
    * @type {ComputedProperty<string>}
    */
   urn = computed('params', function(this: DataSystemsContainer): string {
-    const { platform, prefix } = get(this, 'params');
+    const { platform, prefix = '' } = get(this, 'params');
     return buildLiUrn(<DatasetPlatform>platform, prefix);
   });
 
@@ -89,7 +89,7 @@ export default class DataSystemsContainer extends Component {
    * @type {(Task<Promise<Array<string>>, (a?: any) => TaskInstance<Promise<Array<string>>>>)}
    */
   getDataSystemsNodesTask = task(function*(this: DataSystemsContainer): IterableIterator<Promise<Array<string>>> {
-    const { prefix, platform, entity } = get(this, 'params');
+    const { prefix = '', platform, entity } = get(this, 'params');
     const nodes = mapDataSystemsPathToLinkNode(<DatasetPlatform>platform, entity)(
       yield readPlatforms({ platform, prefix })
     );

--- a/wherehows-web/app/routes/browse/entity.ts
+++ b/wherehows-web/app/routes/browse/entity.ts
@@ -8,7 +8,7 @@ import BrowseEntityController from 'wherehows-web/controllers/browse/entity';
 import Configurator from 'wherehows-web/services/configurator';
 import { IAppConfig } from 'wherehows-web/typings/api/configurator/configurator';
 
-const queryParamsKeys = ['page', 'prefix', 'platform', 'size'];
+const queryParamsKeys: Array<keyof IBrowserRouteParams> = ['page', 'prefix', 'platform', 'size'];
 
 /**
  * Describes the route parameter interface for the browser route
@@ -23,7 +23,14 @@ export interface IBrowserRouteParams {
   prefix: string | void;
 }
 
-export default class BrowseEntity extends Route.extend(AuthenticatedRouteMixin) {
+export default class BrowseEntity extends Route.extend(AuthenticatedRouteMixin, {
+  resetController(controller: BrowseEntityController, isExiting: boolean) {
+    if (isExiting) {
+      // clear out sticky params
+      setProperties(controller, { prefix: '', platform: '' });
+    }
+  }
+}) {
   queryParams = refreshModelQueryParams(queryParamsKeys);
 
   /**

--- a/wherehows-web/app/routes/browse/entity.ts
+++ b/wherehows-web/app/routes/browse/entity.ts
@@ -20,7 +20,7 @@ export interface IBrowserRouteParams {
   page: number;
   size: number;
   platform: string;
-  prefix: string;
+  prefix: string | void;
 }
 
 export default class BrowseEntity extends Route.extend(AuthenticatedRouteMixin) {

--- a/wherehows-web/app/templates/components/more-info.hbs
+++ b/wherehows-web/app/templates/components/more-info.hbs
@@ -8,8 +8,6 @@
       More Info
     {{/if}}
 
-
-    <span class="glyphicon glyphicon-question-sign"
-          title="Click for {{tooltip}}"></span>
+    <span class="glyphicon glyphicon-question-sign"></span>
   </sup>
 </a>

--- a/wherehows-web/app/utils/entities/bake-urn-breadcrumbs.ts
+++ b/wherehows-web/app/utils/entities/bake-urn-breadcrumbs.ts
@@ -8,7 +8,7 @@ import { datasetUrnRegexLI } from 'wherehows-web/utils/validators/urn';
 export interface IDatasetBreadcrumb {
   crumb: string;
   platform: DatasetPlatform;
-  prefix: string;
+  prefix: string | void;
 }
 
 /**
@@ -28,11 +28,17 @@ export default (urn: string): Array<IDatasetBreadcrumb> => {
     // For HDFS drop leading slash
     const hierarchy = isHdfs ? segments.split('/').slice(1) : segments.split('.');
 
-    return [platform, ...hierarchy].reduce((breadcrumbs, crumb, index) => {
+    return [platform, ...hierarchy].reduce((breadcrumbs: Array<IDatasetBreadcrumb>, crumb: string, index) => {
       if (crumb) {
-        const previousCrumb = breadcrumbs[index - 1];
-        // if hdfs, precede with slash, otherwise trailing period
-        const prefix = !index ? '' : isHdfs ? `${previousCrumb.prefix}/${crumb}` : `${previousCrumb.prefix}${crumb}.`;
+        let prefix: void | string;
+
+        // List isn't empty an a previous crumb exists
+        if (index) {
+          const previousCrumb = breadcrumbs[index - 1];
+          const { prefix: previousPrefix = '' } = previousCrumb;
+          // if hdfs, precede with slash, otherwise trailing period
+          prefix = isHdfs ? `${previousPrefix}/${crumb}` : `${previousPrefix}${crumb}.`;
+        }
 
         return [
           ...breadcrumbs,

--- a/wherehows-web/app/utils/validators/urn.ts
+++ b/wherehows-web/app/utils/validators/urn.ts
@@ -105,7 +105,7 @@ const convertWhUrnToLiUrn = (whUrn: string): string => {
  * @param {Fabric} [fabric=Fabric.Prod]
  * @return {string}
  */
-const buildLiUrn = (platform: DatasetPlatform, path: string, fabric: Fabric = Fabric.Prod): string => {
+const buildLiUrn = (platform: DatasetPlatform, path: string = '', fabric: Fabric = Fabric.Prod): string => {
   const formattedPath = convertWhDatasetPathToLiPath(platform, path);
   return `urn:li:dataset:(urn:li:dataPlatform:${platform},${formattedPath},${fabric})`;
 };


### PR DESCRIPTION
- fixes issue with urn navigation when data system prefix does not exist