### PR TITLE
Move import of staging mock data to constants file in app instead of mirage

### DIFF
--- a/wherehows-web/app/components/datasets/containers/dataset-health.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-health.ts
@@ -3,10 +3,8 @@ import { get, computed, setProperties, getProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
 import ComputedProperty from '@ember/object/computed';
 import { IChartDatum } from 'wherehows-web/typings/app/visualization/charts';
-import healthCategories from 'wherehows-web/mirage/fixtures/health-categories';
-import healthSeverity from 'wherehows-web/mirage/fixtures/health-severity';
-import healthDetail from 'wherehows-web/mirage/fixtures/health-detail';
 import { IHealthScore } from 'wherehows-web/typings/api/datasets/health';
+import { healthCategories, healthSeverity, healthDetail } from 'wherehows-web/constants/data/temp-mock/health';
 
 /**
  * Used for the dataset health tab, represents the fieldnames for the health score table

--- a/wherehows-web/app/constants/data/temp-mock/health.ts
+++ b/wherehows-web/app/constants/data/temp-mock/health.ts
@@ -1,0 +1,48 @@
+import { IHealthScore } from 'wherehows-web/typings/api/datasets/health';
+
+export const healthCategories = [{ name: 'Compliance', value: 60 }, { name: 'Ownership', value: 40 }];
+export const healthSeverity = [
+  { name: 'Minor', value: 50 },
+  { name: 'Warning', value: 30 },
+  { name: 'Critical', value: 25 }
+];
+export const healthDetail = <Array<IHealthScore>>[
+  {
+    category: 'Compliance',
+    description:
+      'Sample description for this score based on compliance category that is extra long' +
+      'just to make sure we can handle any length of descriptions',
+    score: 30,
+    severity: 'Critical'
+  },
+  {
+    category: 'Compliance',
+    description:
+      'It is a dark time for the Rebellion. Although the Death Star has been destroyed, ' +
+      'Imperial troops have driven the Rebel forces from their hidden base and pursued them across ' +
+      'the galaxy.\nEvading the dreaded Imperial Starfleet, a group of freedom fighters led by Luke ' +
+      'Skywalker has established a new secret base on the remote ice world of Hoth.\n' +
+      'The evil lord Darth Vader, obsessed with finding young Skywalker, has dispatched thousands of ' +
+      'remote probes into the far reaches of space...',
+    score: 50,
+    severity: 'Warning'
+  },
+  {
+    category: 'Ownership',
+    description: 'Sample ownership description here',
+    score: 75,
+    severity: 'Minor'
+  },
+  {
+    category: 'Ownership',
+    description: 'Sample ownership description here',
+    score: 90,
+    severity: null
+  },
+  {
+    category: 'Compliance',
+    description: 'Sample compliance description here',
+    score: 100,
+    severity: null
+  }
+];


### PR DESCRIPTION
Since we do not use mirage in staging, importing directly from mirage directory caused an error. Instead, put the mock data to show in staging in a constants folder to keep mock data modular away from code without using mirage.

`ember test` results:
```
1..376
# tests 376
# pass  370
# skip  6
# fail  0

# ok
```