### PR TITLE
Add dummy login module to jaas config

### DIFF
--- a/wherehows-frontend/app/security/DummyLoginModule.java
+++ b/wherehows-frontend/app/security/DummyLoginModule.java
@@ -1,0 +1,34 @@
+package security;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.util.Map;
+
+/**
+ * This LoginModule performs dummy authentication.
+ * Any username and password can work for authentication
+ */
+public class DummyLoginModule implements LoginModule {
+
+  public void initialize(final Subject subject, final CallbackHandler callbackHandler, final Map<String, ?> sharedState, final Map<String, ?> options) {
+  }
+
+  public boolean login() throws LoginException {
+    return true;
+  }
+
+  public boolean commit() throws LoginException {
+    return true;
+  }
+
+  public boolean abort() throws LoginException {
+    return true;
+  }
+
+  public boolean logout() throws LoginException {
+    return true;
+  }
+
+}

--- a/wherehows-frontend/conf/jaas.conf
+++ b/wherehows-frontend/conf/jaas.conf
@@ -1,5 +1,10 @@
-// This is just a sample JAAS config that uses LDAP for authentication.
+// This is a sample JAAS config that uses the following login modules
+// DummyLoginModule -- this module can work with a username (that is in user table) and any password
+// LdapLoginModule -- this module uses LDAP for authentication
+
 WHZ-Authentication {
+  security.DummyLoginModule sufficient;
+
   com.sun.security.auth.module.LdapLoginModule sufficient
   userProvider="ldap://ldap-svr/ou=people,dc=example,dc=com"
   authIdentity="{USERNAME}"

--- a/wherehows-frontend/test/DummyLoginModuleTest.java
+++ b/wherehows-frontend/test/DummyLoginModuleTest.java
@@ -1,0 +1,29 @@
+import com.sun.security.auth.callback.TextCallbackHandler;
+import java.util.HashMap;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.Subject;
+import org.junit.Test;
+import security.DummyLoginModule;
+
+import static org.junit.Assert.*;
+
+
+public class DummyLoginModuleTest {
+
+  @Test
+  public void testAuthenticate() {
+    DummyLoginModule lmodule = new DummyLoginModule();
+    lmodule.initialize(new Subject(), new TextCallbackHandler(), null, new HashMap());
+    LoginException ex = null;
+    try {
+      assertTrue("Failed to login", lmodule.login());
+      assertTrue("Failed to logout",lmodule.logout());
+      assertTrue("Failed to commit", lmodule.commit());
+      assertTrue("Failed to abort", lmodule.abort());
+    } catch (LoginException e) {
+      ex = e;
+    }
+    assertNull(ex);
+  }
+
+}


### PR DESCRIPTION
This change adds a new login module for WH authentication that works for a username (that is in the user table) and any password. In future, we would like this module to work for any username.