### PR TITLE
Adding license header to dummy login module

### DIFF
--- a/wherehows-frontend/app/security/DummyLoginModule.java
+++ b/wherehows-frontend/app/security/DummyLoginModule.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package security;
 
 import javax.security.auth.Subject;

--- a/wherehows-frontend/test/DummyLoginModuleTest.java
+++ b/wherehows-frontend/test/DummyLoginModuleTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
 import com.sun.security.auth.callback.TextCallbackHandler;
 import java.util.HashMap;
 import javax.security.auth.login.LoginException;


### PR DESCRIPTION
License headers were missing in the relevant files. This change adds them.