### PR TITLE
More cleanup to get rid of WHZ_LDAP_* references

### DIFF
--- a/wherehows-docker/.env
+++ b/wherehows-docker/.env
@@ -11,8 +11,3 @@ WHZ_SEARCH_ENGINE=elasticsearch
 WHZ_ES_DATASET_URL=http://localhost:9200/wherehows/dataset/_search
 WHZ_ES_METRIC_URL=http://localhost:9200/wherehows/metric/_search
 WHZ_ES_FLOW_URL=http://localhost:9200/wherehows/flow_jobs/_search
-
-# LDAP
-WHZ_LDAP_URL=your_ldap_url
-WHZ_LDAP_PRINCIPAL_DOMAIN=your_ldap_principal_domain
-WHZ_LDAP_SEARCH_BASE=your_ldap_search_base

--- a/wherehows-docker/README.md
+++ b/wherehows-docker/README.md
@@ -44,11 +44,7 @@ WHZ_SEARCH_ENGINE=elasticsearch
 WHZ_ES_DATASET_URL=http://localhost:9200/wherehows/dataset/_search
 WHZ_ES_METRIC_URL=http://localhost:9200/wherehows/metric/_search
 WHZ_ES_FLOW_URL=http://localhost:9200/wherehows/flow_jobs/_search
-  
-# LDAP
-WHZ_LDAP_URL=your_ldap_url
-WHZ_LDAP_PRINCIPAL_DOMAIN=your_ldap_principal_domain
-WHZ_LDAP_SEARCH_BASE=your_ldap_search_base
+
 ```
 
 ## Build Docker Container

--- a/wherehows-docker/docker-compose.yml
+++ b/wherehows-docker/docker-compose.yml
@@ -43,9 +43,6 @@ services:
       WHZ_ES_DATASET_URL: ${WHZ_ES_DATASET_URL}
       WHZ_ES_METRIC_URL: ${WHZ_ES_METRIC_URL}
       WHZ_ES_FLOW_URL: ${WHZ_ES_FLOW_URL}
-      WHZ_LDAP_URL: ${WHZ_LDAP_URL}
-      WHZ_LDAP_PRINCIPAL_DOMAIN: ${WHZ_LDAP_PRINCIPAL_DOMAIN}
-      WHZ_LDAP_SEARCH_BASE: ${WHZ_LDAP_SEARCH_BASE}
     command: dockerize -wait tcp://wherehows-mysql:3306 -wait http://wherehows-elasticsearch:9200 -timeout 120s bin/playBinary
     links:
       - "wherehows-mysql:wherehows-mysql"

--- a/wherehows-frontend/README.md
+++ b/wherehows-frontend/README.md
@@ -70,11 +70,7 @@ WHZ_SEARCH_ENGINE=elasticsearch
 WHZ_ES_DATASET_URL="http://localhost:9200/wherehows/dataset/_search"
 WHZ_ES_METRIC_URL="http://localhost:9200/wherehows/metric/_search"
 WHZ_ES_FLOW_URL="http://localhost:9200/wherehows/flow_jobs/_search"
-  
-# LDAP
-WHZ_LDAP_URL=your_ldap_url
-WHZ_LDAP_PRINCIPAL_DOMAIN=your_ldap_principal_domain
-WHZ_LDAP_SEARCH_BASE=your_ldap_search_base
+
 
 # Piwik tracking configuration
 PIWIK_SITE_ID="0000" # change_to_your_piwik_id


### PR DESCRIPTION
Now that we are not restricting ourselves to using LDAP for authentication, let's get rid of it's references from documentation and config files.