### PR TITLE
Add health score gauge to the dataset meta header

### DIFF
--- a/wherehows-web/app/styles/layout/_dataset.scss
+++ b/wherehows-web/app/styles/layout/_dataset.scss
@@ -12,3 +12,22 @@
   text-overflow: ellipsis;
   margin: 0;
 }
+
+.dataset-header-meta {
+  display: flex;
+  position: relative;
+
+  .dataset-health-score {
+    position: absolute;
+    right: item-spacing(5);
+    bottom: 0;
+  }
+
+  .dataset-owner-list {
+    margin-left: item-spacing(4);
+
+    .avatar-container {
+      justify-content: flex-start;
+    }
+  }
+}

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -49,17 +49,32 @@
           {{/if}}
         </div>
 
-        {{#datasets/containers/dataset-fabrics class="dataset-fabric-row-container" urn=model.uri as |fabricsContainer|}}
-          <div class="dataset-fabric-entity-container">
-            <strong>Fabric:</strong> {{datasets/dataset-fabric-switcher
-            urn=fabricsContainer.urn
-          }}
-          </div>
-        {{/datasets/containers/dataset-fabrics}}
+        <div class="dataset-header-meta">
+          {{#datasets/containers/dataset-fabrics class="dataset-fabric-row-container" urn=model.uri as |fabricsContainer|}}
+            <div class="dataset-fabric-entity-container">
+              <strong>Fabric:</strong> {{datasets/dataset-fabric-switcher urn=fabricsContainer.urn }}
+            </div>
+          {{/datasets/containers/dataset-fabrics}}
+
+          {{#if shouldShowDatasetHealth}}
+            {{datasets/containers/dataset-owner-list
+              urn=encodedUrn
+              class="dataset-owner-list"
+              shouldShowDatasetHealth=shouldShowDatasetHealth}}
+
+            {{visualization/charts/score-gauge
+              class="dataset-health-score"
+              score=83
+              title="Health Score:"}}
+          {{/if}}
+        </div>
+
       </div>
     </div>
 
-    {{datasets/containers/dataset-owner-list urn=encodedUrn}}
+    {{#unless shouldShowDatasetHealth}}
+      {{datasets/containers/dataset-owner-list urn=encodedUrn}}
+    {{/unless}}
 
   </div>
 </div>


### PR DESCRIPTION
Rearrange items to fit in the current iteration of the header, but only for case `showDatasetHealth == true`

`ember test` results:
```
1..379
# tests 379
# pass  373
# skip  6
# fail  0

# ok
```

<img width="1201" alt="screen shot 2018-08-08 at 10 35 36 am" src="https://user-images.githubusercontent.com/16459843/43854176-f2ecd4c0-9af6-11e8-9f1f-b590589ae912.png">
