### PR TITLE
Ui health typings and api handler

### DIFF
--- a/wherehows-web/app/components/datasets/containers/dataset-health.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-health.ts
@@ -3,8 +3,9 @@ import { get, computed, setProperties, getProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
 import ComputedProperty from '@ember/object/computed';
 import { IChartDatum } from 'wherehows-web/typings/app/visualization/charts';
-import { IHealthScore } from 'wherehows-web/typings/api/datasets/health';
+import { IHealthScore, IDatasetHealth } from 'wherehows-web/typings/api/datasets/health';
 import { healthCategories, healthSeverity, healthDetail } from 'wherehows-web/constants/data/temp-mock/health';
+import { readDatasetHealthByUrn } from 'wherehows-web/utils/api/datasets/health';
 
 /**
  * Used for the dataset health tab, represents the fieldnames for the health score table
@@ -124,7 +125,8 @@ export default class DatasetHealthContainer extends Component {
    * An async parent task to group all data tasks for this container component
    * @type {Task<TaskInstance<Promise<any>>, (a?: any) => TaskInstance<TaskInstance<Promise<any>>>>}
    */
-  getContainerDataTask = task(function*(this: DatasetHealthContainer): IterableIterator<void> {
+  getContainerDataTask = task(function*(this: DatasetHealthContainer): IterableIterator<Promise<IDatasetHealth>> {
+    const { health } = yield readDatasetHealthByUrn(get(this, 'urn'));
     // Pretend like we're getting data from somehwere
     const healthData = {
       categories: healthCategories,
@@ -137,6 +139,8 @@ export default class DatasetHealthContainer extends Component {
       severityMetrics: healthData.severity,
       tableData: healthData.detail
     });
+
+    return health; // Do something with health information
   });
 
   /**

--- a/wherehows-web/app/typings/api/datasets/health.d.ts
+++ b/wherehows-web/app/typings/api/datasets/health.d.ts
@@ -1,4 +1,33 @@
 /**
+ * This object is a raw response object for a health score detail from the api layer that will
+ * be used mainly in our metadata health score table
+ */
+export interface IHealthScoreObject {
+  tier: string | null;
+  // score will be a float between 0 and 1 representing a percentage
+  score: number;
+  description: string;
+  weight: number;
+  validator: string;
+}
+
+/**
+ * This is the abstracted response from the api request to datasets/:urn/health
+ */
+export interface IDatasetHealth {
+  // score will be a float between 0 and 1 representing a percetnage
+  score: number;
+  validations: Array<IHealthScoreObject>;
+}
+
+/**
+ * This is the raw response from the api layer for a request to datasets/:urn/health
+ */
+export interface IHealthScoreResponse {
+  health: IDatasetHealth;
+}
+
+/**
  * Primarily used in the dataset health tab, represents an individual health score entry for the table
  */
 export interface IHealthScore {

--- a/wherehows-web/app/typings/ember-cli-mirage.d.ts
+++ b/wherehows-web/app/typings/ember-cli-mirage.d.ts
@@ -22,7 +22,7 @@ export interface IMirageServer {
   loadFixtures: (...files: Array<string>) => void;
   loadFactories: (factoryMap: object) => void;
   create: (type: string, options?: object) => object;
-  createList: <T>(type: string, amount: number, traitsAndOverrides?: object) => Array<T>;
+  createList: <T>(type: string, amount: number, traitsAndOverrides?: object | string) => Array<T>;
   shutdown: (this: IMirageServer) => void;
 }
 

--- a/wherehows-web/app/utils/api/datasets/health.ts
+++ b/wherehows-web/app/utils/api/datasets/health.ts
@@ -1,0 +1,25 @@
+import { datasetUrlByUrn } from 'wherehows-web/utils/api/datasets/shared';
+import { getJSON } from 'wherehows-web/utils/api/fetcher';
+import { IHealthScoreResponse, IDatasetHealth } from 'wherehows-web/typings/api/datasets/health';
+
+/**
+ * Returns the url for dataset metadata health by urn
+ * @param urn
+ * @return {string}
+ */
+const datasetHealthUrlByUrn = (urn: string): string => `${datasetUrlByUrn(urn)}/health`;
+
+export const readDatasetHealthByUrn = async (urn: string): Promise<IDatasetHealth> => {
+  let health: IDatasetHealth;
+
+  try {
+    ({ health } = await getJSON<IHealthScoreResponse>({ url: datasetHealthUrlByUrn(urn) }));
+  } catch {
+    return {
+      score: 0,
+      validations: []
+    };
+  }
+
+  return health;
+};

--- a/wherehows-web/app/utils/api/datasets/health.ts
+++ b/wherehows-web/app/utils/api/datasets/health.ts
@@ -10,16 +10,7 @@ import { IHealthScoreResponse, IDatasetHealth } from 'wherehows-web/typings/api/
 const datasetHealthUrlByUrn = (urn: string): string => `${datasetUrlByUrn(urn)}/health`;
 
 export const readDatasetHealthByUrn = async (urn: string): Promise<IDatasetHealth> => {
-  let health: IDatasetHealth;
+  const { health } = await getJSON<IHealthScoreResponse>({ url: datasetHealthUrlByUrn(urn) });
 
-  try {
-    ({ health } = await getJSON<IHealthScoreResponse>({ url: datasetHealthUrlByUrn(urn) }));
-  } catch {
-    return {
-      score: 0,
-      validations: []
-    };
-  }
-
-  return health;
+  return health || { score: 0, validations: [] };
 };

--- a/wherehows-web/app/utils/api/datasets/health.ts
+++ b/wherehows-web/app/utils/api/datasets/health.ts
@@ -10,7 +10,13 @@ import { IHealthScoreResponse, IDatasetHealth } from 'wherehows-web/typings/api/
 const datasetHealthUrlByUrn = (urn: string): string => `${datasetUrlByUrn(urn)}/health`;
 
 export const readDatasetHealthByUrn = async (urn: string): Promise<IDatasetHealth> => {
-  const { health } = await getJSON<IHealthScoreResponse>({ url: datasetHealthUrlByUrn(urn) });
+  const defaultResponse = { score: 0, validations: [] };
 
-  return health || { score: 0, validations: [] };
+  try {
+    const { health } = await getJSON<IHealthScoreResponse>({ url: datasetHealthUrlByUrn(urn) });
+
+    return health;
+  } catch {
+    return defaultResponse;
+  }
 };

--- a/wherehows-web/mirage/config.ts
+++ b/wherehows-web/mirage/config.ts
@@ -42,7 +42,7 @@ export default function(this: IMirageServer) {
 
   this.get('/datasets/:dataset_id/schema', getDatasetSchema);
 
-  this.get('/datasets/:dataset_id/compliance/suggestions', getDatasetComplianceSuggestion);
+  this.get('/datasets/:dataset_id/compliance/suggestion', getDatasetComplianceSuggestion);
 
   this.get('/datasets/:dataset_id/owners', getDatasetOwners);
 

--- a/wherehows-web/mirage/config.ts
+++ b/wherehows-web/mirage/config.ts
@@ -25,6 +25,7 @@ import { aclAuth } from 'wherehows-web/mirage/helpers/aclauth';
 import { getDatasetUpstreams } from 'wherehows-web/mirage/helpers/dataset-upstreams';
 import { getDatasetRetention } from 'wherehows-web/mirage/helpers/dataset-retentions';
 import { getDatasetFabrics } from 'wherehows-web/mirage/helpers/dataset-fabrics';
+import { getDatasetHealth } from 'wherehows-web/mirage/helpers/dataset-health';
 
 export default function(this: IMirageServer) {
   this.get('/config', getConfig);
@@ -56,6 +57,8 @@ export default function(this: IMirageServer) {
   this.get('/datasets/:dataset_id/compliance', getDatasetCompliance);
 
   this.get('/datasets/:dataset_id/fabrics', getDatasetFabrics);
+
+  this.get('/datasets/:dataset_id/health', getDatasetHealth);
 
   this.namespace = '/api/v1';
 

--- a/wherehows-web/mirage/factories/dataset.ts
+++ b/wherehows-web/mirage/factories/dataset.ts
@@ -40,11 +40,5 @@ export default Factory.extend({
     schema(id: number) {
       return id === 0 ? testSchemaA : 'abcd';
     }
-  }),
-
-  withHealth: trait({
-    afterCreate(dataset: any, server: any) {
-      server.create('health', 1, { dataset });
-    }
   })
 });

--- a/wherehows-web/mirage/factories/dataset.ts
+++ b/wherehows-web/mirage/factories/dataset.ts
@@ -40,5 +40,11 @@ export default Factory.extend({
     schema(id: number) {
       return id === 0 ? testSchemaA : 'abcd';
     }
+  }),
+
+  withHealth: trait({
+    afterCreate(dataset: any, server: any) {
+      server.create('health', 1, { dataset });
+    }
   })
 });

--- a/wherehows-web/mirage/factories/health.ts
+++ b/wherehows-web/mirage/factories/health.ts
@@ -27,10 +27,6 @@ export default Factory.extend({
     return validations;
   },
 
-  refDatasetUrn() {
-    return this.dataset ? this.dataset.urn : 'fakeUrn';
-  },
-
   forTesting: trait({
     score: 83,
     validations() {

--- a/wherehows-web/mirage/factories/health.ts
+++ b/wherehows-web/mirage/factories/health.ts
@@ -1,0 +1,52 @@
+import { Factory, faker, trait } from 'ember-cli-mirage';
+import { IHealthScoreObject } from 'wherehows-web/typings/api/datasets/health';
+
+const tierOptions = ['CRITICAL', 'WARNING', 'MINOR'];
+
+export default Factory.extend({
+  id(id: number) {
+    return id;
+  },
+  score: faker.random.number({ min: 0, max: 100 }),
+  validations() {
+    const numValidations = faker.random.number({ min: 1, max: 6 });
+    const validations: Array<IHealthScoreObject> = [];
+
+    for (let i = 0; i < numValidations; i++) {
+      const validation: IHealthScoreObject = {
+        tier: tierOptions[i % 3],
+        score: faker.random.number({ min: 0, max: 100 }) / 100,
+        description: faker.lorem.sentences(),
+        weight: faker.random.number({ min: 0, max: 100 }) / 100,
+        validator: 'fake'
+      };
+
+      validations.push(validation);
+    }
+
+    return validations;
+  },
+
+  refDatasetUrn() {
+    return this.dataset ? this.dataset.urn : 'fakeUrn';
+  },
+
+  forTesting: trait({
+    score: 83,
+    validations() {
+      const validations: Array<IHealthScoreObject> = [];
+
+      for (let i = 0; i < 3; i++) {
+        const validation: IHealthScoreObject = {
+          tier: tierOptions[i],
+          score: 1 - (3 - i) * 0.25,
+          description: faker.lorem.sentences(2),
+          weight: faker.random.number({ min: 0, max: 100 }) / 100,
+          validator: 'fake'
+        };
+
+        validations.push(validation);
+      }
+    }
+  })
+});

--- a/wherehows-web/mirage/helpers/dataset-health.ts
+++ b/wherehows-web/mirage/helpers/dataset-health.ts
@@ -1,9 +1,7 @@
 import { IFunctionRouteHandler } from 'wherehows-web/typings/ember-cli-mirage';
 
-export const getDatasetHealth = function(this: IFunctionRouteHandler, { health }: any, request: any) {
-  const { dataset_id } = request.params;
-
+export const getDatasetHealth = function(this: IFunctionRouteHandler, { db: healths }: any) {
   return {
-    health: health.filter((score: any) => score.refDatasetUrn === dataset_id)[0] || null
+    health: this.serialize(healths[0])
   };
 };

--- a/wherehows-web/mirage/helpers/dataset-health.ts
+++ b/wherehows-web/mirage/helpers/dataset-health.ts
@@ -1,0 +1,9 @@
+import { IFunctionRouteHandler } from 'wherehows-web/typings/ember-cli-mirage';
+
+export const getDatasetHealth = function(this: IFunctionRouteHandler, { health }: any, request: any) {
+  const { dataset_id } = request.params;
+
+  return {
+    health: health.filter((score: any) => score.refDatasetUrn === dataset_id)[0] || null
+  };
+};

--- a/wherehows-web/mirage/scenarios/default.ts
+++ b/wherehows-web/mirage/scenarios/default.ts
@@ -13,7 +13,7 @@ export default function(server: IMirageServer) {
   server.loadFixtures(...fixtures);
   server.create('config');
   server.createList('owner', 6);
-  server.createList('dataset', 10);
+  server.createList('dataset', 10, 'withHealth');
   server.createList('datasetView', 2);
   server.createList('column', 2);
   server.createList('comment', 2);

--- a/wherehows-web/mirage/scenarios/default.ts
+++ b/wherehows-web/mirage/scenarios/default.ts
@@ -13,7 +13,7 @@ export default function(server: IMirageServer) {
   server.loadFixtures(...fixtures);
   server.create('config');
   server.createList('owner', 6);
-  server.createList('dataset', 10, 'withHealth');
+  server.createList('dataset', 10);
   server.createList('datasetView', 2);
   server.createList('column', 2);
   server.createList('comment', 2);
@@ -27,4 +27,5 @@ export default function(server: IMirageServer) {
   server.createList('suggestion', 2);
   server.createList('platform', 2);
   server.createList('version', 2);
+  server.createList('health', 1);
 }

--- a/wherehows-web/tests/integration/components/datasets/containers/dataset-health-test.js
+++ b/wherehows-web/tests/integration/components/datasets/containers/dataset-health-test.js
@@ -1,13 +1,20 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { waitUntil, find } from 'ember-native-dom-helpers';
+import { urn } from 'wherehows-web/mirage/fixtures/urn';
+import sinon from 'sinon';
 
-module('Integration | Component | datasets/containers/dataset-health', function(hooks) {
-  setupRenderingTest(hooks);
-  // TODO: More meaningful tests as we continue with development
-  test('it renders', async function(assert) {
-    await render(hbs`{{datasets/containers/dataset-health}}`);
-    assert.ok(this.element, 'Renders without errors');
-  });
+moduleForComponent(
+  'datasets/containers/dataset-health',
+  'Integration | Component | datasets/containers/dataset-health',
+  {
+    integration: true
+  }
+);
+
+test('it renders', async function(assert) {
+  this.set('urn', urn);
+  this.render(hbs`{{datasets/containers/dataset-health urn=urn}}`);
+
+  assert.ok(find('.dataset-health__score-table'), 'renders the health table component');
 });

--- a/wherehows-web/tests/integration/components/datasets/containers/dataset-health-test.js
+++ b/wherehows-web/tests/integration/components/datasets/containers/dataset-health-test.js
@@ -1,20 +1,17 @@
-import { moduleForComponent, test } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
-import { waitUntil, find } from 'ember-native-dom-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import { urn } from 'wherehows-web/mirage/fixtures/urn';
-import sinon from 'sinon';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent(
-  'datasets/containers/dataset-health',
-  'Integration | Component | datasets/containers/dataset-health',
-  {
-    integration: true
-  }
-);
+module('Integration | Component | datasets/containers/dataset-health', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders', async function(assert) {
-  this.set('urn', urn);
-  this.render(hbs`{{datasets/containers/dataset-health urn=urn}}`);
+  test('it renders', async function(assert) {
+    this.set('urn', urn);
+    await render(hbs`{{datasets/containers/dataset-health urn=urn}}`);
 
-  assert.ok(find('.dataset-health__score-table'), 'renders the health table component');
+    assert.ok(this.element, 'Renders without errors');
+    assert.ok(find('.dataset-health__score-table'), 'renders the health table component');
+  });
 });


### PR DESCRIPTION
### v1
- Add typings for expected health response and health score objects
- Implement util api function to retrieve dataset health information (TODO: Actually apply this once we have a real backend)
- Create mirage factory to generate health information

`ember test` results:
```
1..379
# tests 379
# pass  373
# skip  6
# fail  0

# ok
```