### PR TITLE
Health tab fix

### DIFF
--- a/wherehows-web/app/components/datasets/containers/dataset-health.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-health.ts
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
-import { get, computed, setProperties, getProperties } from '@ember/object';
+import { get, computed, setProperties, getProperties, set } from '@ember/object';
 import { task } from 'ember-concurrency';
-import ComputedProperty from '@ember/object/computed';
+import ComputedProperty, { equal } from '@ember/object/computed';
 import { IChartDatum } from 'wherehows-web/typings/app/visualization/charts';
 import { IHealthScore, IDatasetHealth } from 'wherehows-web/typings/api/datasets/health';
 import { healthCategories, healthSeverity, healthDetail } from 'wherehows-web/constants/data/temp-mock/health';
@@ -68,6 +68,22 @@ export default class DatasetHealthContainer extends Component {
    * @type {Array<IHealthScore>}
    */
   tableData: Array<IHealthScore> = [];
+
+  /**
+   * Passed in from the higher level component, we use this property in order to determine whether the dataset health
+   * tab is the currently selected tab
+   * @type {string}
+   */
+  tabSelected: string;
+
+  /**
+   * Calculated from the currently selected tab to determine whether this container is the currently selected tab.
+   * Note: Highcharts calculates size and other chart details upon initial render and doesn't do a good job of handling
+   * rerenders. Because of this we want those calculations to take place when dataset health is the currently active tab,
+   * otherwise we will insert elements off screen and size will default to 0 and we lose our charts
+   * @type {ComputedProperty<boolean>}
+   */
+  isActiveTab = equal('tabSelected', 'health');
 
   /**
    * Modified categoryMetrics to add properties that will help us render our actual charts without modifying the original
@@ -162,5 +178,12 @@ export default class DatasetHealthContainer extends Component {
       currentCategoryFilter: filterType === 'category' && newFilterName !== currentCategoryFilter ? newFilterName : '',
       currentSeverityFilter: filterType === 'severity' && newFilterName !== currentSeverityFilter ? newFilterName : ''
     });
+  }
+
+  constructor() {
+    super(...arguments);
+    console.log('constructing');
+    console.log(this.tabSelected);
+    set(this, 'tabSelected', this.tabSelected);
   }
 }

--- a/wherehows-web/app/components/datasets/containers/dataset-health.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-health.ts
@@ -1,11 +1,13 @@
 import Component from '@ember/component';
-import { get, computed, setProperties, getProperties, set } from '@ember/object';
+import { get, computed, setProperties, getProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
-import ComputedProperty, { equal } from '@ember/object/computed';
+import ComputedProperty from '@ember/object/computed';
 import { IChartDatum } from 'wherehows-web/typings/app/visualization/charts';
 import { IHealthScore, IDatasetHealth } from 'wherehows-web/typings/api/datasets/health';
 import { healthCategories, healthSeverity, healthDetail } from 'wherehows-web/constants/data/temp-mock/health';
 import { readDatasetHealthByUrn } from 'wherehows-web/utils/api/datasets/health';
+import { Tabs } from 'wherehows-web/constants/datasets/shared';
+import { equal } from '@ember-decorators/object/computed';
 
 /**
  * Used for the dataset health tab, represents the fieldnames for the health score table
@@ -72,9 +74,9 @@ export default class DatasetHealthContainer extends Component {
   /**
    * Passed in from the higher level component, we use this property in order to determine whether the dataset health
    * tab is the currently selected tab
-   * @type {string}
+   * @type {Tabs}
    */
-  tabSelected: string;
+  tabSelected: Tabs;
 
   /**
    * Calculated from the currently selected tab to determine whether this container is the currently selected tab.
@@ -83,7 +85,8 @@ export default class DatasetHealthContainer extends Component {
    * otherwise we will insert elements off screen and size will default to 0 and we lose our charts
    * @type {ComputedProperty<boolean>}
    */
-  isActiveTab = equal('tabSelected', 'health');
+  @equal('tabSelected', Tabs.Health)
+  isActiveTab: boolean;
 
   /**
    * Modified categoryMetrics to add properties that will help us render our actual charts without modifying the original
@@ -178,12 +181,5 @@ export default class DatasetHealthContainer extends Component {
       currentCategoryFilter: filterType === 'category' && newFilterName !== currentCategoryFilter ? newFilterName : '',
       currentSeverityFilter: filterType === 'severity' && newFilterName !== currentSeverityFilter ? newFilterName : ''
     });
-  }
-
-  constructor() {
-    super(...arguments);
-    console.log('constructing');
-    console.log(this.tabSelected);
-    set(this, 'tabSelected', this.tabSelected);
   }
 }

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-health.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-health.hbs
@@ -1,5 +1,6 @@
 <h3>Metadata Health</h3>
 {{datasets/health/metrics-charts
+  isActiveTab=isActiveTab
   categoryData=renderedCategories
   severityData=renderedSeverity
   onCategorySelect=(action onFilterSelect "category")

--- a/wherehows-web/app/templates/components/datasets/health/metrics-charts.hbs
+++ b/wherehows-web/app/templates/components/datasets/health/metrics-charts.hbs
@@ -1,5 +1,5 @@
 <div class="dataset-health__chart-container">
-  {{#if categoryData}}
+  {{#if (and isActiveTab categoryData)}}
     {{visualization/charts/horizontal-bar-chart
       title="Categories"
       series=categoryData
@@ -8,7 +8,7 @@
   {{/if}}
 </div>
 <div class="dataset-health__chart-container">
-  {{#if severityData}}
+  {{#if (and isActiveTab severityData)}}
     {{visualization/charts/horizontal-bar-chart
       class="severity-chart"
       title="Severity"

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -172,7 +172,7 @@
 
     {{#if shouldShowDatasetHealth}}
       {{#tabs.tabpanel tabIds.Health}}
-        {{datasets/containers/dataset-health urn=encodedUrn}}
+        {{datasets/containers/dataset-health urn=encodedUrn tabSelected=tabSelected}}
       {{/tabs.tabpanel}}
     {{/if}}
   </div>

--- a/wherehows-web/tests/integration/components/datasets/health/metrics-charts-test.js
+++ b/wherehows-web/tests/integration/components/datasets/health/metrics-charts-test.js
@@ -31,6 +31,7 @@ module('Integration | Component | datasets/health/metrics-charts', function(hook
     });
 
     await render(hbs`{{datasets/health/metrics-charts
+                      isActiveTab=true
                       categoryData=categoryData
                       severityData=severityData}}`);
 

--- a/wherehows-web/tests/test-helper.js
+++ b/wherehows-web/tests/test-helper.js
@@ -2,6 +2,15 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { registerDeprecationHandler } from '@ember/debug';
+
+// Suggestion to keep this here until we are ready to handle the deprecation to use definePRoperty for
+// computed properties. Otherwise, tests and build logs becoming overwhelming to look at
+registerDeprecationHandler(function(message, { id }, next) {
+  if (!message.includes('defineProperty')) {
+    next(...arguments);
+  }
+});
 
 setApplication(Application.create(config.APP));
 

--- a/wherehows-web/tests/test-helper.js
+++ b/wherehows-web/tests/test-helper.js
@@ -4,10 +4,18 @@ import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { registerDeprecationHandler } from '@ember/debug';
 
+const testState = { showWarning: false };
+let hasShownDefinePropDeprecation = false;
+
 // Suggestion to keep this here until we are ready to handle the deprecation to use definePRoperty for
 // computed properties. Otherwise, tests and build logs becoming overwhelming to look at
 registerDeprecationHandler(function(message, { id }, next) {
-  if (!message.includes('defineProperty')) {
+  if (message.includes('defineProperty')) {
+    if (!hasShownDefinePropDeprecation) {
+      next(...arguments);
+      hasShownDefinePropDeprecation = true;
+    }
+  } else {
     next(...arguments);
   }
 });

--- a/wherehows-web/tests/test-helper.js
+++ b/wherehows-web/tests/test-helper.js
@@ -4,7 +4,6 @@ import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { registerDeprecationHandler } from '@ember/debug';
 
-const testState = { showWarning: false };
 let hasShownDefinePropDeprecation = false;
 
 // Suggestion to keep this here until we are ready to handle the deprecation to use definePRoperty for


### PR DESCRIPTION
Highcharts calculates size and other chart details upon initial render and doesn't rerender when we switch tabs. Because of this we want those calculations to take place when dataset health is the currently active tab, otherwise we will insert elements off screen and size will default to 0 and we lose our charts.

Also remove annoying deprecation warnings that aren't relevant yet.

`ember test` results:
```
1..482
# tests 482
# pass  476
# skip  6
# fail  0

# ok
```