### PR TITLE
Red dot ownership

### DIFF
--- a/wherehows-web/app/components/dataset-authors.ts
+++ b/wherehows-web/app/components/dataset-authors.ts
@@ -20,6 +20,7 @@ import {
 } from 'wherehows-web/constants/datasets/owner';
 import { OwnerSource, OwnerType } from 'wherehows-web/utils/api/datasets/owners';
 import Notifications, { NotificationEvent } from 'wherehows-web/services/notifications';
+import { noop } from 'wherehows-web/utils/helpers/functions';
 
 type Comparator = -1 | 0 | 1;
 
@@ -114,6 +115,8 @@ export default class DatasetAuthors extends Component {
    */
   isAddingOwner = false;
 
+  setOwnershipRuleChange: (notConfirmed: boolean) => void;
+
   /**
    * Flag that resolves in the affirmative if the number of confirmed owner is less the minimum required
    * @type {ComputedProperty<boolean>}
@@ -128,7 +131,9 @@ export default class DatasetAuthors extends Component {
     }
     // If there have been no changes, then we want to automatically set true in order to disable save button
     // when no changes have been made
-    return changedState === -1 ? true : isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
+    const requiredOwnersNotConfirmed = isRequiredMinOwnersNotConfirmed(get(this, 'confirmedOwners'));
+    get(this, 'setOwnershipRuleChange')(requiredOwnersNotConfirmed);
+    return changedState === -1 || requiredOwnersNotConfirmed;
   }
 
   /**
@@ -201,6 +206,8 @@ export default class DatasetAuthors extends Component {
       `Expected action save to be an function (Ember action), got ${typeOfSaveAction}`,
       typeOfSaveAction === 'function'
     );
+
+    this.setOwnershipRuleChange || (this.setOwnershipRuleChange = noop);
   }
 
   /**

--- a/wherehows-web/app/controllers/datasets/dataset.ts
+++ b/wherehows-web/app/controllers/datasets/dataset.ts
@@ -7,7 +7,7 @@ import { Tabs } from 'wherehows-web/constants/datasets/shared';
 import { action } from '@ember-decorators/object';
 import { DatasetPlatform } from 'wherehows-web/constants';
 import { IDatasetView } from 'wherehows-web/typings/api/datasets/dataset';
-import { once } from '@ember/runloop';
+import { next } from '@ember/runloop';
 
 export default class DatasetController extends Controller {
   queryParams = ['urn'];
@@ -241,8 +241,6 @@ export default class DatasetController extends Controller {
    */
   @action
   setOwnershipRuleChange(ownersNotConfirmed: boolean) {
-    once('afterRender', () => {
-      set(this, 'datasetOwnersRequiredNotMet', ownersNotConfirmed);
-    });
+    next(this, () => set(this, 'datasetOwnersRequiredNotMet', ownersNotConfirmed));
   }
 }

--- a/wherehows-web/app/controllers/datasets/dataset.ts
+++ b/wherehows-web/app/controllers/datasets/dataset.ts
@@ -7,6 +7,7 @@ import { Tabs } from 'wherehows-web/constants/datasets/shared';
 import { action } from '@ember-decorators/object';
 import { DatasetPlatform } from 'wherehows-web/constants';
 import { IDatasetView } from 'wherehows-web/typings/api/datasets/dataset';
+import { once } from '@ember/runloop';
 
 export default class DatasetController extends Controller {
   queryParams = ['urn'];
@@ -101,6 +102,14 @@ export default class DatasetController extends Controller {
    * @memberof DatasetController
    */
   datasetContainsPersonalData: boolean;
+
+  datasetOwnersRequiredNotMet: boolean;
+
+  /**
+   * Flag indicating that the dataset ownership requires user attention
+   * @type {ComputedProperty<boolean>}
+   */
+  ownershipRequiresUserAction: ComputedProperty<boolean> = or('datasetOwnersRequiredNotMet');
 
   /**
    * Flag indicating that the compliance policy needs user attention
@@ -218,5 +227,17 @@ export default class DatasetController extends Controller {
   setOnChangeSetDrift(hasDrift: boolean) {
     const fromUpstream = get(this, 'isPolicyFromUpstream');
     set(this, 'compliancePolicyHasDrift', !fromUpstream && hasDrift);
+  }
+
+  /**
+   * Triggered when the ownership information changes, will alert the user on the tab with a red dot if
+   * the current state of the dataset doesn't match the rules set out for the dataset ownership
+   * @param ownersNotConfirmed - Whether or not the owners for the dataset meet the requirements
+   */
+  @action
+  setOwnershipRuleChange(ownersNotConfirmed: boolean) {
+    once('afterRender', () => {
+      set(this, 'datasetOwnersRequiredNotMet', ownersNotConfirmed);
+    });
   }
 }

--- a/wherehows-web/app/controllers/datasets/dataset.ts
+++ b/wherehows-web/app/controllers/datasets/dataset.ts
@@ -103,6 +103,11 @@ export default class DatasetController extends Controller {
    */
   datasetContainsPersonalData: boolean;
 
+  /**
+   * Whether or not we have met the dataset ownership count requirements
+   * @type {boolean}
+   * @memberof DatasetController
+   */
   datasetOwnersRequiredNotMet: boolean;
 
   /**

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-ownership.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-ownership.hbs
@@ -34,6 +34,7 @@
         owners=owners
         suggestedOwners=suggestedOwners
         ownerTypes=ownerTypes
+        setOwnershipRuleChange=setOwnershipRuleChange
         save=(action "saveOwnerChanges")
       }}
 

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -94,7 +94,7 @@
         {{#tablist.tab tabIds.Ownership on-select=(action "tabSelectionChanged")}}
           Ownership
 
-          {{#if requiredMinNotConfirmed}}
+          {{#if ownershipRequiresUserAction}}
             <span class="notification-dot notification-dot--on-tab" aria-hidden="true"></span>
           {{/if}}
         {{/tablist.tab}}
@@ -142,7 +142,9 @@
     {{/tabs.tabpanel}}
 
     {{#tabs.tabpanel tabIds.Ownership}}
-      {{datasets/containers/dataset-ownership urn=encodedUrn}}
+      {{datasets/containers/dataset-ownership
+        urn=encodedUrn
+        setOwnershipRuleChange=(action "setOwnershipRuleChange")}}
     {{/tabs.tabpanel}}
 
     {{#tabs.tabpanel tabIds.Compliance}}


### PR DESCRIPTION
###v1:
- Creates a red dot on the ownership tab (similar to compliance tab) when requirements for this are not met. 

`ember test` results:
```
1..487
# tests 487
# pass  481
# skip  6
# fail  0

# ok
```