### PR TITLE
Allow for equals sign in urn validator

### DIFF
--- a/wherehows-web/app/utils/validators/urn.ts
+++ b/wherehows-web/app/utils/validators/urn.ts
@@ -5,7 +5,7 @@ import { DatasetPlatform, Fabric, isDatasetFabric } from 'wherehows-web/constant
  * Path segment in a urn. common btw WH and LI formats
  * @type {RegExp}
  */
-const urnPath = /[\w.$\-\/{}+()\s\*]+/;
+const urnPath = /[\w.$\-\/{}+()\s=\*]+/;
 /**
  * Matches a url string with a `urn` query. urn query with letters or underscore segment of any length greater
  *   than 1 followed by colon and 3 forward slashes and a segment containing letters, {, }, _ or /, or none


### PR DESCRIPTION
`ember test` results:
```
1..504
# tests 504
# pass  498
# skip  6
# fail  0

# ok
```