### PR TITLE
Move logic for dataset compliance entities to a new component

### DIFF
--- a/wherehows-web/app/components/datasets/compliance/schema-entities.ts
+++ b/wherehows-web/app/components/datasets/compliance/schema-entities.ts
@@ -1,0 +1,778 @@
+import Component from '@ember/component';
+import ComputedProperty, { not, alias } from '@ember/object/computed';
+import { IComplianceDataType } from 'wherehows-web/typings/api/list/compliance-datatypes';
+import {
+  lowQualitySuggestionConfidenceThreshold,
+  TagFilter,
+  tagsRequiringReview,
+  changeSetReviewableAttributeTriggers,
+  mergeComplianceEntitiesWithSuggestions,
+  asyncMapSchemaColumnPropsToCurrentPrivacyPolicy,
+  sortFoldedChangeSetTuples,
+  foldComplianceChangeSets,
+  tagSuggestionNeedsReview,
+  getSupportedPurgePolicies,
+  PurgePolicy,
+  singleTagsInChangeSet,
+  tagsForIdentifierField,
+  tagsWithoutIdentifierType,
+  ComplianceFieldIdValue,
+  NonIdLogicalType,
+  overrideTagReadonly,
+  getDefaultSecurityClassification,
+  SuggestionIntent,
+  getFieldIdentifierOptions
+} from 'wherehows-web/constants';
+import { computed, get, set, getProperties, setProperties } from '@ember/object';
+import { arrayMap, compact, iterateArrayAsync, arrayFilter } from 'wherehows-web/utils/array';
+import {
+  IComplianceChangeSet,
+  ISchemaFieldsToPolicy,
+  ISchemaFieldsToSuggested,
+  IdentifierFieldWithFieldChangeSetTuple,
+  IComplianceEntityWithMetadata,
+  IComplianceFieldIdentifierOption,
+  IDropDownOption
+} from 'wherehows-web/typings/app/dataset-compliance';
+import { run, next } from '@ember/runloop';
+import { readPlatforms } from 'wherehows-web/utils/api/list/platforms';
+import { IDatasetColumn } from 'wherehows-web/typings/api/datasets/columns';
+import { IColumnFieldProps } from 'wherehows-web/typings/app/dataset-columns';
+import { getTagsSuggestions } from 'wherehows-web/utils/datasets/compliance-suggestions';
+import { task, waitForProperty } from 'ember-concurrency';
+import {
+  IComplianceInfo,
+  ISuggestedFieldClassification,
+  IComplianceSuggestion,
+  IComplianceEntity
+} from 'wherehows-web/typings/api/datasets/compliance';
+import { assert } from '@ember/debug';
+import { pluralize } from 'ember-inflector';
+import { action } from '@ember-decorators/object';
+import { identity } from 'wherehows-web/utils/helpers/functions';
+import { IDataPlatform } from 'wherehows-web/typings/api/list/platforms';
+import { IDatasetView } from 'wherehows-web/typings/api/datasets/dataset';
+import { pick } from 'wherehows-web/utils/object';
+import { TrackableEventCategory, trackableEvent } from 'wherehows-web/constants/analytics/event-tracking';
+import { notificationDialogActionFactory } from 'wherehows-web/utils/notifications/notifications';
+import Notifications, { NotificationEvent } from 'wherehows-web/services/notifications';
+import { service } from '@ember-decorators/service';
+
+export default class ComplianceSchemaEntities extends Component {
+  /**
+   * Reference to the application notifications Service
+   * @type {ComputedProperty<Notifications>}
+   */
+  @service
+  notifications: Notifications;
+
+  complianceInfo: undefined | IComplianceInfo;
+  platform: IDatasetView['platform'];
+  isCompliancePolicyAvailable: boolean = false;
+  searchTerm: string;
+
+  /**
+   * Enum of categories that can be tracked for this component
+   * @type {TrackableEventCategory}
+   */
+  trackableCategory = TrackableEventCategory;
+
+  /**
+   * Map of events that can be tracked
+   * @type {ITrackableEventCategoryEvent}
+   */
+  trackableEvent = trackableEvent;
+
+  /**
+   * Flag determining whether or not we are in an editing state. This is passed in from the
+   * dataset-compliance parent
+   * @type {boolean}
+   */
+  isEditing: boolean;
+
+  /**
+   * Maybe not useful anymore, used when the dataset has not had any compliance info edits,
+   * passed in from the dataset-compliance parent
+   * @type {boolean}
+   */
+  isNewComplianceInfo: boolean;
+
+  /**
+   * List of complianceDataType values, passed in from the dataset-compliance parent
+   * @type {Array<IComplianceDataType>}
+   */
+  complianceDataTypes: Array<IComplianceDataType>;
+
+  /**
+   * Convenience flag indicating the policy is not currently being edited
+   * @type {ComputedProperty<boolean>}
+   * @memberof ComplianceSchemaEntities
+   */
+  isReadOnly: ComputedProperty<boolean> = not('isEditing');
+
+  /**
+   * Confidence percentage number used to filter high quality suggestions versus lower quality, passed
+   * in from dataset-compliance parent
+   * @type {number}
+   */
+  suggestionConfidenceThreshold: number;
+
+  /**
+   * Flag indicating that the field names in each compliance row is truncated or rendered in full
+   * @type {boolean}
+   */
+  isShowingFullFieldNames = true;
+
+  /**
+   * Flag indicating the current compliance policy edit-view mode. Guided mode involves fields and dropdowns
+   * while the "advanced mode" is a direct json schema edit
+   * @type {boolean}
+   */
+  showGuidedComplianceEditMode: boolean = true;
+
+  /**
+   * Flag indicating the readonly confirmation dialog should not be shown again for this compliance form
+   * @type {boolean}
+   */
+  doNotShowReadonlyConfirmation: boolean = false;
+
+  /**
+   * Default to show all fields to review
+   * @type {string}
+   * @memberof ComplianceSchemaEntities
+   */
+  fieldReviewOption: TagFilter = TagFilter.showAll;
+
+  /**
+   * References the ComplianceFieldIdValue enum
+   * @type {ComplianceFieldIdValue}
+   */
+  ComplianceFieldIdValue = ComplianceFieldIdValue;
+
+  /**
+   * Reduces the current filtered changeSet to a list of IdentifierFieldWithFieldChangeSetTuple
+   * @type {Array<IdentifierFieldWithFieldChangeSetTuple>}
+   * @memberof ComplianceSchemaEntities
+   */
+  foldedChangeSet: Array<IdentifierFieldWithFieldChangeSetTuple>;
+
+  /**
+   * The list of supported purge policies for the related platform
+   * @type {Array<PurgePolicy>}
+   * @memberof ComplianceSchemaEntities
+   */
+  supportedPurgePolicies: Array<PurgePolicy> = [];
+
+  /**
+   * A list of ui values and labels for review filter drop-down
+   * @type {Array<{value: string, label:string}>}
+   * @memberof ComplianceSchemaEntities
+   */
+  fieldReviewOptions: Array<{ value: TagFilter; label: string }> = [
+    { value: TagFilter.showAll, label: 'Show all fields' },
+    { value: TagFilter.showReview, label: 'Show required fields' },
+    { value: TagFilter.showSuggested, label: 'Show suggested fields' }
+  ];
+
+  schemaFieldNamesMappedToDataTypes: Array<Pick<IDatasetColumn, 'dataType' | 'fieldName'>>;
+
+  /**
+   * Computed prop over the current Id fields in the Privacy Policy
+   * @type {ISchemaFieldsToPolicy}
+   */
+  columnIdFieldsToCurrentPrivacyPolicy: ISchemaFieldsToPolicy = {};
+
+  /**
+   * Suggested values for compliance types e.g. identifier type and/or logical type
+   * @type {IComplianceSuggestion | void}
+   */
+  complianceSuggestion: IComplianceSuggestion | void;
+
+  notifyOnChangeSetSuggestions: (hasSuggestions: boolean) => void;
+  notifyOnChangeSetRequiresReview: (hasChangeSetDrift: boolean) => void;
+  notifyOnComplianceSuggestionFeedback: () => void;
+
+  /**
+   * The changeSet tags that require user attention
+   * @type {ComputedProperty<Array<IComplianceChangeSet>>}
+   * @memberof ComplianceSchemaEntities
+   */
+  changeSetReview = computed(
+    `compliancePolicyChangeSet.@each.{${changeSetReviewableAttributeTriggers}}`,
+    'complianceDataTypes',
+    'suggestionConfidenceThreshold',
+    function(this: ComplianceSchemaEntities): Array<IComplianceChangeSet> {
+      const { suggestionConfidenceThreshold, compliancePolicyChangeSet } = getProperties(this, [
+        'suggestionConfidenceThreshold',
+        'compliancePolicyChangeSet'
+      ]);
+
+      return tagsRequiringReview(get(this, 'complianceDataTypes'), {
+        checkSuggestions: true,
+        suggestionConfidenceThreshold
+      })(compliancePolicyChangeSet);
+    }
+  );
+
+  /**
+   * Returns a count of changeSet tags that require user attention
+   * @type {ComputedProperty<number>}
+   * @memberof ComplianceSchemaEntities
+   */
+  changeSetReviewCount = alias('changeSetReview.length');
+
+  /**
+   * Computes a cta string for the selected field review filter option
+   * @type {ComputedProperty<string>}
+   * @memberof ComplianceSchemaEntities
+   */
+  fieldReviewHint: ComputedProperty<string> = computed('fieldReviewOption', 'changeSetReviewCount', function(
+    this: ComplianceSchemaEntities
+  ): string {
+    type TagFilterHint = { [K in TagFilter]: string };
+
+    const { fieldReviewOption, changeSetReviewCount } = getProperties(this, [
+      'fieldReviewOption',
+      'changeSetReviewCount'
+    ]);
+
+    const hint = (<TagFilterHint>{
+      [TagFilter.showAll]: `${pluralize(changeSetReviewCount, 'field')} to be reviewed`,
+      [TagFilter.showReview]: 'It is required to select compliance info for all fields',
+      [TagFilter.showSuggested]: 'Please review suggestions and provide feedback'
+    })[fieldReviewOption];
+
+    return changeSetReviewCount ? hint : '';
+  });
+
+  /**
+   * Creates a mapping of compliance suggestions to identifierField
+   * This improves performance in a subsequent merge op since this loop
+   * happens only once and is cached
+   * @type {ComputedProperty<ISchemaFieldsToSuggested>}
+   * @memberof ComplianceSchemaEntities
+   */
+  identifierFieldToSuggestion = computed('complianceSuggestion', function(
+    this: ComplianceSchemaEntities
+  ): ISchemaFieldsToSuggested {
+    const fieldSuggestions: ISchemaFieldsToSuggested = {};
+    const complianceSuggestion = get(this, 'complianceSuggestion') || {
+      lastModified: 0,
+      suggestedFieldClassification: <Array<ISuggestedFieldClassification>>[]
+    };
+    const { lastModified: suggestionsModificationTime, suggestedFieldClassification = [] } = complianceSuggestion;
+
+    // If the compliance suggestions array contains suggestions the create reduced lookup map,
+    // otherwise, ignore
+    if (suggestedFieldClassification.length) {
+      return suggestedFieldClassification.reduce(
+        (
+          fieldSuggestions: ISchemaFieldsToSuggested,
+          { suggestion: { identifierField, identifierType, logicalType, securityClassification }, confidenceLevel, uid }
+        ) => ({
+          ...fieldSuggestions,
+          [identifierField]: {
+            identifierType,
+            logicalType,
+            securityClassification,
+            confidenceLevel,
+            uid,
+            suggestionsModificationTime
+          }
+        }),
+        fieldSuggestions
+      );
+    }
+
+    return fieldSuggestions;
+  });
+
+  /**
+   * Caches a reference to the generated list of merged data between the column api and the current compliance entities list
+   * @type {ComputedProperty<IComplianceChangeSet>}
+   * @memberof ComplianceSchemaEntities
+   */
+  compliancePolicyChangeSet = computed(
+    'columnIdFieldsToCurrentPrivacyPolicy',
+    'complianceDataTypes',
+    'identifierFieldToSuggestion',
+    'suggestionConfidenceThreshold',
+    function(this: ComplianceSchemaEntities): Array<IComplianceChangeSet> {
+      // schemaFieldNamesMappedToDataTypes is a dependency for CP columnIdFieldsToCurrentPrivacyPolicy, so no need to dep on that directly
+      const changeSet = mergeComplianceEntitiesWithSuggestions(
+        get(this, 'columnIdFieldsToCurrentPrivacyPolicy'),
+        get(this, 'identifierFieldToSuggestion')
+      );
+
+      const suggestionThreshold = get(this, 'suggestionConfidenceThreshold');
+
+      // pass current changeSet state to parent handlers
+      run(() => next(this, 'notifyHandlerOfSuggestions', suggestionThreshold, changeSet));
+      run(() =>
+        next(
+          this,
+          'notifyHandlerOfFieldsRequiringReview',
+          suggestionThreshold,
+          get(this, 'complianceDataTypes'),
+          changeSet
+        )
+      );
+
+      return changeSet;
+    }
+  );
+
+  /**
+   * Returns a list of changeSet fields that meets the user selected filter criteria
+   * @type {ComputedProperty<IComplianceChangeSet>}
+   * @memberof ComplianceSchemaEntities
+   */
+  filteredChangeSet = computed(
+    'changeSetReviewCount',
+    'fieldReviewOption',
+    'compliancePolicyChangeSet',
+    'complianceDataTypes',
+    'suggestionConfidenceThreshold',
+    function(this: ComplianceSchemaEntities): Array<IComplianceChangeSet> {
+      /**
+       * Aliases the index signature for a hash of callback functions keyed by TagFilter
+       * to filter out compliance changeset items
+       * @alias
+       */
+      type TagFilterCallback<T = Array<IComplianceChangeSet>> = { [K in TagFilter]: (x: T) => T };
+
+      const {
+        compliancePolicyChangeSet: changeSet,
+        complianceDataTypes,
+        suggestionConfidenceThreshold
+      } = getProperties(this, ['compliancePolicyChangeSet', 'complianceDataTypes', 'suggestionConfidenceThreshold']);
+
+      // references the filter predicate for changeset items based on the currently set tag filter
+      const changeSetFilter = (<TagFilterCallback>{
+        [TagFilter.showAll]: identity,
+        [TagFilter.showReview]: tagsRequiringReview(complianceDataTypes, {
+          checkSuggestions: true,
+          suggestionConfidenceThreshold
+        }),
+        [TagFilter.showSuggested]: arrayFilter((tag: IComplianceChangeSet) =>
+          tagSuggestionNeedsReview({ ...tag, suggestionConfidenceThreshold })
+        )
+      })[get(this, 'fieldReviewOption')];
+
+      return changeSetFilter(changeSet);
+    }
+  );
+
+  /**
+   * Lists the IComplianceChangeSet / tags without an identifierType value
+   * @type {ComputedProperty<Array<IComplianceChangeSet>>}
+   * @memberof ComplianceSchemaEntities
+   */
+  unspecifiedTags = computed(`compliancePolicyChangeSet.@each.{${changeSetReviewableAttributeTriggers}}`, function(
+    this: ComplianceSchemaEntities
+  ): Array<IComplianceChangeSet> {
+    const tags = get(this, 'compliancePolicyChangeSet');
+    const singleTags = singleTagsInChangeSet(tags, tagsForIdentifierField);
+
+    return tagsWithoutIdentifierType(singleTags);
+  });
+
+  /**
+   * Formatted JSON string representing the compliance entities for this dataset
+   * @type {ComputedProperty<string>}
+   */
+  jsonComplianceEntities: ComputedProperty<string> = computed('columnIdFieldsToCurrentPrivacyPolicy', function(
+    this: ComplianceSchemaEntities
+  ): string {
+    const entityAttrs: Array<keyof IComplianceEntity> = [
+      'identifierField',
+      'identifierType',
+      'logicalType',
+      'nonOwner',
+      'valuePattern',
+      'readonly'
+    ];
+    const entityMap: ISchemaFieldsToPolicy = get(this, 'columnIdFieldsToCurrentPrivacyPolicy');
+    const entitiesWithModifiableKeys = arrayMap((tag: IComplianceEntityWithMetadata) => pick(tag, entityAttrs))(
+      (<Array<IComplianceEntityWithMetadata>>[]).concat(...Object.values(entityMap))
+    );
+
+    return JSON.stringify(entitiesWithModifiableKeys, null, '\t');
+  });
+
+  /**
+   * Reads the complianceDataTypes property and transforms into a list of drop down options for the field
+   * identifier type
+   * @type {ComputedProperty<Array<IComplianceFieldIdentifierOption  | IDropDownOption<null | 'NONE'>>>}
+   */
+  complianceFieldIdDropdownOptions = computed('complianceDataTypes', function(
+    this: ComplianceSchemaEntities
+  ): Array<IComplianceFieldIdentifierOption | IDropDownOption<null | ComplianceFieldIdValue.None>> {
+    // object with interface IComplianceDataType and an index number indicative of position
+    type IndexedComplianceDataType = IComplianceDataType & { index: number };
+
+    const noneDropDownOption: IDropDownOption<ComplianceFieldIdValue.None> = {
+      value: ComplianceFieldIdValue.None,
+      label: 'None'
+    };
+    // Creates a list of IComplianceDataType each with an index. The intent here is to perform a stable sort on
+    // the items in the list, Array#sort is not stable, so for items that equal on the primary comparator
+    // break the tie based on position in original list
+    const indexedDataTypes: Array<IndexedComplianceDataType> = (get(this, 'complianceDataTypes') || []).map(
+      (type, index): IndexedComplianceDataType => ({
+        ...type,
+        index
+      })
+    );
+
+    /**
+     * Compares each compliance data type, ensure that positional order is maintained
+     * @param {IComplianceDataType} a the compliance type to compare
+     * @param {IComplianceDataType} b the other
+     * @returns {number} 0, 1, -1 indicating sort order
+     */
+    const dataTypeComparator = (a: IndexedComplianceDataType, b: IndexedComplianceDataType): number => {
+      const { idType: aIdType, index: aIndex } = a;
+      const { idType: bIdType, index: bIndex } = b;
+      // Convert boolean values to number type
+      const typeCompare = Number(aIdType) - Number(bIdType);
+
+      // True types first, hence negation
+      // If types are same, then sort on original position i.e stable sort
+      return typeCompare ? -typeCompare : aIndex - bIndex;
+    };
+
+    /**
+     * Inserts a divider in the list of compliance field identifier options
+     * @param {Array<IComplianceFieldIdentifierOption>} types
+     * @returns {Array<IComplianceFieldIdentifierOption>}
+     */
+    const insertDividers = (
+      types: Array<IComplianceFieldIdentifierOption>
+    ): Array<IComplianceFieldIdentifierOption> => {
+      const isId = ({ isId }: IComplianceFieldIdentifierOption): boolean => isId;
+      const ids = types.filter(isId);
+      const nonIds = types.filter((type): boolean => !isId(type));
+      //divider to indicate section for ids
+      const idsDivider = { value: '', label: 'First Party IDs', isDisabled: true };
+      // divider to indicate section for non ids
+      const nonIdsDivider = { value: '', label: 'Non First Party IDs', isDisabled: true };
+
+      return [
+        <IComplianceFieldIdentifierOption>idsDivider,
+        ...ids,
+        <IComplianceFieldIdentifierOption>nonIdsDivider,
+        ...nonIds
+      ];
+    };
+
+    return [
+      noneDropDownOption,
+      ...insertDividers(getFieldIdentifierOptions(indexedDataTypes.sort(dataTypeComparator)))
+    ];
+  });
+
+  /**
+   * Task to retrieve column fields async and set values on Component
+   * @type {Task<Promise<any>, () => TaskInstance<Promise<any>>>}
+   * @memberof ComplianceSchemaEntities
+   */
+  columnFieldsToCompliancePolicyTask = task(function*(this: ComplianceSchemaEntities): IterableIterator<any> {
+    // Truncated list of Dataset field names and data types currently returned from the column endpoint
+    const schemaFieldNamesMappedToDataTypes: ComplianceSchemaEntities['schemaFieldNamesMappedToDataTypes'] = yield waitForProperty(
+      this,
+      'schemaFieldNamesMappedToDataTypes',
+      ({ length }) => !!length
+    );
+
+    const { complianceEntities = [], modifiedTime }: Pick<IComplianceInfo, 'complianceEntities' | 'modifiedTime'> = get(
+      this,
+      'complianceInfo'
+    )!;
+
+    const renameFieldNameAttr = ({
+      fieldName,
+      dataType
+    }: Pick<IDatasetColumn, 'dataType' | 'fieldName'>): {
+      identifierField: IDatasetColumn['fieldName'];
+      dataType: IDatasetColumn['dataType'];
+    } => ({
+      identifierField: fieldName,
+      dataType
+    });
+    const columnProps: Array<IColumnFieldProps> = yield iterateArrayAsync(arrayMap(renameFieldNameAttr))(
+      schemaFieldNamesMappedToDataTypes
+    );
+
+    const columnIdFieldsToCurrentPrivacyPolicy: ISchemaFieldsToPolicy = yield asyncMapSchemaColumnPropsToCurrentPrivacyPolicy(
+      {
+        columnProps,
+        complianceEntities,
+        policyModificationTime: modifiedTime
+      }
+    );
+
+    set(this, 'columnIdFieldsToCurrentPrivacyPolicy', columnIdFieldsToCurrentPrivacyPolicy);
+  }).enqueue();
+
+  /**
+   * Invokes external action with flag indicating that at least 1 suggestion exists for a field in the changeSet
+   * @param {number} suggestionConfidenceThreshold confidence threshold for filtering out higher quality suggestions
+   * @param {Array<IComplianceChangeSet>} changeSet
+   */
+  notifyHandlerOfSuggestions = (
+    suggestionConfidenceThreshold: number,
+    changeSet: Array<IComplianceChangeSet>
+  ): void => {
+    const hasChangeSetSuggestions = !!compact(getTagsSuggestions({ suggestionConfidenceThreshold })(changeSet)).length;
+    this.notifyOnChangeSetSuggestions(hasChangeSetSuggestions);
+  };
+
+  /**
+   * Invokes external action with flag indicating that a field in the tags requires user review
+   * @param {number} suggestionConfidenceThreshold confidence threshold for filtering out higher quality suggestions
+   * @param {Array<IComplianceDataType>} complianceDataTypes
+   * @param {Array<IComplianceChangeSet>} tags
+   */
+  notifyHandlerOfFieldsRequiringReview = (
+    suggestionConfidenceThreshold: number,
+    complianceDataTypes: Array<IComplianceDataType>,
+    tags: Array<IComplianceChangeSet>
+  ): void => {
+    // adding assertions for run-loop callback invocation, because static type checks are bypassed
+    assert('expected complianceDataTypes to be of type `array`', Array.isArray(complianceDataTypes));
+    assert('expected tags to be of type `array`', Array.isArray(tags));
+
+    const hasChangeSetDrift = !!tagsRequiringReview(complianceDataTypes, {
+      checkSuggestions: true,
+      suggestionConfidenceThreshold
+    })(tags).length;
+
+    this.notifyOnChangeSetRequiresReview(hasChangeSetDrift);
+  };
+
+  /**
+   * Sets the default classification for the given identifier field's tag
+   * Using the identifierType, determine the tag's default security classification based on a values
+   * supplied by complianceDataTypes endpoint
+   * @param {string} identifierField the field for which the default classification should apply
+   * @param {ComplianceFieldIdValue} identifierType the value of the field's identifier type
+   */
+  setDefaultClassification(
+    this: ComplianceSchemaEntities,
+    { identifierField, identifierType }: Pick<IComplianceEntity, 'identifierField' | 'identifierType'>
+  ): void {
+    const complianceDataTypes = get(this, 'complianceDataTypes');
+    const defaultSecurityClassification = getDefaultSecurityClassification(complianceDataTypes, identifierType);
+
+    this.actions.tagClassificationChanged.call(this, { identifierField }, { value: defaultSecurityClassification });
+  }
+
+  /**
+   * Task to retrieve platform policies and set supported policies for the current platform
+   * @type {Task<Promise<any>, () => TaskInstance<Promise<any>>>}
+   * @memberof ComplianceSchemaEntities
+   */
+  foldChangeSetTask = task(function*(this: ComplianceSchemaEntities): IterableIterator<any> {
+    //@ts-ignore dot notation for property access
+    yield waitForProperty(this, 'columnFieldsToCompliancePolicyTask.isIdle');
+    const filteredChangeSet = get(this, 'filteredChangeSet');
+    const foldedChangeSet: Array<IdentifierFieldWithFieldChangeSetTuple> = yield foldComplianceChangeSets(
+      filteredChangeSet
+    );
+
+    set(this, 'foldedChangeSet', sortFoldedChangeSetTuples(foldedChangeSet));
+  }).enqueue();
+
+  /**
+   * Task to retrieve platform policies and set supported policies for the current platform
+   * @type {Task<Promise<Array<IDataPlatform>>, () => TaskInstance<Promise<Array<IDataPlatform>>>>}
+   * @memberof ComplianceSchemaEntities
+   */
+  getPlatformPoliciesTask = task(function*(
+    this: ComplianceSchemaEntities
+  ): IterableIterator<Promise<Array<IDataPlatform>>> {
+    const platform = get(this, 'platform');
+
+    if (platform) {
+      set(this, 'supportedPurgePolicies', getSupportedPurgePolicies(platform, yield readPlatforms()));
+    }
+  }).restartable();
+
+  /**
+   * Sets the identifierType attribute on IComplianceChangeSetFields without an identifierType to ComplianceFieldIdValue.None
+   * @returns {Promise<Array<IComplianceChangeSet>>}
+   */
+  setUnspecifiedTagsAsNoneTask = task(function*(
+    this: ComplianceSchemaEntities
+  ): IterableIterator<Promise<Array<ComplianceFieldIdValue | NonIdLogicalType>>> {
+    const unspecifiedTags = get(this, 'unspecifiedTags');
+    const setTagIdentifier = (value: ComplianceFieldIdValue | NonIdLogicalType) => (tag: IComplianceChangeSet) =>
+      set(tag, 'identifierType', value);
+
+    yield iterateArrayAsync(arrayMap(setTagIdentifier(ComplianceFieldIdValue.None)))(unspecifiedTags);
+  }).drop();
+
+  constructor() {
+    super(...arguments);
+    // Setting default values for passed in properties
+    typeof this.isEditing === 'boolean' || (this.isEditing = false);
+    typeof this.isNewComplianceInfo === 'boolean' || (this.isNewComplianceInfo = false);
+    this.searchTerm || set(this, 'searchTerm', '');
+    typeof this.suggestionConfidenceThreshold === 'number' ||
+      (this.suggestionConfidenceThreshold = lowQualitySuggestionConfidenceThreshold);
+    this.complianceDataTypes || (this.complianceDataTypes = []);
+    // this.schemaFieldNamesMappedToDataTypes || (this.schemaFieldNamesMappedToDataTypes = []);
+  }
+
+  didInsertElement(): void {
+    get(this, 'columnFieldsToCompliancePolicyTask').perform();
+    get(this, 'foldChangeSetTask').perform();
+  }
+
+  didUpdateAttrs(): void {
+    get(this, 'columnFieldsToCompliancePolicyTask').perform();
+    get(this, 'foldChangeSetTask').perform();
+  }
+
+  /**
+   * Updates the fieldReviewOption with the user selected value
+   * @param {{value: TagFilter}} { value }
+   * @returns {TagFilter}
+   */
+  @action
+  onFieldReviewChange(this: ComplianceSchemaEntities, { value }: { value: TagFilter }): TagFilter {
+    const option = set(this, 'fieldReviewOption', value);
+    get(this, 'foldChangeSetTask').perform();
+
+    return option;
+  }
+
+  /**
+   * Toggles the flag isShowingFullFieldNames when invoked
+   */
+  @action
+  onFieldDblClick(): void {
+    this.toggleProperty('isShowingFullFieldNames');
+  }
+
+  /**
+   * Adds a new field tag to the list of compliance change set items
+   * @param {IComplianceChangeSet} tag properties for new field tag
+   * @return {IComplianceChangeSet}
+   */
+  @action
+  onFieldTagAdded(this: ComplianceSchemaEntities, tag: IComplianceChangeSet): void {
+    get(this, 'compliancePolicyChangeSet').addObject(tag);
+    get(this, 'foldChangeSetTask').perform();
+  }
+
+  /**
+   * Removes a field tag from the list of compliance change set items
+   * @param {IComplianceChangeSet} tag
+   * @return {IComplianceChangeSet}
+   */
+  @action
+  onFieldTagRemoved(this: ComplianceSchemaEntities, tag: IComplianceChangeSet): void {
+    get(this, 'compliancePolicyChangeSet').removeObject(tag);
+    get(this, 'foldChangeSetTask').perform();
+  }
+
+  /**
+   * Disables the readonly attribute of a compliance policy changeSet tag,
+   * allowing the user to override properties on the tag
+   * @param {IComplianceChangeSet} tag the IComplianceChangeSet instance
+   */
+  @action
+  async onTagReadOnlyDisable(this: ComplianceSchemaEntities, tag: IComplianceChangeSet): Promise<void> {
+    const { dialogActions, dismissedOrConfirmed } = notificationDialogActionFactory();
+    const {
+      doNotShowReadonlyConfirmation,
+      notifications: { notify }
+    } = getProperties(this, ['doNotShowReadonlyConfirmation', 'notifications']);
+
+    if (doNotShowReadonlyConfirmation) {
+      overrideTagReadonly(tag);
+      return;
+    }
+
+    notify(NotificationEvent.confirm, {
+      header: 'Are you sure you would like to modify this field?',
+      content:
+        "This field's compliance information is currently readonly, please confirm if you would like to override this value",
+      dialogActions,
+      toggleText: 'Do not show this again for this dataset',
+      onDialogToggle: (doNotShow: boolean): boolean => set(this, 'doNotShowReadonlyConfirmation', doNotShow)
+    });
+
+    try {
+      await dismissedOrConfirmed;
+      overrideTagReadonly(tag);
+    } catch (e) {
+      return;
+    }
+  }
+
+  /**
+   * When a user updates the identifierFieldType, update working copy
+   * @param {IComplianceChangeSet} tag
+   * @param {ComplianceFieldIdValue} identifierType
+   */
+  @action
+  tagIdentifierChanged(
+    this: ComplianceSchemaEntities,
+    tag: IComplianceChangeSet,
+    { value: identifierType }: { value: ComplianceFieldIdValue }
+  ): void {
+    const { identifierField } = tag;
+    if (tag) {
+      setProperties(tag, {
+        identifierType,
+        logicalType: null,
+        nonOwner: null,
+        isDirty: true,
+        valuePattern: null
+      });
+    }
+
+    this.setDefaultClassification({ identifierField, identifierType });
+  }
+
+  /**
+   * Augments the tag props with a suggestionAuthority indicating that the tag
+   * suggestion has either been accepted or ignored, and assigns the value of that change to the prop
+   * @param {IComplianceChangeSet} tag tag for which this suggestion intent should apply
+   * @param {SuggestionIntent} [intent=SuggestionIntent.ignore] user's intended action for suggestion, Defaults to `ignore`
+   */
+  @action
+  onFieldSuggestionIntentChange(
+    this: ComplianceSchemaEntities,
+    tag: IComplianceChangeSet,
+    intent: SuggestionIntent = SuggestionIntent.ignore
+  ): void {
+    set(tag, 'suggestionAuthority', intent);
+  }
+
+  /**
+   * Applies wholesale user changes to a field tag's properties
+   * @param {IComplianceChangeSet} tag a reference to the current tag object
+   * @param {IComplianceChangeSet} tagUpdates updated properties to be applied to the current tag
+   */
+  @action
+  tagPropertiesUpdated(tag: IComplianceChangeSet, tagUpdates: IComplianceChangeSet) {
+    setProperties(tag, tagUpdates);
+  }
+
+  /**
+   * Toggle the visibility of the guided compliance edit view vs the advanced edit view modes
+   * @param {boolean} toggle flag ,if true, show guided edit mode, otherwise, advanced
+   */
+  @action
+  onShowGuidedEditMode(this: ComplianceSchemaEntities, toggle: boolean): void {
+    const isShowingGuidedEditMode = set(this, 'showGuidedComplianceEditMode', toggle);
+
+    if (!isShowingGuidedEditMode) {
+      this.actions.onManualComplianceUpdate.call(this, get(this, 'jsonComplianceEntities'));
+    }
+  }
+}

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -305,6 +305,9 @@ export default class DatasetComplianceContainer extends Component {
     if (complianceInfo) {
       const { complianceEntities } = complianceInfo;
 
+      console.log('saving compliance policy');
+      console.log(complianceInfo);
+
       await this.notifyOnSave<void>(
         saveDatasetComplianceByUrn(get(this, 'urn'), {
           ...complianceInfo,

--- a/wherehows-web/app/constants/dataset-compliance.ts
+++ b/wherehows-web/app/constants/dataset-compliance.ts
@@ -94,6 +94,17 @@ const complianceSteps = {
   }
 };
 
+// Should replace compliance steps
+/**
+ * Defines the edit states that the compliance policy component can ahve
+ */
+enum ComplianceEdit {
+  CompliancePolicy = 'editCompliancePolicy',
+  PurgePolicy = 'editPurgePolicy',
+  DatasetLevelPolicy = 'editDatasetLevelCompliancePolicy',
+  ExportPolicy = 'editExportPolicy'
+}
+
 /**
  * Takes a map of dataset options and constructs the relevant compliance edit wizard steps to build the wizard flow
  * @param {boolean} [hasSchema=true] flag indicating if the dataset has a schema or otherwise
@@ -129,8 +140,8 @@ const editableTags = (entities: Array<IComplianceEntity>): Array<IComplianceEnti
  * Strips out the readonly attribute from a list of compliance entities
  * @type {(entities: Array<IComplianceEntity>) => Array<IComplianceEntity>}
  */
-const removeReadonlyAttr = <(entities: Array<IComplianceEntity>) => Array<IComplianceEntity>>arrayMap(
-  (entity: IComplianceEntity) => omit(entity, ['readonly'])
+const removeReadonlyAttr = <(entities: Array<IComplianceEntity>) => Array<IComplianceEntity>>(
+  arrayMap((entity: IComplianceEntity) => omit(entity, ['readonly']))
 );
 
 /**
@@ -667,5 +678,6 @@ export {
   tagsWithoutIdentifierType,
   tagsForIdentifierField,
   singleTagsInChangeSet,
-  overrideTagReadonly
+  overrideTagReadonly,
+  ComplianceEdit
 };

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -21,35 +21,18 @@
           {{#if isEditing}}
 
             <div class="container action-bar__content">
-              {{#if (has-next editStep editSteps)}}
+              {{#if showAdvancedEditApplyStep}}
 
-                {{#if showAdvancedEditApplyStep}}
-
-                  {{#track-ui-event category=trackableCategory.Compliance action=trackableEvent.Compliance.ManualApply
-                                    name=editStep.name as |metrics|}}
-                    <button
-                      class="nacho-button nacho-button--large-inverse action-bar__item"
-                      title="Apply JSON"
-                      onclick={{action metrics.trackOnAction (action "onApplyComplianceJson")}}
-                      disabled={{isManualApplyDisabled}}>
-                      Apply
-                    </button>
-                  {{/track-ui-event}}
-
-                {{else}}
-
-                  {{#track-ui-event category=trackableCategory.Compliance action=trackableEvent.Compliance.Next
-                                    name=editStep.name as |metrics|}}
-                    <button
-                      class="nacho-button nacho-button--large-inverse action-bar__item"
-                      title="Next"
-                      onclick={{action metrics.trackOnAction (action "nextStep")}}
-                      disabled={{initialStepNeedsReview}}>
-                      Next
-                    </button>
-                  {{/track-ui-event}}
-
-                {{/if}}
+                {{#track-ui-event category=trackableCategory.Compliance action=trackableEvent.Compliance.ManualApply
+                                  name=editStep.name as |metrics|}}
+                  <button
+                    class="nacho-button nacho-button--large-inverse action-bar__item"
+                    title="Apply JSON"
+                    onclick={{action metrics.trackOnAction (action "onApplyComplianceJson")}}
+                    disabled={{isManualApplyDisabled}}>
+                    Apply
+                  </button>
+                {{/track-ui-event}}
 
               {{else}}
 
@@ -67,25 +50,11 @@
 
               {{/if}}
 
-              {{#if (has-previous editStep editSteps)}}
-                {{#track-ui-event category=trackableCategory.Compliance
-                                  action=trackableEvent.Compliance.Previous
-                                  name=editStep.name as |metrics|}}
-                  <button
-                    class="nacho-button nacho-button--large nacho-button--secondary action-bar__item"
-                    title="Back"
-                    onclick={{action metrics.trackOnAction (action "previousStep")}}>
-                    Back
-                  </button>
-                {{/track-ui-event}}
-
-              {{/if}}
-
               {{#track-ui-event category=trackableCategory.Compliance
                                 action=trackableEvent.Compliance.Cancel as |metrics|}}
                 <button
                   class="nacho-button nacho-button--large nacho-button--secondary action-bar__item"
-                  onclick={{action metrics.trackOnAction (action "onCancel")}}>
+                  onclick={{action metrics.trackOnAction (action "onToggleEditing" false)}}>
                   Cancel
                 </button>
               {{/track-ui-event}}
@@ -106,19 +75,6 @@
       {{/if}}
 
       <div class="secondary-actions">
-        {{#unless isEditing}}
-
-          {{#track-ui-event category=trackableCategory.Compliance
-                            action=trackableEvent.Compliance.Edit as |metrics|}}
-            <button
-              class="nacho-button nacho-button--large secondary-actions__action"
-              onclick={{action metrics.trackOnAction (action "nextStep")}}>
-              Edit
-            </button>
-          {{/track-ui-event}}
-
-        {{/unless}}
-
         <div class="policy-last-saved">
           Last saved:
           {{#if isNewComplianceInfo}}
@@ -136,17 +92,11 @@
         </div>
       </div>
 
-      {{#if isEditing}}
-        <div class="dataset-compliance-step-container">
-          {{partial "datasets/dataset-compliance/dataset-compliance-step-indicator"}}
-        </div>
-      {{/if}}
-
-      {{#if (or isReadOnly (eq editStep.name editSteps.2.name))}}
+      {{#if (or isReadOnly (eq editTarget ComplianceEdit.DatasetLevelPolicy))}}
         {{partial "datasets/dataset-compliance/dataset-classification"}}
       {{/if}}
 
-      {{#if (or isReadOnly (eq editStep.name editSteps.1.name))}}
+      {{#if (or isReadOnly (eq editTarget ComplianceEdit.PurgePolicy))}}
         {{#if getPlatformPoliciesTask.isRunning}}
           {{pendulum-ellipsis-animation}}
         {{/if}}
@@ -184,7 +134,7 @@
                 <div class="compliance-entities-meta__secondary">
                   <button
                     class="nacho-button nacho-button--tertiary"
-                    onclick={{action "nextStep"}}>
+                    onclick={{action "onToggleEditing" true ComplianceEdit.PurgePolicy}}>
 
                     <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
 
@@ -223,24 +173,34 @@
 
       {{else}}
 
-        {{#if (or isReadOnly isInitialEditStep)}}
-          {{datasets/compliance/schema-entities
+        {{#if (or isReadOnly (eq editTarget ComplianceEdit.CompliancePolicy))}}
+          {{partial "datasets/dataset-compliance/dataset-compliance-entities"}}
+          {{!-- This is part of a refactor that's not ready yet. Leaving commented --}}
+          {{!-- {{datasets/compliance/schema-entities
             datasetName=datasetName
             schemaless=schemaless
+            compliancePolicyChangeSet=compliancePolicyChangeSet
+            columnIdFieldsToCurrentPrivacyPolicy=columnIdFieldsToCurrentPrivacyPolicy
+            filteredChangeSet=filteredChangeSet
+            foldedChangeSet=foldedChangeSet
+            foldChangeSetTask=foldChangeSetTask
+            changeSetReview=changeSetReview
             complianceSuggestion=complianceSuggestion
             complianceInfo=complianceInfo
+            ComplianceEdit=ComplianceEdit
             isEditing=isEditing
             platform=platform
             searchTerm=searchTerm
             isNewComplianceInfo=isNewComplianceInfo
             complianceDataTypes=complianceDataTypes
-            nextStep=(action "nextStep")
+            nextStep=(action "onToggleEditing")
+            onManualComplianceUpdate=(action "onManualComplianceUpdate")
             schemaFieldNamesMappedToDataTypes=schemaFieldNamesMappedToDataTypes
             suggestionConfidenceThreshold=suggestionConfidenceThreshold
             notifyOnChangeSetSuggestions=notifyOnChangeSetSuggestions
             onComplianceJsonUpdate=onComplianceJsonUpdate
             notifyOnComplianceSuggestionFeedback=notifyOnComplianceSuggestionFeedback
-            notifyOnChangeSetRequiresReview=notifyOnChangeSetRequiresReview}}
+            notifyOnChangeSetRequiresReview=notifyOnChangeSetRequiresReview}} --}}
         {{/if}}
 
       {{/if}}

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -228,16 +228,17 @@
             datasetName=datasetName
             schemaless=schemaless
             complianceSuggestion=complianceSuggestion
+            complianceInfo=complianceInfo
             isEditing=isEditing
             platform=platform
             searchTerm=searchTerm
-            complianceInfo=complianceInfo
             isNewComplianceInfo=isNewComplianceInfo
             complianceDataTypes=complianceDataTypes
             nextStep=(action "nextStep")
             schemaFieldNamesMappedToDataTypes=schemaFieldNamesMappedToDataTypes
             suggestionConfidenceThreshold=suggestionConfidenceThreshold
             notifyOnChangeSetSuggestions=notifyOnChangeSetSuggestions
+            onComplianceJsonUpdate=onComplianceJsonUpdate
             notifyOnComplianceSuggestionFeedback=notifyOnComplianceSuggestionFeedback
             notifyOnChangeSetRequiresReview=notifyOnChangeSetRequiresReview}}
         {{/if}}

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -224,7 +224,22 @@
       {{else}}
 
         {{#if (or isReadOnly isInitialEditStep)}}
-          {{partial "datasets/dataset-compliance/dataset-compliance-entities"}}
+          {{datasets/compliance/schema-entities
+            datasetName=datasetName
+            schemaless=schemaless
+            complianceSuggestion=complianceSuggestion
+            isEditing=isEditing
+            platform=platform
+            searchTerm=searchTerm
+            complianceInfo=complianceInfo
+            isNewComplianceInfo=isNewComplianceInfo
+            complianceDataTypes=complianceDataTypes
+            nextStep=(action "nextStep")
+            schemaFieldNamesMappedToDataTypes=schemaFieldNamesMappedToDataTypes
+            suggestionConfidenceThreshold=suggestionConfidenceThreshold
+            notifyOnChangeSetSuggestions=notifyOnChangeSetSuggestions
+            notifyOnComplianceSuggestionFeedback=notifyOnComplianceSuggestionFeedback
+            notifyOnChangeSetRequiresReview=notifyOnChangeSetRequiresReview}}
         {{/if}}
 
       {{/if}}

--- a/wherehows-web/app/templates/components/datasets/compliance/schema-entities.hbs
+++ b/wherehows-web/app/templates/components/datasets/compliance/schema-entities.hbs
@@ -1,0 +1,516 @@
+<section class="metadata-prompt">
+  <header class="metadata-prompt__header">
+    <p>
+      {{if isEditing
+           "Does any field in the schema contain an IDs (e.g. Member ID, Enterprise Profile ID etc) or other PII information?"
+           "IDs and PII in the schema"}}
+
+      {{more-info
+        link="http://go/gdpr-pii"
+        tooltip="Click for more information on Schema field format and types"
+      }}
+
+    </p>
+  </header>
+</section>
+
+<section class="compliance-entities-meta">
+  <button
+    class="nacho-button nacho-button{{if showGuidedComplianceEditMode '--inverse' '--secondary'}}"
+    onclick={{action "onShowGuidedEditMode" true}}>
+    {{tooltip-on-element
+      text="Show Guided View"
+    }}
+
+    {{fa-icon "table" aria-label="Show Guided View"}}
+  </button>
+
+  <button
+    class="nacho-button nacho-button{{if showGuidedComplianceEditMode '--secondary' '--inverse'}}"
+    onclick={{action "onShowGuidedEditMode" false}}>
+    {{tooltip-on-element
+      text="Show Advanced View"
+    }}
+
+    {{fa-icon "code" aria-label="Show Advanced View"}}
+  </button>
+</section>
+
+<section class="compliance-entities-meta">
+  {{#if showGuidedComplianceEditMode}}
+    {{ember-selector
+      values=fieldReviewOptions
+      selected=(readonly fieldReviewOption)
+      selectionDidChange=(action "onFieldReviewChange")
+    }}
+
+    {{#if fieldReviewHint}}
+      <span class="dataset-compliance-fields__has-suggestions">
+        {{fieldReviewHint}}
+      </span>
+    {{/if}}
+  {{/if}}
+
+  {{#if isEditing}}
+
+    <div class="compliance-entities-meta__secondary">
+      {{#if (and unspecifiedTags showGuidedComplianceEditMode)}}
+        <p class="set-fields-to-none-text">Set all unspecified field types to {{ComplianceFieldIdValue.None}}</p>
+
+        {{#track-ui-event category=trackableCategory.Compliance
+                          action=trackableEvent.Compliance.SetUnspecifiedAsNone as |metrics|}}
+          <button
+            class="nacho-button nacho-button--large nacho-button--secondary action-bar__item"
+            onclick={{action metrics.trackOnAction (perform setUnspecifiedTagsAsNoneTask)}}>
+
+            {{#if setUnspecifiedTagsAsNoneTask.isRunning}}
+              {{pendulum-ellipsis-animation}}
+            {{else}}
+              Set {{pluralize unspecifiedTags.length "tag"}} to {{ComplianceFieldIdValue.None}}
+            {{/if}}
+
+          </button>
+        {{/track-ui-event}}
+      {{/if}}
+    </div>
+  {{/if}}
+
+  {{#if isReadOnly}}
+    <div class="compliance-entities-meta__secondary">
+      <button
+        class="nacho-button nacho-button--tertiary"
+        {{action nextStep}}>
+
+        <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
+
+        Edit
+      </button>
+    </div>
+  {{/if}}
+</section>
+
+{{#if showGuidedComplianceEditMode}}
+  {{#if foldedChangeSet.length}}
+    {{#dataset-table
+      class="dataset-compliance-fields"
+      fields=foldedChangeSet
+      filterBy=filterBy
+      tableRowComponent='dataset-compliance-rollup-row'
+      searchTerm=searchTerm as |table|
+    }}
+
+      {{#table.head as |head|}}
+        {{#head.column class="dataset-compliance-fields__notification-column"}}{{/head.column}}
+        {{#head.column class="dataset-compliance-fields__identifier-column"}}
+          Field
+
+          {{more-info
+            link="http://go/tms-schema"
+            tooltip="Click for more information on Schema"
+          }}
+        {{/head.column}}
+        {{#head.column class="nacho-table-cell-wrapped"}}Compliance Information{{/head.column}}
+        {{#head.column class="nacho-table-cell-wrapped"}}
+          System Suggestion & Confidence
+        {{/head.column}}
+      {{/table.head}}
+
+      <tr>
+        <th>{{!--spacer--}}</th>
+        <th colspan="3">
+          <div class="dataset-compliance-fields__actions">
+            {{disable-bubble-input
+              title="Search field names"
+              placeholder="Search field names"
+              value=table.searchTerm
+              class="dataset-compliance-fields__search"
+              on-input=(action table.filterDidChange value="target.value")
+            }}
+          </div>
+        </th>
+      </tr>
+
+      {{#table.body as |body|}}
+        {{#each table.data as |field|}}
+          {{#body.row
+            field=field
+            isNewComplianceInfo=isNewComplianceInfo
+            complianceDataTypes=complianceDataTypes
+            suggestionConfidenceThreshold=suggestionConfidenceThreshold
+            onFieldDblClick=(action "onFieldDblClick")
+            onFieldTagAdded=(action "onFieldTagAdded")
+            onFieldTagRemoved=(action "onFieldTagRemoved")
+            onTagReadOnlyDisable=(action "onTagReadOnlyDisable")
+            onTagIdentifierTypeChange=(action "tagIdentifierChanged")
+            onSuggestionIntent=(action "onFieldSuggestionIntentChange") as |row|
+          }}
+            {{! template-lint-disable no-invalid-interactive }}
+            <tr class="{{if row.isReadonly 'dataset-compliance-fields--readonly'}}" ondblclick={{action
+              row.onFragmentDblClick}}>
+              {{#row.cell}}
+                {{#if
+                  (and row.suggestion (and (not row.suggestionMatchesCurrentValue) (not row.suggestionResolution)))}}
+
+                  <span class="nacho-tooltip" data-title="Has suggestions">
+                    <i class="fa fa-exclamation dataset-compliance-fields__has-suggestions__icon"
+                       title="Compliance field has suggested values"></i>
+                  </span>
+
+                {{else}}
+
+                  {{#if row.isReviewRequested}}
+
+                    <span class="nacho-tooltip" data-title="Please review">
+                      <i class="fa fa-question dataset-compliance-fields--review-required__icon"
+                         title="Compliance policy information needs review"></i>
+                    </span>
+
+                  {{else}}
+
+                    <span class="nacho-tooltip" data-title="All good!">
+                      <i class="fa fa-check dataset-compliance-fields--ok__icon" title="All good!"></i>
+                    </span>
+
+
+                  {{/if}}
+
+                {{/if}}
+              {{/row.cell}}
+
+              {{#row.cell}}
+                <div class="dataset-compliance-fields__id-field-wrap">
+                  <div title="{{row.identifierField}}">
+                    <strong>
+                      {{if isShowingFullFieldNames row.identifierField (split-text row.identifierField 23)}}
+                    </strong>
+                  </div>
+
+                  <div title="{{row.dataType}}">
+                    {{if isShowingFullFieldNames row.dataType (split-text row.dataType 23)}}
+                  </div>
+                </div>
+              {{/row.cell}}
+
+              {{#row.cell}}
+                {{#if (and isEditing (not row.isReadonly))}}
+                  {{#each row.fieldChangeSet as |tag|}}
+
+                    <div class="dataset-compliance-fields__tag-item">
+                      {{#basic-dropdown as |tagDrop|}}
+                        {{#tagDrop.trigger
+                          class="dataset-compliance-fields__tag-info dataset-compliance-fields__tag-info--editable"}}
+
+                          <p class="dataset-compliance-fields__tag-info__text">
+                            {{#if tag.identifierType}}
+                              {{tag.identifierType}}{{if tag.logicalType (concat " (" tag.logicalType ")")}}
+                            {{else}}
+                              <span
+                                class="dataset-compliance-fields__tag-info__text dataset-compliance-fields__tag-info__text--obscure">
+                                Select Field Type ...
+                              </span>
+                            {{/if}}
+                          </p>
+
+                        {{/tagDrop.trigger}}
+
+                        {{#tagDrop.content overlay=true class="dataset-compliance-fields__guided-modal"}}
+                          {{#dataset-compliance-field-tag
+                            sourceTag=tag
+                            parentHasSingleTag=row.hasSingleTag
+                            tagDidChange=(action "tagPropertiesUpdated")
+                            suggestionConfidenceThreshold=suggestionConfidenceThreshold
+                            complianceFieldIdDropdownOptions=complianceFieldIdDropdownOptions
+                            complianceDataTypes=complianceDataTypes as |tagRowComponent|
+                          }}
+                            <article class="dataset-compliance-fields__field-tag__content">
+                              <section class="dataset-compliance-fields__compliance-info-column">
+                                <header class="dataset-compliance-fields__compliance-info-column__title">
+                                  <strong>Select field type</strong>
+                                </header>
+
+                                <div class="dataset-compliance-fields__compliance-info-column__content">
+                                  {{#track-ui-event category=trackableCategory.Compliance
+                                                    action=trackableEvent.Compliance.FieldIndentifier
+                                                    name=tagRowComponent.tag.identifierType as |metrics|}}
+
+                                    {{#each tagRowComponent.tagIdOptions as |tagOption|}}
+                                      {{#radio-button-composer
+                                        value=tagOption.value
+                                        name="datasetFieldClassification"
+                                        groupValue=(readonly tagRowComponent.tag.identifierType)
+                                        class="dataset-compliance-fields__tag-radio"
+                                        disabled=tagOption.isDisabled
+                                        disabledClass="dataset-compliance-fields__tag-radio--disabled"
+                                        checkedClass="dataset-compliance-fields__tag-radio--checked"
+                                        onMouseEnter=(action tagRowComponent.onFieldTagIdentifierEnter)
+                                        onMouseLeave=(action tagRowComponent.onFieldTagIdentifierLeave)
+                                        changed=(action metrics.trackOnAction (action tagRowComponent.tagIdentifierTypeDidChange))}}
+                                        {{tagOption.label}}
+                                      {{/radio-button-composer}}
+                                    {{/each}}
+
+                                  {{/track-ui-event}}
+                                </div>
+                              </section>
+
+                              {{#if tagRowComponent.fieldIdQuickDesc}}
+
+                                <section class="dataset-compliance-fields__compliance-info-column">
+                                  <div class="dataset-compliance-fields__field-tag__quick-desc">
+                                    <strong>
+                                      {{tagRowComponent.fieldIdQuickDesc.title}}:
+                                    </strong>
+
+                                    <p>
+                                      {{tagRowComponent.fieldIdQuickDesc.description}}
+                                    </p>
+                                  </div>
+                                </section>
+
+                              {{else}}
+
+                                {{#if tagRowComponent.isIdType}}
+                                  <section class="dataset-compliance-fields__compliance-info-column">
+                                    <header class="dataset-compliance-fields__compliance-info-column__title">
+                                      <strong>Select field format</strong>
+                                    </header>
+
+                                    <div class="dataset-compliance-fields__compliance-info-column__content">
+                                      {{#track-ui-event category=trackableCategory.Compliance
+                                                        action=trackableEvent.Compliance.FieldFormat
+                                                        name=tagRowComponent.tag.logicalType as |metrics|}}
+
+                                        {{#each tagRowComponent.fieldFormats as |fieldFormat|}}
+                                          {{#radio-button-composer
+                                            value=fieldFormat.value
+                                            name="datasetFieldFieldFormat"
+                                            groupValue=(readonly tagRowComponent.tag.logicalType)
+                                            class="dataset-compliance-fields__tag-radio"
+                                            checkedClass="dataset-compliance-fields__tag-radio--checked"
+                                            onMouseEnter=(action tagRowComponent.onFieldFormatEnter)
+                                            onMouseLeave=(action tagRowComponent.onFieldFormatLeave)
+                                            changed=(action metrics.trackOnAction (action tagRowComponent.tagLogicalTypeDidChange))}}
+                                            {{fieldFormat.label}}
+                                          {{/radio-button-composer}}
+                                        {{/each}}
+
+                                      {{/track-ui-event}}
+                                    </div>
+                                  </section>
+                                  {{#if tagRowComponent.fieldFormatQuickDesc}}
+
+                                    <section class="dataset-compliance-fields__compliance-info-column">
+                                      <div class="dataset-compliance-fields__field-tag__quick-desc">
+                                        <strong>
+                                          {{tagRowComponent.fieldFormatQuickDesc.title}}:
+                                        </strong>
+
+                                        <p>
+                                          {{tagRowComponent.fieldFormatQuickDesc.description}}
+                                        </p>
+                                      </div>
+                                    </section>
+
+                                  {{else}}
+
+                                    {{#if tagRowComponent.showCustomInput}}
+                                      <section class="dataset-compliance-fields__compliance-info-column">
+                                        <header class="dataset-compliance-fields__compliance-info-column__title">
+                                          <strong>Custom RegEx</strong>
+                                        </header>
+
+                                        <div
+                                          class="dataset-compliance-fields__compliance-info-column__content">
+
+                                          <div class="dataset-compliance-fields__text-pattern-wrap">
+                                            <div class="dataset-compliance-fields__text-pattern-wrap--input">
+                                              <input
+                                                placeholder="Enter a RegExp"
+                                                value="{{readonly tagRowComponent.tag.valuePattern}}"
+                                                disabled={{or (not isEditing) row.isReadonly}}
+                                                  class="dataset-compliance-fields__text-pattern {{if
+                                              tagRowComponent.valuePatternError
+                                              'dataset-compliance-fields--missing-selection'}}"
+                                              oninput={{action tagRowComponent.tagValuePatternDidChange
+                                                               value="target.value"}}
+                                              >
+                                            </div>
+
+                                            {{more-info
+                                              link="http://go/metadata-custom-regex"
+                                              tooltip="Click for more information on RegExp format"
+                                            }}
+
+                                            {{#if tagRowComponent.valuePatternError}}
+                                              <div class="dataset-compliance-fields__text-pattern-wrap--error">
+                                                {{tagRowComponent.valuePatternError}}
+                                              </div>
+                                            {{/if}}
+                                          </div>
+                                        </div>
+                                      </section>
+                                    {{/if}}
+
+                                    {{#unless tagRowComponent.isTagFormatMissing}}
+                                      <section class="dataset-compliance-fields__compliance-info-column">
+                                        <header class="dataset-compliance-fields__compliance-info-column__title">
+                                          <strong>Is purge key?</strong>
+                                        </header>
+
+                                        <div class="dataset-compliance-fields__compliance-info-column__content">
+
+                                          {{#radio-button-composer
+                                            value=false
+                                            name="datasetFieldOwnerToggle"
+                                            groupValue=(readonly tagRowComponent.tag.nonOwner)
+                                            class="dataset-compliance-fields__tag-radio"
+                                            checkedClass="dataset-compliance-fields__tag-radio--checked"
+                                            changed=(action tagRowComponent.tagOwnerDidChange)}}
+                                            Yes
+                                          {{/radio-button-composer}}
+
+                                          {{#radio-button-composer
+                                            value=true
+                                            name="datasetFieldOwnerToggle"
+                                            groupValue=(readonly tagRowComponent.tag.nonOwner)
+                                            class="dataset-compliance-fields__tag-radio"
+                                            checkedClass="dataset-compliance-fields__tag-radio--checked"
+                                            changed=(action tagRowComponent.tagOwnerDidChange)}}
+                                            No
+                                          {{/radio-button-composer}}
+                                        </div>
+                                      </section>
+                                    {{/unless}}
+
+                                  {{/if}}
+                                {{/if}}
+                              {{/if}}
+                            </article>
+
+                            <footer class="dataset-compliance-fields__field-tag__footer">
+                              {{#if tagRowComponent.localTagHasDiverged}}
+                                <button
+                                  class="nacho-button nacho-button--large-inverse"
+                                  onclick={{action tagRowComponent.onFieldTagUpdate tagDrop.actions.close}}
+                                    disabled={{tagRowComponent.isTagReviewRequired}}>
+                                  Done
+                                </button>
+                              {{/if}}
+                            </footer>
+                          {{/dataset-compliance-field-tag}}
+                        {{/tagDrop.content}}
+                      {{/basic-dropdown}}
+
+                      {{#if (and isEditing (not row.hasSingleTag))}}
+                        <span class="nacho-tooltip" data-title="Delete Tag">
+                          <button class="nacho-button nacho-button--tertiary dataset-compliance-fields__remove-tag"
+                                  onclick={{action row.onRemoveFieldTag tag}}>
+                            {{fa-icon "trash"}}
+                          </button>
+                        </span>
+                      {{/if}}
+                    </div>
+                  {{/each}}
+
+                  {{#unless row.hasNoneTag}}
+                    <button
+                      class="nacho-button nacho-button--tertiary dataset-compliance-fields__add-field"
+                      onclick={{action row.onAddFieldTag}}>
+                      + Add More
+                    </button>
+                  {{/unless}}
+
+                {{else}}
+                  {{#each row.fieldChangeSet as |tag|}}
+
+                    <div class="dataset-compliance-fields__tag-info">
+                      {{tag.identifierType}}{{if tag.logicalType (concat " (" tag.logicalType ")")}}
+
+                      {{#if row.isReadonly}}
+                        <span class="nacho-tooltip" data-title="Readonly">
+                          <button class="nacho-button nacho-button--tertiary dataset-compliance-fields--readonly__icon"
+                                  disabled={{not isEditing}}
+                                  onclick={{action row.onEditReadonlyTag tag}}>
+                            {{fa-icon "lock"}}
+                          </button>
+                        </span>
+                      {{/if}}
+                    </div>
+
+                  {{/each}}
+                {{/if}}
+              {{/row.cell}}
+
+              {{#row.cell}}
+                <div class="dataset-compliance-fields__suggested-values">
+                  {{#if row.suggestion}}
+                    <span
+                      class="dataset-compliance-fields__suggested-value {{unless row.suggestionResolution
+                                                                                 'dataset-compliance-fields__suggested-value--no-res'}}"
+                      title="{{row.suggestion.identifierType}} ({{row.suggestion.confidence}}%)">
+                      {{row.suggestion.identifierType}} ({{row.suggestion.confidence}}%)
+                    </span>
+
+                    {{#if isEditing}}
+                      <div class="dataset-compliance-fields__suggestion-actions">
+                        {{#if row.suggestionResolution}}
+                          <div
+                            class="dataset-compliance-fields__resolution {{if (eq row.suggestionResolution 'Accepted')
+                                                                              'dataset-compliance-fields__resolution--ok'}}">
+                            {{row.suggestionResolution}}
+                          </div>
+                        {{else}}
+                          {{auto-suggest-action
+                            type="accept"
+                            field=row.fieldProps
+                            feedbackAction=(action notifyOnComplianceSuggestionFeedback)
+                            onSuggestionClick=(action row.onSuggestionClick)
+                          }}
+
+                          {{auto-suggest-action
+                            field=row.fieldProps
+                            feedbackAction=(action notifyOnComplianceSuggestionFeedback)
+                            onSuggestionClick=(action row.onSuggestionClick)
+                          }}
+                        {{/if}}
+                      </div>
+                    {{/if}}
+                  {{else}}
+                    &mdash;
+                  {{/if}}
+                </div>
+              {{/row.cell}}
+            </tr>
+
+          {{/body.row}}
+        {{/each}}
+      {{/table.body}}
+
+    {{/dataset-table}}
+
+  {{else}}
+
+    {{empty-state
+      heading="No fields found"
+      subHead="If you have a filter applied, setting this to the least restrictive option may yield more results."
+    }}
+
+  {{/if}}
+{{else}}
+
+  {{ember-ace
+    readOnly=isReadOnly
+    update=(action "onManualComplianceUpdate")
+    class="dataset-compliance-editor"
+    value=jsonComplianceEntities
+    enableAutocompletion=true
+    enableLiveAutocompletion=true
+    minLines=10
+    maxLines=50
+    showLineNumbers=true
+    useWrapMode=true
+    mode="ace/mode/json"
+    worker="ace/mode/json_worker"
+    theme="ace/theme/github"}}
+
+{{/if}}

--- a/wherehows-web/app/templates/components/datasets/compliance/schema-entities.hbs
+++ b/wherehows-web/app/templates/components/datasets/compliance/schema-entities.hbs
@@ -79,7 +79,7 @@
     <div class="compliance-entities-meta__secondary">
       <button
         class="nacho-button nacho-button--tertiary"
-        {{action nextStep}}>
+        {{action nextStep true ComplianceEdit.CompliancePolicy}}>
 
         <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
 
@@ -500,7 +500,7 @@
 
   {{ember-ace
     readOnly=isReadOnly
-    update=(action "onManualComplianceUpdate")
+    update=onManualComplianceUpdate
     class="dataset-compliance-editor"
     value=jsonComplianceEntities
     enableAutocompletion=true

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-classification.hbs
@@ -16,7 +16,7 @@
       <div class="compliance-entities-meta__secondary">
         <button
           class="nacho-button nacho-button--tertiary"
-          onclick={{action "nextStep"}}>
+          onclick={{action "onToggleEditing" true ComplianceEdit.DatasetLevelPolicy}}>
 
           <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
 

--- a/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
+++ b/wherehows-web/app/templates/datasets/dataset-compliance/-dataset-compliance-entities.hbs
@@ -79,7 +79,7 @@
     <div class="compliance-entities-meta__secondary">
       <button
         class="nacho-button nacho-button--tertiary"
-        onclick={{action "nextStep"}}>
+        onclick={{action "onToggleEditing" true ComplianceEdit.CompliancePolicy}}>
 
         <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
 

--- a/wherehows-web/tests/integration/components/datasets/compliance/schema-entities-test.js
+++ b/wherehows-web/tests/integration/components/datasets/compliance/schema-entities-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import notificationsStub from 'wherehows-web/tests/stubs/services/notifications';
+import { noop } from 'wherehows-web/utils/helpers/functions';
+
+module('Integration | Component | datasets/compliance/schema-entities', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('service:notifications', notificationsStub);
+    this.notifications = this.owner.lookup('service:notifications');
+    this.setProperties({
+      noop: noop
+    });
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{datasets/compliance/schema-entities
+                       nextStep=noop
+                       notifyOnChangeSetSuggestions=noop
+                       notifyOnComplianceSuggestionFeedback=noop
+                       notifyOnChangeSetRequiresReview=noop}}`);
+
+    assert.ok(this.element, 'Renders without errors');
+    assert.ok(document.querySelector('empty-state'));
+  });
+});


### PR DESCRIPTION
### v1:
- The dataset compliance tab code has become too complex with continual iterations. Moving code for dataset compliance entities, which makes up a large amount of this complexity, into its own separate component
- Many of the properties and computed properties on the dataset-compliance component can be removed in a future PR. For now, the coupling to the edit wizard logic is too tight.
- Edit wizard is pending removal, will remove the above properties at the same time with that.

Manually tested to ensure application still builds and behaves as expected.

`ember test` results:
```
1..513
# tests 513
# pass  507
# skip  6
# fail  0

# ok
```