### PR TITLE
Change global hotkeys to use native event listener

### DIFF
--- a/wherehows-web/app/components/hotkeys/global-hotkeys.ts
+++ b/wherehows-web/app/components/hotkeys/global-hotkeys.ts
@@ -56,11 +56,27 @@ export default class GlobalHotkeys extends Component {
    * Method for handling the global keyup.
    * @param {KeyboardEvent} e - KeyboardEvent triggered by user input
    */
-  keyUp(e: KeyboardEvent) {
+  onKeyUp(e: KeyboardEvent) {
     const target = <HTMLElement>e.target;
 
     if (this.isEligibleTarget(target)) {
       get(this, 'hotKeys').applyKeyMapping(e.keyCode);
+    }
+  }
+
+  didInsertElement() {
+    const body = document.getElementsByClassName('ember-application')[0];
+
+    if (body) {
+      body.addEventListener('keyup', this.onKeyUp.bind(this));
+    }
+  }
+
+  willDestroyElement() {
+    const body = document.getElementsByClassName('ember-application')[0];
+
+    if (body) {
+      body.removeEventListener('keyup', this.onKeyUp.bind(this));
     }
   }
 }

--- a/wherehows-web/app/components/hotkeys/global-hotkeys.ts
+++ b/wherehows-web/app/components/hotkeys/global-hotkeys.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import { service } from '@ember-decorators/service';
 import ComputedProperty from '@ember/object/computed';
 import HotKeys from 'wherehows-web/services/hot-keys';
@@ -40,6 +40,11 @@ export default class GlobalHotkeys extends Component {
   hotKeys: ComputedProperty<HotKeys>;
 
   /**
+   * The event listener function created for the body
+   */
+  bodyEventListener: (e: KeyboardEvent) => void;
+
+  /**
    * Returns true if target exists, is not an input, and is not an editable div
    * @param {HTMLElement} target - target element
    * @returns {boolean}
@@ -68,7 +73,7 @@ export default class GlobalHotkeys extends Component {
     const body = document.querySelector('.ember-application');
 
     if (body) {
-      body.addEventListener('keyup', this.onKeyUp.bind(this));
+      body.addEventListener('keyup', set(this, 'bodyEventListener', this.onKeyUp.bind(this)));
     }
   }
 
@@ -76,7 +81,7 @@ export default class GlobalHotkeys extends Component {
     const body = document.querySelector('.ember-application');
 
     if (body) {
-      body.removeEventListener('keyup', this.onKeyUp.bind(this));
+      body.removeEventListener('keyup', this.bodyEventListener);
     }
   }
 }

--- a/wherehows-web/app/components/hotkeys/global-hotkeys.ts
+++ b/wherehows-web/app/components/hotkeys/global-hotkeys.ts
@@ -65,7 +65,7 @@ export default class GlobalHotkeys extends Component {
   }
 
   didInsertElement() {
-    const body = document.getElementsByClassName('ember-application')[0];
+    const body = document.querySelector('.ember-application');
 
     if (body) {
       body.addEventListener('keyup', this.onKeyUp.bind(this));
@@ -73,7 +73,7 @@ export default class GlobalHotkeys extends Component {
   }
 
   willDestroyElement() {
-    const body = document.getElementsByClassName('ember-application')[0];
+    const body = document.querySelector('.ember-application');
 
     if (body) {
       body.removeEventListener('keyup', this.onKeyUp.bind(this));

--- a/wherehows-web/app/components/hotkeys/global-hotkeys.ts
+++ b/wherehows-web/app/components/hotkeys/global-hotkeys.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get, set } from '@ember/object';
+import { get } from '@ember/object';
 import { service } from '@ember-decorators/service';
 import ComputedProperty from '@ember/object/computed';
 import HotKeys from 'wherehows-web/services/hot-keys';
@@ -40,11 +40,6 @@ export default class GlobalHotkeys extends Component {
   hotKeys: ComputedProperty<HotKeys>;
 
   /**
-   * The event listener function created for the body
-   */
-  bodyEventListener: (e: KeyboardEvent) => void;
-
-  /**
    * Returns true if target exists, is not an input, and is not an editable div
    * @param {HTMLElement} target - target element
    * @returns {boolean}
@@ -61,19 +56,21 @@ export default class GlobalHotkeys extends Component {
    * Method for handling the global keyup.
    * @param {KeyboardEvent} e - KeyboardEvent triggered by user input
    */
-  onKeyUp(e: KeyboardEvent) {
+  // Note: Important to define this as an arrow function in order to maintain this context when
+  // attaching to event listener below
+  onKeyUp = (e: KeyboardEvent) => {
     const target = <HTMLElement>e.target;
 
     if (this.isEligibleTarget(target)) {
       get(this, 'hotKeys').applyKeyMapping(e.keyCode);
     }
-  }
+  };
 
   didInsertElement() {
     const body = document.querySelector('.ember-application');
 
     if (body) {
-      body.addEventListener('keyup', set(this, 'bodyEventListener', this.onKeyUp.bind(this)));
+      body.addEventListener('keyup', this.onKeyUp);
     }
   }
 
@@ -81,7 +78,7 @@ export default class GlobalHotkeys extends Component {
     const body = document.querySelector('.ember-application');
 
     if (body) {
-      body.removeEventListener('keyup', this.bodyEventListener);
+      body.removeEventListener('keyup', this.onKeyUp);
     }
   }
 }


### PR DESCRIPTION
Original implementation of global hotkeys used a wrapper ember component to handle all keystrokes that bubbled up to it. However, it seems like this approach isn't perfect as when a user is browsing and enters a new page, the only element that has focus for keystrokes is the `<body>`. Because of this, changing implementation to add an event listener to the body in order to capture all keystrokes. 

`ember test` results:
```
1..520
# tests 520
# pass  513
# skip  7
# fail  0

# ok
```