### PR TITLE
Update the export policy immediately based on response to POST request

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -242,7 +242,7 @@ export default class DatasetCompliance extends Component {
   /**
    * Passthrough from parent to export policy component to save the export policy
    */
-  onSaveExportPolicy: (exportPolicy: IDatasetExportPolicy) => Promise<void>;
+  onSaveExportPolicy: (exportPolicy: IDatasetExportPolicy) => Promise<IDatasetExportPolicy>;
 
   /**
    * External action to handle manual compliance entity metadata entry
@@ -1518,12 +1518,17 @@ export default class DatasetCompliance extends Component {
     async saveExportPolicy(this: DatasetCompliance, exportPolicy: IDatasetExportPolicy): Promise<void> {
       const onSaveExportPolicy = get(this, 'onSaveExportPolicy');
 
+      let response: IDatasetExportPolicy | undefined;
+
       try {
         set(this, 'isSaving', true);
-        await onSaveExportPolicy(exportPolicy);
+        response = await onSaveExportPolicy(exportPolicy);
         return;
       } finally {
         set(this, 'isSaving', false);
+        if (response) {
+          set(this, 'exportPolicy', response);
+        }
         this.toggleEditing(false, get(this, 'editTarget'));
       }
     },

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -345,10 +345,11 @@ export default class DatasetComplianceContainer extends Component {
    * @return {Promise<void}
    */
   @action
-  async saveExportPolicy(this: DatasetComplianceContainer, exportPolicy: IDatasetExportPolicy): Promise<void> {
-    await this.notifyOnSave<void>(saveDatasetExportPolicyByUrn(get(this, 'urn'), exportPolicy));
-
-    this.getExportPolicyTask.perform();
+  async saveExportPolicy(
+    this: DatasetComplianceContainer,
+    exportPolicy: IDatasetExportPolicy
+  ): Promise<IDatasetExportPolicy> {
+    return await this.notifyOnSave<IDatasetExportPolicy>(saveDatasetExportPolicyByUrn(get(this, 'urn'), exportPolicy));
   }
 
   /**

--- a/wherehows-web/app/utils/api/datasets/compliance.ts
+++ b/wherehows-web/app/utils/api/datasets/compliance.ts
@@ -160,11 +160,16 @@ const readDatasetExportPolicyByUrn = async (urn: string): Promise<IDatasetExport
   return exportPolicy;
 };
 
-const saveDatasetExportPolicyByUrn = async (urn: string, exportPolicy: IDatasetExportPolicy): Promise<void> => {
-  await postJSON<void>({
+const saveDatasetExportPolicyByUrn = async (
+  urn: string,
+  exportPolicy: IDatasetExportPolicy
+): Promise<IDatasetExportPolicy> => {
+  const response = await postJSON<IDatasetExportPolicyResponse>({
     url: datasetExportPolicyByUrn(urn),
     data: exportPolicy
   });
+
+  return response.exportPolicy;
 };
 
 /**


### PR DESCRIPTION
This fixes an issue where the export policy UI was not updating after a POST request.

`ember test` results:
```
1..508
# tests 508
# pass  501
# skip  7
# fail  0

# ok
```