### PR TITLE
Fixes issues where schemaless tagging component was permanently uneditable

### DIFF
--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -98,6 +98,7 @@
         {{datasets/compliance/export-policy
           exportPolicyData=exportPolicy
           isEditing=isEditing
+          wikiLinks=@wikiLinks
           toggleEditing=(action toggleEditing)
           onSaveExportPolicy=(action "saveExportPolicy")}}
       {{/if}}
@@ -166,14 +167,17 @@
 
       {{#if schemaless}}
 
-        {{#if (or isReadOnly (eq editTarget ComplianceEdit.CompliancePolicy))}}
+        {{#if (or isReadOnly (eq editTarget ComplianceEdit.DatasetLevelPolicy))}}
           {{datasets/schemaless-tagging
             classificationHelpLink=@wikiLinks.dht
-            isEditable=(not isReadOnly)
+            isEditing=isEditing
             classification=(readonly complianceInfo.confidentiality)
             containsPersonalData=(readonly complianceInfo.containingPersonalData)
+            toggleEditing=(action toggleEditing)
             onClassificationChange=(action "onDatasetSecurityClassificationChange")
             onPersonalDataChange=(action "onDatasetLevelPolicyChange")
+            onSaveCompliance=(action "saveCompliance")
+            resetCompliance=(action "resetCompliance")
           }}
         {{/if}}
 

--- a/wherehows-web/app/templates/components/datasets/schemaless-tagging.hbs
+++ b/wherehows-web/app/templates/components/datasets/schemaless-tagging.hbs
@@ -2,9 +2,23 @@
   <header class="metadata-prompt__header">
     <p>
       Dataset <span title="Personally Identifiable Information" class="define-text">PII</span> & Security Classification
+
     </p>
+
+    {{#unless isEditing}}
+      <div class="compliance-entities-meta__secondary">
+        <button class="nacho-button nacho-button--tertiary" {{action toggleEditing true ComplianceEdit.DatasetLevelPolicy}}>
+          <i class="fa fa-pencil" aria-label="Edit Schemaless Classification"></i>
+          Edit
+        </button>
+      </div>
+    {{/unless}}
   </header>
 </section>
+
+{{#if isEditing}}
+  {{partial "datasets/dataset-compliance/action-bar"}}
+{{/if}}
 
 <div class="schemaless-tagging__tag">
   <h4 class="schemaless-tagging__prompt">
@@ -16,7 +30,7 @@
       id=(concat elementId '-schemaless-checkbox')
       type="checkbox"
       class="toggle-switch toggle-switch--light"
-      disabled=(not isEditable)
+      disabled=(not isEditing)
       checked=(readonly containsPersonalData)
       change=(action "onPersonalDataToggle" value="target.checked")
     }}
@@ -39,7 +53,7 @@
     {{ember-selector
       values=classifiers
       selected=classification
-      disabled=(not isEditable)
+      disabled=(not isEditing)
       selectionDidChange=(action "onSecurityClassificationChange")
     }}
   </div>


### PR DESCRIPTION
### v1
- Previously, editing was done with a wizard, but we moved to allowing each component in dataset compliance tab to be individually editable. However, this change did not incorporate the scenario in which a dataset was schemaless.
- We now give this component the same UX as the purge policy or export policy edits
- Also taking the chance to isolate most functionality in the component rather than depending on the parent dataset-compliance complex component.

`ember test` results
```
1..507
# tests 507
# pass  500
# skip  7
# fail  0

# ok
```

![screen shot 2018-09-10 at 2 52 51 pm](https://user-images.githubusercontent.com/16459843/45326644-4adb0180-b509-11e8-8b04-629d80cbcddf.png)
![screen shot 2018-09-10 at 2 53 18 pm](https://user-images.githubusercontent.com/16459843/45326654-4f9fb580-b509-11e8-8730-92877f89bff7.png)
