### PR TITLE
Compliance tab fix and cleanup

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -1496,9 +1496,6 @@ export default class DatasetCompliance extends Component {
       const setSaveFlag = (flag = false): boolean => set(this, 'isSaving', flag);
       const editTarget = get(this, 'editTarget');
 
-      console.log('saving compliance');
-      console.log(get(this, 'changeSetNeedsReview'));
-
       try {
         const isSaving = true;
         const onSave = get(this, 'onSave');

--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -1496,6 +1496,9 @@ export default class DatasetCompliance extends Component {
       const setSaveFlag = (flag = false): boolean => set(this, 'isSaving', flag);
       const editTarget = get(this, 'editTarget');
 
+      console.log('saving compliance');
+      console.log(get(this, 'changeSetNeedsReview'));
+
       try {
         const isSaving = true;
         const onSave = get(this, 'onSave');

--- a/wherehows-web/app/components/datasets/compliance/export-policy.ts
+++ b/wherehows-web/app/components/datasets/compliance/export-policy.ts
@@ -78,6 +78,11 @@ export default class ComplianceExportPolicy extends Component.extend({
    */
   exportPolicyData: IDatasetExportPolicy | undefined;
 
+  @computed('exportPolicyData', 'isEditing')
+  get showExportPolicyUndefined(): boolean {
+    return !get(this, 'isEditing') && !get(this, 'exportPolicyData');
+  }
+
   /**
    * Calculates the table for the export policy questions with seeded information based on the api response
    * for the dataset's export policy

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -49,7 +49,7 @@ type BatchComplianceResponse = [
   Array<IComplianceDataType>,
   IComplianceSuggestion,
   IDatasetSchema,
-  IDatasetExportPolicy
+  IDatasetExportPolicy | null
 ];
 
 /**
@@ -125,7 +125,7 @@ export default class DatasetComplianceContainer extends Component {
    * Object containing the fields for the export policy for this dataset
    * @type {IDatasetExportPolicy}
    */
-  exportPolicy: IDatasetExportPolicy | undefined;
+  exportPolicy: IDatasetExportPolicy | null;
 
   /**
    * The platform / db that the dataset is persisted
@@ -249,7 +249,7 @@ export default class DatasetComplianceContainer extends Component {
    */
   getExportPolicyTask = task(function*(
     this: DatasetComplianceContainer
-  ): IterableIterator<Promise<IDatasetExportPolicy>> {
+  ): IterableIterator<Promise<IDatasetExportPolicy | null>> {
     const exportPolicy: IDatasetExportPolicy = yield readDatasetExportPolicyByUrn(get(this, 'urn'));
 
     set(this, 'exportPolicy', exportPolicy);

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -44,7 +44,7 @@
                     title="{{unless isDatasetFullyClassified
                                     'Ensure you have provided a yes/no value for all dataset tags'
                                     'Save'}}"
-                    onclick={{action metrics.trackOnAction (action "saveCompliance")}} disabled={{and (eq edit ComplianceEdit.CompliancePolicy) changeSetNeedsReview}}>
+                    onclick={{action metrics.trackOnAction (action "saveCompliance")}} disabled={{and (eq editTarget ComplianceEdit.CompliancePolicy) changeSetNeedsReview}}>
                     Save
                   </button>
                 {{/track-ui-event}}

--- a/wherehows-web/app/templates/components/datasets/compliance/export-policy.hbs
+++ b/wherehows-web/app/templates/components/datasets/compliance/export-policy.hbs
@@ -52,7 +52,7 @@
   {{/table.head}}
 
   {{#table.body as |body|}}
-    {{#each (if shouldShowAllExportPolicyData table.data (filter-by "value" true table.data)) as |classification|}}
+    {{#each table.data as |classification|}}
       {{#body.row as |row|}}
         {{#row.cell class="dataset-field-content__prompt"}}
           <span class="dataset-tag-container">
@@ -126,27 +126,5 @@
 
     {{/each}}
   {{/table.body}}
-
-  {{#if (not isEditing)}}
-
-    {{#table.foot}}
-      <td colspan="2" class="text-center">
-        <button
-          {{action "onShowAllExportPolicyData"}}
-          class="nacho-button--large nacho-button--tertiary">
-          {{#if shouldShowMorePolicyData}}
-
-            See Less <span class="fa fa-caret-up" aria-label="See Less Types of Data"></span>
-
-          {{else}}
-
-            See More <span class="fa fa-caret-down" aria-label="See More Types of Data"></span>
-
-          {{/if}}
-        </button>
-      </td>
-    {{/table.foot}}
-
-  {{/if}}
 
 {{/dataset-table}}

--- a/wherehows-web/app/templates/components/datasets/compliance/export-policy.hbs
+++ b/wherehows-web/app/templates/components/datasets/compliance/export-policy.hbs
@@ -52,7 +52,7 @@
   {{/table.head}}
 
   {{#table.body as |body|}}
-    {{#each table.data as |classification|}}
+    {{#each (unless showExportPolicyUndefined table.data false) as |classification|}}
       {{#body.row as |row|}}
         {{#row.cell class="dataset-field-content__prompt"}}
           <span class="dataset-tag-container">
@@ -111,15 +111,9 @@
           <div>
             <header>
               <strong>
-                None selected
+                No Export Policy Defined
               </strong>
             </header>
-
-            {{#if (and excludesSomeMemberData (not isEditing))}}
-              <p>
-                Click 'See More' below to view all available types of data
-              </p>
-            {{/if}}
           </div>
         </td>
       </tr>

--- a/wherehows-web/app/utils/api/datasets/compliance.ts
+++ b/wherehows-web/app/utils/api/datasets/compliance.ts
@@ -146,7 +146,7 @@ const readDatasetComplianceSuggestionByUrn = async (urn: string): Promise<ICompl
  * @param urn
  * @return {Promise<IDatasetExportPolicy>}
  */
-const readDatasetExportPolicyByUrn = async (urn: string): Promise<IDatasetExportPolicy> => {
+const readDatasetExportPolicyByUrn = async (urn: string): Promise<IDatasetExportPolicy | null> => {
   let exportPolicy: IDatasetExportPolicy = <IDatasetExportPolicy>{};
 
   try {
@@ -154,7 +154,7 @@ const readDatasetExportPolicyByUrn = async (urn: string): Promise<IDatasetExport
       url: datasetExportPolicyByUrn(urn)
     }));
   } catch {
-    return exportPolicy;
+    return null;
   }
 
   return exportPolicy;


### PR DESCRIPTION
### v1:
- Remove see more and see less from export policy component as there are only 3 fields
- Fix typo that prevented disable of save button for compliance policy when fields were incomplete
- Improve UX for export policy by showing "No policy defined" when getting a 404 vs showing all fields as "no" which can be confusing

`ember test` results:
```
1..507
# tests 507
# pass  500
# skip  7
# fail  0

# ok
```