### PR TITLE
Separate compliance and retention post requests on save

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -240,6 +240,11 @@ export default class DatasetCompliance extends Component {
   onSave: <T>() => Promise<T>;
 
   /**
+   * Passthrough from parent to export policy component to save the retention policy
+   */
+  onSaveRetentionPolicy: <T>() => Promise<T>;
+
+  /**
    * Passthrough from parent to export policy component to save the export policy
    */
   onSaveExportPolicy: (exportPolicy: IDatasetExportPolicy) => Promise<IDatasetExportPolicy>;
@@ -1499,10 +1504,11 @@ export default class DatasetCompliance extends Component {
       try {
         const isSaving = true;
         const onSave = get(this, 'onSave');
+        const onSaveRetentionPolicy = get(this, 'onSaveRetentionPolicy');
         setSaveFlag(isSaving);
 
         await this.beforeSaveCompliance(editTarget);
-        await onSave();
+        await (editTarget === ComplianceEdit.PurgePolicy ? onSaveRetentionPolicy() : onSave());
         return;
       } finally {
         setSaveFlag();

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -40,6 +40,9 @@ import { notificationDialogActionFactory } from 'wherehows-web/utils/notificatio
 import Configurator from 'wherehows-web/services/configurator';
 import { typeOf } from '@ember/utils';
 import { service } from '@ember-decorators/service';
+import { saveDatasetRetentionByUrn } from 'wherehows-web/utils/api/datasets/retention';
+import { extractRetentionFromComplianceInfo } from 'wherehows-web/utils/datasets/retention';
+import { IDatasetRetention } from 'wherehows-web/typings/api/datasets/retention';
 
 /**
  * Type alias for the response when container data items are batched
@@ -334,6 +337,30 @@ export default class DatasetComplianceContainer extends Component {
           // filter out readonly entities, then omit readonly attribute from remaining entities before save
           complianceEntities: removeReadonlyAttr(editableTags(complianceEntities))
         })
+      );
+
+      this.resetPrivacyCompliancePolicy.call(this);
+    }
+  }
+
+  /**
+   * Persists the updates to the retention policy on the remote host
+   * @return {Promise<void>}
+   */
+  @action
+  async saveRetentionPolicy(this: DatasetComplianceContainer): Promise<void> {
+    const complianceInfo = get(this, 'complianceInfo');
+    if (complianceInfo) {
+      const { complianceEntities } = complianceInfo;
+
+      await this.notifyOnSave<IDatasetRetention>(
+        saveDatasetRetentionByUrn(
+          get(this, 'urn'),
+          extractRetentionFromComplianceInfo({
+            ...complianceInfo,
+            complianceEntities: removeReadonlyAttr(editableTags(complianceEntities))
+          })
+        )
       );
 
       this.resetPrivacyCompliancePolicy.call(this);

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -332,7 +332,7 @@ export default class DatasetComplianceContainer extends Component {
       const { complianceEntities } = complianceInfo;
 
       await this.notifyOnSave<void>(
-        saveDatasetComplianceByUrn(get(this, 'urn'), {
+        saveDatasetComplianceByUrn(this.urn, {
           ...complianceInfo,
           // filter out readonly entities, then omit readonly attribute from remaining entities before save
           complianceEntities: removeReadonlyAttr(editableTags(complianceEntities))
@@ -355,9 +355,10 @@ export default class DatasetComplianceContainer extends Component {
 
       await this.notifyOnSave<IDatasetRetention>(
         saveDatasetRetentionByUrn(
-          get(this, 'urn'),
+          this.urn,
           extractRetentionFromComplianceInfo({
             ...complianceInfo,
+            // filter out readonly entities, then omit readonly attribute from remaining entities before save
             complianceEntities: removeReadonlyAttr(editableTags(complianceEntities))
           })
         )

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
@@ -35,6 +35,7 @@
       notifyOnComplianceSuggestionFeedback=(action "onSuggestionsComplianceFeedback")
       notifyOnChangeSetRequiresReview=(action "onCompliancePolicyChangeSetDrift")
       onSave=(action "savePrivacyCompliancePolicy")
+      onSaveRetentionPolicy=(action "saveRetentionPolicy")
       onSaveExportPolicy=(action "saveExportPolicy")
       onReset=(action "resetPrivacyCompliancePolicy")
       onComplianceJsonUpdate=(action "onComplianceJsonUpdate")

--- a/wherehows-web/app/utils/api/datasets/compliance.ts
+++ b/wherehows-web/app/utils/api/datasets/compliance.ts
@@ -11,11 +11,7 @@ import {
   IDatasetExportPolicy
 } from 'wherehows-web/typings/api/datasets/compliance';
 import { getJSON, postJSON } from 'wherehows-web/utils/api/fetcher';
-import { saveDatasetRetentionByUrn } from 'wherehows-web/utils/api/datasets/retention';
-import {
-  extractRetentionFromComplianceInfo,
-  nullifyRetentionFieldsOnComplianceInfo
-} from 'wherehows-web/utils/datasets/retention';
+import { nullifyRetentionFieldsOnComplianceInfo } from 'wherehows-web/utils/datasets/retention';
 
 /**
  * Constructs the dataset compliance url
@@ -106,7 +102,6 @@ const saveDatasetComplianceByUrn = async (urn: string, complianceInfo: IComplian
     url: datasetComplianceUrlByUrn(urn),
     data: nullifyRetentionFieldsOnComplianceInfo(complianceInfo)
   });
-  await saveDatasetRetentionByUrn(urn, extractRetentionFromComplianceInfo(complianceInfo));
 };
 
 /**


### PR DESCRIPTION
###v1:
- Because we are allowing editing of compliance tab components individually, we need to split up the save requests as putting them together is causing issues on the mid-tier/backend

`ember test` results:
```
1..507
# tests 507
# pass  500
# skip  7
# fail  0

# ok
```