### PR TITLE
Add jitacl contact to configs update getconfigs to take default value

### DIFF
--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -93,7 +93,7 @@ public class Application extends Controller {
       Play.application().configuration().getString("links.wiki.exportPolicy", "");
 
   private static final String WHZ_LINKS__JIT_ACL_CONTACT =
-      Play.application().configuration().getString("links.jitAcl.contact");
+      Play.application().configuration().getString("links.jitAcl.contact", "");
 
   private static final String DB_WHEREHOWS_URL =
       Play.application().configuration().getString("database.opensource.url");
@@ -212,7 +212,7 @@ public class Application extends Controller {
     config.put("suggestionConfidenceThreshold", Integer.parseInt(WHZ_SUGGESTION_CONFIDENCE_THRESHOLD));
     config.set("wikiLinks", wikiLinks());
     config.set("JitAclAccessWhitelist", Json.toJson(StringUtils.split(JIT_ACL_WHITELIST, ',')));
-    config.set("jitAclContact", WHZ_LINKS__JIT_ACL_CONTACT);
+    config.put("jitAclContact", WHZ_LINKS__JIT_ACL_CONTACT);
     config.set("tracking", trackingInfo());
     // In a staging environment, we can trigger this flag to be true so that the UI can handle based on
     // such config and alert users that their changes will not affect production data

--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -93,7 +93,7 @@ public class Application extends Controller {
       Play.application().configuration().getString("links.wiki.exportPolicy", "");
 
   private static final String WHZ_LINKS__JIT_ACL_CONTACT =
-      Play.application().configuration().getString("links.jitAcl.contact")
+      Play.application().configuration().getString("links.jitAcl.contact");
 
   private static final String DB_WHEREHOWS_URL =
       Play.application().configuration().getString("database.opensource.url");

--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -92,6 +92,9 @@ public class Application extends Controller {
   private static final String WHZ_WIKI_LINKS__EXPORT_POLICY =
       Play.application().configuration().getString("links.wiki.exportPolicy", "");
 
+  private static final String WHZ_LINKS__JIT_ACL_CONTACT =
+      Play.application().configuration().getString("links.jitAcl.contact")
+
   private static final String DB_WHEREHOWS_URL =
       Play.application().configuration().getString("database.opensource.url");
   private static final String WHZ_DB_DSCLASSNAME =
@@ -209,6 +212,7 @@ public class Application extends Controller {
     config.put("suggestionConfidenceThreshold", Integer.parseInt(WHZ_SUGGESTION_CONFIDENCE_THRESHOLD));
     config.set("wikiLinks", wikiLinks());
     config.set("JitAclAccessWhitelist", Json.toJson(StringUtils.split(JIT_ACL_WHITELIST, ',')));
+    config.set("jitAclContact", WHZ_LINKS__JIT_ACL_CONTACT);
     config.set("tracking", trackingInfo());
     // In a staging environment, we can trigger this flag to be true so that the UI can handle based on
     // such config and alert users that their changes will not affect production data

--- a/wherehows-web/app/components/datasets/containers/dataset-acl-access.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-acl-access.ts
@@ -77,6 +77,11 @@ export default class DatasetAclAccessContainer extends Component {
   isJitAclAccessEnabled: boolean;
 
   /**
+   * Who to contact in case of error
+   */
+  jitAclContact: string;
+
+  /**
    * Request object for the current user requesting access control
    * @type {IRequestAccessControlEntry}
    * @memberof DatasetAclAccessContainer
@@ -170,7 +175,9 @@ export default class DatasetAclAccessContainer extends Component {
 
     notify(NotificationEvent.confirm, {
       header: 'Successfully processed ACL request',
-      content: `${message} Your access should be enabled within 15 minutes. Contact ask_acl@linkedin.com if you're still having issues after that time.`,
+      content: `${message} Your access should be enabled within 15 minutes. Contact ${
+        this.jitAclContact
+      } if you're still having issues after that time.`,
       dialogActions,
       confirmButtonText: false,
       dismissButtonText: 'Dismiss'

--- a/wherehows-web/app/controllers/datasets/dataset.ts
+++ b/wherehows-web/app/controllers/datasets/dataset.ts
@@ -61,6 +61,13 @@ export default class DatasetController extends Controller {
   jitAclAccessWhitelist: Array<DatasetPlatform>;
 
   /**
+   * String to indicate who to contact for acl issues
+   * @type {string}
+   * @memberof DatasetController
+   */
+  jitAclContact: string;
+
+  /**
    * References the collection of help links with references to external pages of help information
    * @type {Record<string, string>}
    */

--- a/wherehows-web/app/routes/datasets/dataset.ts
+++ b/wherehows-web/app/routes/datasets/dataset.ts
@@ -95,6 +95,7 @@ export default class DatasetRoute extends Route {
     setProperties(controller, {
       isInternal: !!getConfig('isInternal'),
       jitAclAccessWhitelist: getConfig('JitAclAccessWhitelist') || [],
+      jitAclContact: getConfig('jitAclContact', 'your ACL admin'),
       shouldShowDatasetLineage: getConfig('shouldShowDatasetLineage'),
       shouldShowDatasetHealth: getConfig('shouldShowDatasetHealth'),
       wikiLinks: getConfig('wikiLinks')

--- a/wherehows-web/app/routes/datasets/dataset.ts
+++ b/wherehows-web/app/routes/datasets/dataset.ts
@@ -95,7 +95,7 @@ export default class DatasetRoute extends Route {
     setProperties(controller, {
       isInternal: !!getConfig('isInternal'),
       jitAclAccessWhitelist: getConfig('JitAclAccessWhitelist') || [],
-      jitAclContact: getConfig('jitAclContact', 'your ACL admin'),
+      jitAclContact: getConfig('jitAclContact', { useDefault: true, default: 'your ACL admin' }),
       shouldShowDatasetLineage: getConfig('shouldShowDatasetLineage'),
       shouldShowDatasetHealth: getConfig('shouldShowDatasetHealth'),
       wikiLinks: getConfig('wikiLinks')

--- a/wherehows-web/app/services/configurator.ts
+++ b/wherehows-web/app/services/configurator.ts
@@ -57,15 +57,15 @@ export default class Configurator extends Service {
    */
   static getConfig<K extends keyof IAppConfig | undefined>(
     key?: K,
-    defaultValue?: IAppConfigOrProperty<K>
+    options: { useDefault?: boolean; default?: IAppConfigOrProperty<K> } = {}
   ): IAppConfigOrProperty<K> {
     // Ensure that the application configuration has been successfully cached
     assert('Please ensure you have invoked the `load` method successfully prior to calling `getConfig`.', configLoaded);
 
     return typeof key === 'string' && appConfig.hasOwnProperty(<keyof IAppConfig>key)
       ? <IAppConfigOrProperty<K>>deepClone(appConfig[<keyof IAppConfig>key])
-      : defaultValue !== undefined
-        ? defaultValue
+      : options.useDefault
+        ? <IAppConfigOrProperty<K>>options.default
         : <IAppConfigOrProperty<K>>deepClone(appConfig);
   }
 }

--- a/wherehows-web/app/services/configurator.ts
+++ b/wherehows-web/app/services/configurator.ts
@@ -51,15 +51,21 @@ export default class Configurator extends Service {
    * @static
    * @template K
    * @param {K} [key] if provided, the value is returned with that key on the config hash is returned
+   * @param {IAppConfigOrProperty<K>} [defaultValue] if provided, will default if key is not found in config
    * @returns {IAppConfigOrProperty<K>}
    * @memberof Configurator
    */
-  static getConfig<K extends keyof IAppConfig | undefined>(key?: K): IAppConfigOrProperty<K> {
+  static getConfig<K extends keyof IAppConfig | undefined>(
+    key?: K,
+    defaultValue?: IAppConfigOrProperty<K>
+  ): IAppConfigOrProperty<K> {
     // Ensure that the application configuration has been successfully cached
     assert('Please ensure you have invoked the `load` method successfully prior to calling `getConfig`.', configLoaded);
 
     return typeof key === 'string' && appConfig.hasOwnProperty(<keyof IAppConfig>key)
       ? <IAppConfigOrProperty<K>>deepClone(appConfig[<keyof IAppConfig>key])
-      : <IAppConfigOrProperty<K>>deepClone(appConfig);
+      : defaultValue !== undefined
+        ? defaultValue
+        : <IAppConfigOrProperty<K>>deepClone(appConfig);
   }
 }

--- a/wherehows-web/app/templates/components/dataset-aclaccess.hbs
+++ b/wherehows-web/app/templates/components/dataset-aclaccess.hbs
@@ -217,7 +217,7 @@
 
     {{empty-state
       heading="There are no users in this dataset's ACL"
-      subHead="If you feel this is in error, please contact ask_acl@linkedin.com"
+      subHead=(concat "If you feel this is in error, please contact " jitAclContact)
     }}
 
   {{/if}}

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-acl-access.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-acl-access.hbs
@@ -8,6 +8,7 @@
     {{dataset-aclaccess
       acls=acls
       aclMoreInfoLink=@aclMoreInfoLink
+      jitAclContact=jitAclContact
       hasValidAclRequest=hasValidAclRequest
       userAclRequest=userAclRequest
       userHasAclAccess=userHasAclAccess

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -164,6 +164,7 @@
         urn=encodedUrn
         aclMoreInfoLink=wikiLinks.jitAcl
         isJitAclAccessEnabled=isJitAclAccessEnabled
+        jitAclContact=jitAclContact
       }}
     {{/tabs.tabpanel}}
 

--- a/wherehows-web/app/typings/api/configurator/configurator.d.ts
+++ b/wherehows-web/app/typings/api/configurator/configurator.d.ts
@@ -8,6 +8,7 @@ import { DatasetPlatform } from 'wherehows-web/constants';
 interface IAppConfig {
   isInternal: boolean | void;
   JitAclAccessWhitelist: Array<DatasetPlatform> | void;
+  jitAclContact: string;
   shouldShowDatasetLineage: boolean;
   shouldShowDatasetHealth: boolean;
   // confidence threshold for filtering out higher quality suggestions


### PR DESCRIPTION
Removes a bit of "linkedin" ness from open source world and also improves getconfigs to have one extra optional fallback instead of returning the whole config object

`ember test` results:
```
1..507
# tests 507
# pass  500
# skip  7
# fail  0

# ok
```