### PR TITLE
Do not default to false for export policy. Give live data warning banner

### DIFF
--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -61,6 +61,8 @@ public class Application extends Controller {
       Play.application().configuration().getString("ui.show.ownership.revamp", "hide");
   private static final Boolean WHZ_STG_BANNER =
       Play.application().configuration().getBoolean("ui.show.staging.banner", false);
+  private static final Boolean WHZ_LIVE_DATA_BANNER =
+      Play.application().configuration().getBoolean("ui.show.live.data.banner", false);
   private static final Boolean WHZ_STALE_SEARCH_ALERT =
       Play.application().configuration().getBoolean("ui.show.stale.search", false);
   private static final Boolean HTTPS_REDIRECT = Play.application().configuration().getBoolean("https.redirect", false);
@@ -217,6 +219,7 @@ public class Application extends Controller {
     // In a staging environment, we can trigger this flag to be true so that the UI can handle based on
     // such config and alert users that their changes will not affect production data
     config.put("isStagingBanner", WHZ_STG_BANNER);
+    config.put("isLiveDataWarning", WHZ_LIVE_DATA_BANNER);
     // Flag set in order to warn users that search is experiencing issues
     config.put("isStaleSearch", WHZ_STALE_SEARCH_ALERT);
     response.put("status", "ok");

--- a/wherehows-web/app/components/datasets/compliance/export-policy.ts
+++ b/wherehows-web/app/components/datasets/compliance/export-policy.ts
@@ -95,10 +95,11 @@ export default class ComplianceExportPolicy extends Component.extend({
 
     return policyKeys.map(key => {
       const dataType = ExportPolicyKeys[key];
+      const value = exportPolicyData[dataType];
 
       return {
         dataType,
-        value: exportPolicyData[dataType] || false,
+        value: typeof value === 'boolean' ? value : undefined,
         label: ExportPolicyLabels[key]
       };
     });

--- a/wherehows-web/app/routes/application.js
+++ b/wherehows-web/app/routes/application.js
@@ -43,7 +43,11 @@ export default Route.extend(ApplicationRouteMixin, {
   async model() {
     const { getConfig } = Configurator;
 
-    const [isInternal, showStagingBanner] = await Promise.all([getConfig('isInternal'), getConfig('isStagingBanner')]);
+    const [isInternal, showStagingBanner, showLiveDataWarning] = await Promise.all([
+      getConfig('isInternal'),
+      getConfig('isStagingBanner', { useDefault: true, default: false }),
+      getConfig('isLiveDataWarning', { useDefault: true, default: false })
+    ]);
 
     const { userName } = get(this, 'sessionUser.currentUser') || {};
 
@@ -62,7 +66,7 @@ export default Route.extend(ApplicationRouteMixin, {
       avatarUrl: isInternal ? avatarUrl.replace('[username]', userName) : '/assets/assets/images/default_avatar.png'
     };
 
-    return { feedbackMail, brand, showStagingBanner };
+    return { feedbackMail, brand, showStagingBanner, showLiveDataWarning };
   },
 
   /**
@@ -162,9 +166,12 @@ export default Route.extend(ApplicationRouteMixin, {
    */
   renderTemplate() {
     this._super(...arguments);
-    const { showStagingBanner } = get(this, 'controller').get('model');
+    const { showStagingBanner, showLiveDataWarning } = get(this, 'controller').get('model');
     const banners = get(this, 'banners');
-    run.scheduleOnce('afterRender', this, banners.appInitialBanners.bind(banners), [showStagingBanner]);
+    run.scheduleOnce('afterRender', this, banners.appInitialBanners.bind(banners), [
+      showStagingBanner,
+      showLiveDataWarning
+    ]);
   },
 
   processLegacyDomOperations() {

--- a/wherehows-web/app/services/banners.ts
+++ b/wherehows-web/app/services/banners.ts
@@ -56,11 +56,18 @@ export default class BannerService extends Service {
     return banners.length > 0 && (banners.length > 1 || !banners[0].isExiting);
   });
 
-  appInitialBanners([showStagingBanner]: Array<boolean>): void {
+  appInitialBanners([showStagingBanner, showLiveDataWarning]: Array<boolean>): void {
     if (showStagingBanner) {
       this.addBanner(
         'You are viewing/editing in the staging environment. Changes made here will not reflect in production',
         NotificationEvent['info']
+      );
+    }
+
+    if (showLiveDataWarning) {
+      this.addBanner(
+        'You are viewing/editing live data. Changes made here will affect production data',
+        NotificationEvent['confirm']
       );
     }
   }

--- a/wherehows-web/app/typings/api/configurator/configurator.d.ts
+++ b/wherehows-web/app/typings/api/configurator/configurator.d.ts
@@ -7,6 +7,8 @@ import { DatasetPlatform } from 'wherehows-web/constants';
  */
 interface IAppConfig {
   isInternal: boolean | void;
+  isStagingBanner: boolean;
+  isLiveDataWarning: boolean;
   JitAclAccessWhitelist: Array<DatasetPlatform> | void;
   jitAclContact: string;
   shouldShowDatasetLineage: boolean;

--- a/wherehows-web/app/typings/app/datasets/export-policy.d.ts
+++ b/wherehows-web/app/typings/app/datasets/export-policy.d.ts
@@ -4,7 +4,7 @@ import { ExportPolicyKeys } from 'wherehows-web/constants';
  * Each item in the expected dataset
  */
 export interface IExportPolicyTable {
-  value: boolean;
+  value: boolean | undefined;
   label: string;
   dataType: ExportPolicyKeys;
 }


### PR DESCRIPTION
### v1:
- In calculation for export policy form, default to `undefined` rather than false so that nothing is selected and user has to choose instead of the "lazy method"
- For our private production environment, show a live data warning banner so that users know they are messing with real data

`ember test` results:
```
1..504
# tests 504
# pass  497
# skip  7
# fail  0

# ok
```
![screen shot 2018-09-13 at 10 34 05 am](https://user-images.githubusercontent.com/16459843/45505854-8c0a2600-b742-11e8-81c9-b1eb7e60fcdd.png)
