### PR TITLE
Modify upstream downstream relationships api to use new lineage model

### DIFF
--- a/wherehows-dao/src/main/java/wherehows/dao/table/LineageDao.java
+++ b/wherehows-dao/src/main/java/wherehows/dao/table/LineageDao.java
@@ -19,6 +19,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import wherehows.models.view.DatasetView;
+import wherehows.models.view.LineageView;
 
 
 public class LineageDao {
@@ -38,6 +39,26 @@ public class LineageDao {
    * @return List of DatasetView
    */
   public List<DatasetView> getDownstreamDatasets(@Nonnull String datasetUrn) throws Exception {
+    throw new UnsupportedOperationException("Lineage not implemented yet.");
+  }
+
+  /**
+   * Get upstream datasets lineage for a certain dataset, similar to upstream datasets but with
+   * lineage data attached
+   * @param datasetUrn String
+   * @return List of LineageView
+   */
+  public List<LineageView> getUpstreamLineage(@Nonnull String datasetUrn) throws Exception {
+    throw new UnsupportedOperationException("Lineage not implemented yet.");
+  }
+
+  /**
+   * Get downstream datasets lineage for a certain dataset, similar to downstream datasets but with
+   * lineage data attached
+   * @param datasetUrn String
+   * @return List of LineageView
+   */
+  public List<LineageView> getDownstreamLineage(@Nonnull String datasetUrn) throws Exception {
     throw new UnsupportedOperationException("Lineage not implemented yet.");
   }
 

--- a/wherehows-dao/src/main/java/wherehows/models/view/LineageView.java
+++ b/wherehows-dao/src/main/java/wherehows/models/view/LineageView.java
@@ -28,4 +28,6 @@ public class LineageView {
   private String type;
 
   private String actor;
+
+  private String modified;
 }

--- a/wherehows-dao/src/main/java/wherehows/models/view/LineageView.java
+++ b/wherehows-dao/src/main/java/wherehows/models/view/LineageView.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package wherehows.models.view;
+
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LineageView {
+  private DatasetView dataset;
+
+  private String type;
+
+  private String actor;
+}

--- a/wherehows-frontend/app/controllers/api/v2/Dataset.java
+++ b/wherehows-frontend/app/controllers/api/v2/Dataset.java
@@ -47,6 +47,7 @@ import wherehows.models.view.DatasetRetention;
 import wherehows.models.view.DatasetSchema;
 import wherehows.models.view.DatasetView;
 import wherehows.models.view.DsComplianceSuggestion;
+import wherehows.models.view.LineageView;
 
 import static controllers.api.v1.Dataset.*;
 import static utils.Dataset.*;
@@ -521,9 +522,9 @@ public class Dataset extends Controller {
   }
 
   public static Promise<Result> getDatasetUpstreams(@Nonnull String datasetUrn) {
-    final List<DatasetView> upstreams;
+    final List<LineageView> upstreams;
     try {
-      upstreams = LINEAGE_DAO.getUpstreamDatasets(datasetUrn);
+      upstreams = LINEAGE_DAO.getUpstreamLineage(datasetUrn);
     } catch (Exception e) {
       Logger.error("Fetch Dataset upstreams error", e);
       return Promise.promise(() -> internalServerError(errorResponse(e)));
@@ -532,9 +533,9 @@ public class Dataset extends Controller {
   }
 
   public static Promise<Result> getDatasetDownstreams(@Nonnull String datasetUrn) {
-    final List<DatasetView> downstreams;
+    final List<LineageView> downstreams;
     try {
-      downstreams = LINEAGE_DAO.getDownstreamDatasets(datasetUrn);
+      downstreams = LINEAGE_DAO.getDownstreamLineage(datasetUrn);
     } catch (Exception e) {
       Logger.error("Fetch Dataset upstreams error", e);
       return Promise.promise(() -> internalServerError(errorResponse(e)));

--- a/wherehows-web/app/typings/api/datasets/relationships.d.ts
+++ b/wherehows-web/app/typings/api/datasets/relationships.d.ts
@@ -23,7 +23,7 @@ interface IDatasetLineage {
   dataset: IDatasetView;
   type: string;
   actor: string;
-  modified: string;
+  modified: string | undefined;
 }
 
 export { Relationships, RelationshipType, IDatasetLineage };

--- a/wherehows-web/app/typings/api/datasets/relationships.d.ts
+++ b/wherehows-web/app/typings/api/datasets/relationships.d.ts
@@ -15,4 +15,15 @@ type Relationships = Array<IDatasetView>;
  */
 type RelationshipType = IDropDownOption<string>;
 
-export { Relationships, RelationshipType };
+/**
+ * Relationship upstream and downstream api will return Array<IDatasetLineage> displaying
+ * the type of dataset, type of lineage, and actor urn that modified that relationship
+ */
+interface IDatasetLineage {
+  dataset: IDatasetView;
+  type: string;
+  actor: string;
+  modified: string;
+}
+
+export { Relationships, RelationshipType, IDatasetLineage };


### PR DESCRIPTION
Creates a new response type for relationships tab for lineage to be able to fill out all our necessary lineage information (actor, modified, type, etc). `dataset/<urn>/upstream` and `dataset/<urn>/downstream` will use this new response format instead.

`../gradlew build` results:
```
BUILD SUCCESSFUL in 1m 7s
21 actionable tasks: 6 executed, 15 up-to-date
```