### PR TITLE
Add a tooltip for health score and remove more info from tooltip messages

### DIFF
--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -93,6 +93,8 @@ public class Application extends Controller {
       Play.application().configuration().getString("links.wiki.complianceOwner", "");
   private static final String WHZ_WIKI_LINKS__EXPORT_POLICY =
       Play.application().configuration().getString("links.wiki.exportPolicy", "");
+  private static final String WHZ_WIKI_LINKS__METADATA_HEALTH =
+      Play.application().configuration().getString("links.wiki.metadataHealth", "");
 
   private static final String WHZ_LINKS__JIT_ACL_CONTACT =
       Play.application().configuration().getString("links.jitAcl.contact", "");
@@ -266,6 +268,7 @@ public class Application extends Controller {
     wikiLinks.put("jitAcl", WHZ_WIKI_LINKS__JIT_ACL_FAQ);
     wikiLinks.put("metadataCustomRegex", WHZ_WIKI_LINKS__METADATA_CUSTOM_REGEX);
     wikiLinks.put("exportPolicy", WHZ_WIKI_LINKS__EXPORT_POLICY);
+    wikiLinks.put("metadataHealth", WHZ_WIKI_LINKS__METADATA_HEALTH);
 
     return wikiLinks;
   }

--- a/wherehows-web/app/styles/components/visualization/charts/_score-gauge.scss
+++ b/wherehows-web/app/styles/components/visualization/charts/_score-gauge.scss
@@ -14,6 +14,7 @@ $score-gauge-dimension: 128px;
       font-size: 16px;
       font-weight: 600;
       margin: 0;
+      color: get-color(black);
     }
 
     &-value {

--- a/wherehows-web/app/templates/components/datasets/containers/health-score-gauge.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/health-score-gauge.hbs
@@ -1,8 +1,14 @@
 {{#if getHealthScoreTask.isIdle}}
-  {{visualization/charts/score-gauge
+  {{#visualization/charts/score-gauge
     class="dataset-health-score"
     score=healthScore
-    title="Health Score:"}}
+    customTitleTemplate=true}}
+    Health Score:
+    {{more-info
+      link=@wikiLinks.metadataHealth
+      tooltip="Click for more information on Metadata Health Score"
+    }}
+  {{/visualization/charts/score-gauge}}
 {{else}}
   {{pendulum-ellipsis-animation}}
 {{/if}}

--- a/wherehows-web/app/templates/components/datasets/containers/health-score-gauge.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/health-score-gauge.hbs
@@ -1,8 +1,7 @@
 {{#if getHealthScoreTask.isIdle}}
   {{#visualization/charts/score-gauge
     class="dataset-health-score"
-    score=healthScore
-    customTitleTemplate=true}}
+    score=healthScore}}
     Health Score:
     {{more-info
       link=@wikiLinks.metadataHealth

--- a/wherehows-web/app/templates/components/more-info.hbs
+++ b/wherehows-web/app/templates/components/more-info.hbs
@@ -2,12 +2,11 @@
   <sup>
     {{#if tooltip}}
       <i data-title="{{tooltip}}" class="nacho-tooltip">
-        More Info
+        <span class="glyphicon glyphicon-question-sign"></span>
       </i>
     {{else}}
-      More Info
+      <span class="glyphicon glyphicon-question-sign"></span>
     {{/if}}
 
-    <span class="glyphicon glyphicon-question-sign"></span>
   </sup>
 </a>

--- a/wherehows-web/app/templates/components/visualization/charts/score-gauge.hbs
+++ b/wherehows-web/app/templates/components/visualization/charts/score-gauge.hbs
@@ -1,7 +1,11 @@
 {{high-charts chartOptions=(readonly chartOptions) content=(readonly chartData)}}
 <div class="score-gauge__legend-wrapper">
   <h6 class="score-gauge__legend-title">
-    {{title}}
+    {{#if customTitleTemplate}}
+      {{yield}}
+    {{else}}
+      {{title}}
+    {{/if}}
   </h6>
   <span class="score-gauge__legend-value {{labelValueClass}}">
     {{#if (eq scoreDisplay "percent")}}

--- a/wherehows-web/app/templates/components/visualization/charts/score-gauge.hbs
+++ b/wherehows-web/app/templates/components/visualization/charts/score-gauge.hbs
@@ -1,7 +1,7 @@
 {{high-charts chartOptions=(readonly chartOptions) content=(readonly chartData)}}
 <div class="score-gauge__legend-wrapper">
   <h6 class="score-gauge__legend-title">
-    {{#if customTitleTemplate}}
+    {{#if hasBlock}}
       {{yield}}
     {{else}}
       {{title}}

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -62,7 +62,9 @@
               avatarEntityProps=avatarEntityProps
               class="dataset-owner-list"}}
 
-            {{datasets/containers/health-score-gauge urn=encodedUrn}}
+            {{#link-to "datasets.dataset.health" encodedUrn}}
+              {{datasets/containers/health-score-gauge urn=encodedUrn wikiLinks=wikiLinks}}
+            {{/link-to}}
           {{/if}}
         </div>
 


### PR DESCRIPTION
### v1:
- Clicking on the health score gauge now moves you to the health tab
- The healthscore comes with a tooltip that leads to a wiki page to explain metadata health
- Removes "more info" from the helper tooltips and just leaves the question mark thing
- Mid tier returns a custom wiki link for metadata health

`ember test` results:
```
Note: 
The two failing tests are the avatar ones being fixed in PR https://github.com/linkedin/WhereHows/pull/1390
```

```
1..502
# tests 502
# pass  493
# skip  7
# fail  2
```

![screen shot 2018-09-17 at 5 23 39 pm](https://user-images.githubusercontent.com/16459843/45657345-d3741780-ba9e-11e8-9264-e75ef1e1f23a.png)
