### PR TITLE
Change compliance availability to a computed property

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -7,7 +7,7 @@ import { assert } from '@ember/debug';
 import { IDatasetView } from 'wherehows-web/typings/api/datasets/dataset';
 import { IDataPlatform } from 'wherehows-web/typings/api/list/platforms';
 import { readPlatforms } from 'wherehows-web/utils/api/list/platforms';
-import { task, waitForProperty, TaskInstance } from 'ember-concurrency';
+import { task, waitForProperty } from 'ember-concurrency';
 import {
   getSecurityClassificationDropDownOptions,
   DatasetClassifiers,
@@ -109,7 +109,6 @@ export default class DatasetCompliance extends Component {
   searchTerm: string;
   _hasBadData: boolean;
   platform: IDatasetView['platform'];
-  isCompliancePolicyAvailable: boolean = false;
   showAllDatasetMemberData: boolean;
   complianceInfo: undefined | IComplianceInfo;
 
@@ -217,6 +216,16 @@ export default class DatasetCompliance extends Component {
    */
   showAdvancedEditApplyStep = computed('showGuidedComplianceEditMode', function(this: DatasetCompliance): boolean {
     return !get(this, 'showGuidedComplianceEditMode');
+  });
+
+  /**
+   * Flag indicating if we have compliance available. It's based on whether we receive a compliance info object from the
+   * server
+   * @type {ComputedProperty<boolean>}
+   * @memberof DatasetCompliance
+   */
+  isCompliancePolicyAvailable = computed('complianceInfo', function(): boolean {
+    return !!this.complianceInfo;
   });
 
   /**
@@ -555,7 +564,7 @@ export default class DatasetCompliance extends Component {
   }
 
   didInsertElement(): void {
-    get(this, 'complianceAvailabilityTask').perform();
+    get(this, 'getPlatformPoliciesTask').perform();
     get(this, 'columnFieldsToCompliancePolicyTask').perform();
     get(this, 'foldChangeSetTask').perform();
   }
@@ -564,20 +573,6 @@ export default class DatasetCompliance extends Component {
     get(this, 'columnFieldsToCompliancePolicyTask').perform();
     get(this, 'foldChangeSetTask').perform();
   }
-
-  /**
-   * Parent task to determine if a compliance policy can be created or updated for the dataset
-   * @type {Task<TaskInstance<Promise<Array<IDataPlatform>>>, () => TaskInstance<TaskInstance<Promise<Array<IDataPlatform>>>>>}
-   * @memberof DatasetCompliance
-   */
-  complianceAvailabilityTask = task(function*(
-    this: DatasetCompliance
-  ): IterableIterator<TaskInstance<Promise<Array<IDataPlatform>>>> {
-    yield get(this, 'getPlatformPoliciesTask').perform();
-
-    const supportedPurgePolicies = get(this, 'supportedPurgePolicies');
-    set(this, 'isCompliancePolicyAvailable', !!supportedPurgePolicies.length);
-  }).restartable();
 
   /**
    * Task to retrieve platform policies and set supported policies for the current platform

--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -74,7 +74,6 @@ import { isMetadataObject, jsonValuesMatch } from 'wherehows-web/utils/datasets/
 import { typeOf } from '@ember/utils';
 import { pick } from 'wherehows-web/utils/object';
 import { service } from '@ember-decorators/service';
-import { bool } from '@ember-decorators/object/computed';
 
 const {
   complianceDataException,
@@ -225,8 +224,10 @@ export default class DatasetCompliance extends Component {
    * @type {ComputedProperty<boolean>}
    * @memberof DatasetCompliance
    */
-  @bool('complianceInfo')
-  isCompliancePolicyAvailable: ComputedProperty<boolean>;
+  // We used to use supportedPurgePolicies.length to calculate this flag's state. Since that is not applicable anymore,
+  // setting to always true for now. If a condition appears where we should show no compliance user message, then this
+  // should be modified by a task or turned into a computed property
+  isCompliancePolicyAvailable: true;
 
   /**
    * Flag indicating the readonly confirmation dialog should not be shown again for this compliance form

--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -74,6 +74,7 @@ import { isMetadataObject, jsonValuesMatch } from 'wherehows-web/utils/datasets/
 import { typeOf } from '@ember/utils';
 import { pick } from 'wherehows-web/utils/object';
 import { service } from '@ember-decorators/service';
+import { bool } from '@ember-decorators/object/computed';
 
 const {
   complianceDataException,
@@ -224,9 +225,8 @@ export default class DatasetCompliance extends Component {
    * @type {ComputedProperty<boolean>}
    * @memberof DatasetCompliance
    */
-  isCompliancePolicyAvailable = computed('complianceInfo', function(): boolean {
-    return !!this.complianceInfo;
-  });
+  @bool('complianceInfo')
+  isCompliancePolicyAvailable: ComputedProperty<boolean>;
 
   /**
    * Flag indicating the readonly confirmation dialog should not be shown again for this compliance form

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -1,201 +1,197 @@
-{{#if complianceAvailabilityTask.isRunning}}
-  {{pendulum-ellipsis-animation}}
-{{else}}
-  {{#if isCompliancePolicyAvailable}}
+{{#if isCompliancePolicyAvailable}}
 
-    <div id="compliance" class="tab-body">
-      {{#if _hasBadData}}
-        <div class="alert alert-danger post-action-notification" role="alert">
-          <p>
-            Oops! We have discovered some issues with this Dataset's fields that
-            may put any updates in an invalid state. <br>
-            Unfortunately updates are <strong>disabled</strong> at this time. <br>
-            Please shoot us an email at
-            <a href="mailto:ask_metadata@linkedin.com">ask_metadata@linkedin.com</a>
-            and we will get on this asap! <br>
-            Our apologies.
-          </p>
-        </div>
-      {{else}}
-        <section class="action-bar">
-          {{#if (and isEditing (not (eq editTarget ComplianceEdit.ExportPolicy)))}}
+  <div id="compliance" class="tab-body">
+    {{#if _hasBadData}}
+      <div class="alert alert-danger post-action-notification" role="alert">
+        <p>
+          Oops! We have discovered some issues with this Dataset's fields that
+          may put any updates in an invalid state. <br>
+          Unfortunately updates are <strong>disabled</strong> at this time. <br>
+          Please shoot us an email at
+          <a href="mailto:ask_metadata@linkedin.com">ask_metadata@linkedin.com</a>
+          and we will get on this asap! <br>
+          Our apologies.
+        </p>
+      </div>
+    {{else}}
+      <section class="action-bar">
+        {{#if (and isEditing (not (eq editTarget ComplianceEdit.ExportPolicy)))}}
 
-            <div class="container action-bar__content">
+          <div class="container action-bar__content">
 
-              {{#if showAdvancedEditApplyStep}}
+            {{#if showAdvancedEditApplyStep}}
 
-                {{#track-ui-event category=trackableCategory.Compliance action=trackableEvent.Compliance.ManualApply
-                                  name=editStep.name as |metrics|}}
-                  <button
-                    class="nacho-button nacho-button--large-inverse action-bar__item"
-                    title="Apply JSON"
-                    onclick={{action metrics.trackOnAction (action "onApplyComplianceJson")}}
-                    disabled={{isManualApplyDisabled}}>
-                    Apply
-                  </button>
-                {{/track-ui-event}}
-
-              {{else}}
-
-                {{#track-ui-event category=trackableCategory.Compliance
-                                  action=trackableEvent.Compliance.Save as |metrics|}}
-                  <button
-                    class="nacho-button nacho-button--large-inverse action-bar__item"
-                    title="{{unless isDatasetFullyClassified
-                                    'Ensure you have provided a yes/no value for all dataset tags'
-                                    'Save'}}"
-                    onclick={{action metrics.trackOnAction (action "saveCompliance")}} disabled={{and (eq editTarget ComplianceEdit.CompliancePolicy) changeSetNeedsReview}}>
-                    Save
-                  </button>
-                {{/track-ui-event}}
-
-              {{/if}}
-
-
-              {{#track-ui-event category=trackableCategory.Compliance
-                                action=trackableEvent.Compliance.Cancel as |metrics|}}
+              {{#track-ui-event category=trackableCategory.Compliance action=trackableEvent.Compliance.ManualApply
+                                name=editStep.name as |metrics|}}
                 <button
-                  class="nacho-button nacho-button--large nacho-button--secondary action-bar__item"
-                  onclick={{action metrics.trackOnAction (action "onCancel")}}>
-                  Cancel
+                  class="nacho-button nacho-button--large-inverse action-bar__item"
+                  title="Apply JSON"
+                  onclick={{action metrics.trackOnAction (action "onApplyComplianceJson")}}
+                  disabled={{isManualApplyDisabled}}>
+                  Apply
                 </button>
               {{/track-ui-event}}
 
-              {{#if (and (eq editTarget ComplianceEdit.CompliancePolicy) (and manualParseError (not showGuidedComplianceEditMode)))}}
-                <div class="action-bar__content__error-messages">
-                  {{fa-icon "times-circle-o"}}
+            {{else}}
 
-                  <span class="dataset-compliance-fields__manual-entry-errors">
-                    {{manualParseError}}
-                  </span>
-                </div>
-              {{/if}}
-            </div>
+              {{#track-ui-event category=trackableCategory.Compliance
+                                action=trackableEvent.Compliance.Save as |metrics|}}
+                <button
+                  class="nacho-button nacho-button--large-inverse action-bar__item"
+                  title="{{unless isDatasetFullyClassified
+                                  'Ensure you have provided a yes/no value for all dataset tags'
+                                  'Save'}}"
+                  onclick={{action metrics.trackOnAction (action "saveCompliance")}} disabled={{and (eq editTarget ComplianceEdit.CompliancePolicy) changeSetNeedsReview}}>
+                  Save
+                </button>
+              {{/track-ui-event}}
 
-          {{/if}}
-        </section>
-      {{/if}}
+            {{/if}}
 
-      <div class="secondary-actions">
-        <div class="policy-last-saved">
-          Last saved:
-          {{#if isNewComplianceInfo}}
-            <span class="policy-last-saved__saved">Never</span>
-          {{else}}
-            <span class="policy-last-saved__saved">
-              {{moment-from-now complianceInfo.modifiedTime}}
-            </span>
-            by
-            <span class="policy-last-saved__saved" title="{{complianceInfo.modifiedBy}}">
-              {{tooltip-on-element text=complianceInfo.modifiedBy}}
-              {{split-text complianceInfo.modifiedBy 30}}
-            </span>
-          {{/if}}
-        </div>
-      </div>
 
-      {{#if (or isReadOnly (eq editTarget ComplianceEdit.ExportPolicy))}}
-        {{datasets/compliance/export-policy
-          exportPolicyData=exportPolicy
-          isEditing=isEditing
-          wikiLinks=@wikiLinks
-          toggleEditing=(action toggleEditing)
-          onSaveExportPolicy=(action "saveExportPolicy")}}
-      {{/if}}
+            {{#track-ui-event category=trackableCategory.Compliance
+                              action=trackableEvent.Compliance.Cancel as |metrics|}}
+              <button
+                class="nacho-button nacho-button--large nacho-button--secondary action-bar__item"
+                onclick={{action metrics.trackOnAction (action "onCancel")}}>
+                Cancel
+              </button>
+            {{/track-ui-event}}
 
-      {{#if (or isReadOnly (eq editTarget ComplianceEdit.PurgePolicy))}}
-        {{#if getPlatformPoliciesTask.isRunning}}
-          {{pendulum-ellipsis-animation}}
-        {{/if}}
+            {{#if (and (eq editTarget ComplianceEdit.CompliancePolicy) (and manualParseError (not showGuidedComplianceEditMode)))}}
+              <div class="action-bar__content__error-messages">
+                {{fa-icon "times-circle-o"}}
 
-        {{#if getPlatformPoliciesTask.last.isError}}
-          {{!--todo: swap out with error-state component--}}
-          {{empty-state
-            heading="Purge Policies not available"
-            subHead="Could not find supported purge policies for this platform"
-          }}
-
-          <div class="purge-policy-list__retry-platforms">
-            <button
-              class="nacho-button nacho-button--large-inverse"
-              onclick={{perform getPlatformPoliciesTask}}>
-              Retry
-            </button>
+                <span class="dataset-compliance-fields__manual-entry-errors">
+                  {{manualParseError}}
+                </span>
+              </div>
+            {{/if}}
           </div>
 
         {{/if}}
+      </section>
+    {{/if}}
 
-        {{#if getPlatformPoliciesTask.last.isSuccessful}}
-          <section class="metadata-prompt">
-            <header class="metadata-prompt__header">
-              <p>
-                Compliance Purge Policy
-
-                {{more-info
-                  link=@wikiLinks.purgePolicies
-                  tooltip="Click for more information Purge Policies"
-                }}
-              </p>
-
-              {{#unless isEditing}}
-                <div class="compliance-entities-meta__secondary">
-                  <button
-                    class="nacho-button nacho-button--tertiary"
-                    onclick={{action toggleEditing true ComplianceEdit.PurgePolicy}}>
-
-                    <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
-
-                    Edit
-                  </button>
-                </div>
-              {{/unless}}
-            </header>
-          </section>
-
-          {{purge-policy
-            isEditable=(not isReadOnly)
-            platform=platform
-            missingPolicyText="This dataset does not have a current compliance purge policy."
-            supportedPurgePolicies=supportedPurgePolicies
-            purgeNote=complianceInfo.compliancePurgeNote
-            purgePolicy=(readonly complianceInfo.complianceType)
-            onPolicyChange=(action "onDatasetPurgePolicyChange")
-          }}
-
+    <div class="secondary-actions">
+      <div class="policy-last-saved">
+        Last saved:
+        {{#if isNewComplianceInfo}}
+          <span class="policy-last-saved__saved">Never</span>
+        {{else}}
+          <span class="policy-last-saved__saved">
+            {{moment-from-now complianceInfo.modifiedTime}}
+          </span>
+          by
+          <span class="policy-last-saved__saved" title="{{complianceInfo.modifiedBy}}">
+            {{tooltip-on-element text=complianceInfo.modifiedBy}}
+            {{split-text complianceInfo.modifiedBy 30}}
+          </span>
         {{/if}}
-      {{/if}}
-
-      {{#if schemaless}}
-
-        {{#if (or isReadOnly (eq editTarget ComplianceEdit.DatasetLevelPolicy))}}
-          {{datasets/schemaless-tagging
-            classificationHelpLink=@wikiLinks.dht
-            isEditing=isEditing
-            classification=(readonly complianceInfo.confidentiality)
-            containsPersonalData=(readonly complianceInfo.containingPersonalData)
-            toggleEditing=(action toggleEditing)
-            onClassificationChange=(action "onDatasetSecurityClassificationChange")
-            onPersonalDataChange=(action "onDatasetLevelPolicyChange")
-            onSaveCompliance=(action "saveCompliance")
-            resetCompliance=(action "resetCompliance")
-          }}
-        {{/if}}
-
-      {{else}}
-
-        {{#if (or isReadOnly (eq editTarget ComplianceEdit.CompliancePolicy))}}
-          {{partial "datasets/dataset-compliance/dataset-compliance-entities"}}
-        {{/if}}
-
-      {{/if}}
+      </div>
     </div>
 
-  {{else}}
+    {{#if (or isReadOnly (eq editTarget ComplianceEdit.ExportPolicy))}}
+      {{datasets/compliance/export-policy
+        exportPolicyData=exportPolicy
+        isEditing=isEditing
+        wikiLinks=@wikiLinks
+        toggleEditing=(action toggleEditing)
+        onSaveExportPolicy=(action "saveExportPolicy")}}
+    {{/if}}
 
-    {{empty-state
-      heading="Compliance Policy not available"
-      subHead="Compliance Policy is currently not available for this platform"
-    }}
+    {{#if (or isReadOnly (eq editTarget ComplianceEdit.PurgePolicy))}}
+      {{#if getPlatformPoliciesTask.isRunning}}
+        {{pendulum-ellipsis-animation}}
+      {{/if}}
 
-  {{/if}}
+      {{#if getPlatformPoliciesTask.last.isError}}
+        {{!--todo: swap out with error-state component--}}
+        {{empty-state
+          heading="Purge Policies not available"
+          subHead="Could not find supported purge policies for this platform"
+        }}
+
+        <div class="purge-policy-list__retry-platforms">
+          <button
+            class="nacho-button nacho-button--large-inverse"
+            onclick={{perform getPlatformPoliciesTask}}>
+            Retry
+          </button>
+        </div>
+
+      {{/if}}
+
+      {{#if getPlatformPoliciesTask.last.isSuccessful}}
+        <section class="metadata-prompt">
+          <header class="metadata-prompt__header">
+            <p>
+              Compliance Purge Policy
+
+              {{more-info
+                link=@wikiLinks.purgePolicies
+                tooltip="Click for more information Purge Policies"
+              }}
+            </p>
+
+            {{#unless isEditing}}
+              <div class="compliance-entities-meta__secondary">
+                <button
+                  class="nacho-button nacho-button--tertiary"
+                  onclick={{action toggleEditing true ComplianceEdit.PurgePolicy}}>
+
+                  <i class="fa fa-pencil" aria-label="Edit Compliance Policy"></i>
+
+                  Edit
+                </button>
+              </div>
+            {{/unless}}
+          </header>
+        </section>
+
+        {{purge-policy
+          isEditable=(not isReadOnly)
+          platform=platform
+          missingPolicyText="This dataset does not have a current compliance purge policy."
+          supportedPurgePolicies=supportedPurgePolicies
+          purgeNote=complianceInfo.compliancePurgeNote
+          purgePolicy=(readonly complianceInfo.complianceType)
+          onPolicyChange=(action "onDatasetPurgePolicyChange")
+        }}
+
+      {{/if}}
+    {{/if}}
+
+    {{#if schemaless}}
+
+      {{#if (or isReadOnly (eq editTarget ComplianceEdit.DatasetLevelPolicy))}}
+        {{datasets/schemaless-tagging
+          classificationHelpLink=@wikiLinks.dht
+          isEditing=isEditing
+          classification=(readonly complianceInfo.confidentiality)
+          containsPersonalData=(readonly complianceInfo.containingPersonalData)
+          toggleEditing=(action toggleEditing)
+          onClassificationChange=(action "onDatasetSecurityClassificationChange")
+          onPersonalDataChange=(action "onDatasetLevelPolicyChange")
+          onSaveCompliance=(action "saveCompliance")
+          resetCompliance=(action "resetCompliance")
+        }}
+      {{/if}}
+
+    {{else}}
+
+      {{#if (or isReadOnly (eq editTarget ComplianceEdit.CompliancePolicy))}}
+        {{partial "datasets/dataset-compliance/dataset-compliance-entities"}}
+      {{/if}}
+
+    {{/if}}
+  </div>
+
+{{else}}
+
+  {{empty-state
+    heading="Compliance Policy not available"
+    subHead="Compliance Policy is currently not available for this platform"
+  }}
+
 {{/if}}


### PR DESCRIPTION
based on `complanceinfo` response.

###v1
- Using platform supported purge policies was not an effective way to determine compliance availability as a dataset could have compliance info but no supported purge policies. 

`ember test` results:
```
1..500
# tests 500
# pass  493
# skip  7
# fail  0

# ok
```