### PR TITLE
Use upstream lineage instead of resolved compliance

### DIFF
--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -44,6 +44,8 @@ import { containerDataSource } from 'wherehows-web/utils/components/containers/d
 import { saveDatasetRetentionByUrn } from 'wherehows-web/utils/api/datasets/retention';
 import { extractRetentionFromComplianceInfo } from 'wherehows-web/utils/datasets/retention';
 import { IDatasetRetention } from 'wherehows-web/typings/api/datasets/retention';
+import { readUpstreamDatasetsByUrn } from 'wherehows-web/utils/api/datasets/lineage';
+import { LineageList } from 'wherehows-web/typings/api/datasets/relationships';
 
 /**
  * Type alias for the response when container data items are batched
@@ -53,7 +55,8 @@ type BatchComplianceResponse = [
   Array<IComplianceDataType>,
   IComplianceSuggestion,
   IDatasetSchema,
-  IDatasetExportPolicy | null
+  IDatasetExportPolicy | null,
+  LineageList
 ];
 
 /**
@@ -127,6 +130,13 @@ export default class DatasetComplianceContainer extends Component {
   complianceInfo: IComplianceInfo | void;
 
   /**
+   * List object containing a list of lineage objects that include upstream dataests and lineage
+   * metainformation
+   * @type {LineageList}
+   */
+  upstreams: LineageList = [];
+
+  /**
    * Object containing the fields for the export policy for this dataset
    * @type {IDatasetExportPolicy}
    */
@@ -190,13 +200,15 @@ export default class DatasetComplianceContainer extends Component {
       complianceDataTypes,
       complianceSuggestion,
       { columns, schemaless },
-      exportPolicy
+      exportPolicy,
+      upstreams
     ]: BatchComplianceResponse = await Promise.all([
       readDatasetComplianceByUrn(urn),
       readComplianceDataTypes(),
       readDatasetComplianceSuggestionByUrn(urn),
       readDatasetSchemaByUrn(urn),
-      readDatasetExportPolicyByUrn(urn)
+      readDatasetExportPolicyByUrn(urn),
+      readUpstreamDatasetsByUrn(urn)
     ]);
     const schemaFieldNamesMappedToDataTypes = await iterateArrayAsync(columnDataTypesAndFieldNames)(columns);
     const { containingPersonalData, fromUpstream } = complianceInfo;
@@ -218,7 +230,8 @@ export default class DatasetComplianceContainer extends Component {
       complianceSuggestion,
       schemaFieldNamesMappedToDataTypes,
       schemaless,
-      exportPolicy
+      exportPolicy,
+      upstreams
     });
   }
 

--- a/wherehows-web/app/components/datasets/containers/upstream-dataset.ts
+++ b/wherehows-web/app/components/datasets/containers/upstream-dataset.ts
@@ -136,7 +136,7 @@ export default class UpstreamDatasetContainer extends Component {
   getUpstreamDatasetsTask = task(function*(this: UpstreamDatasetContainer): IterableIterator<Promise<LineageList>> {
     const upstreamDatasets: LineageList = yield readUpstreamDatasetsByUrn(get(this, 'urn'));
     return set(this, 'upstreamLineage', upstreamDatasets);
-  });
+  }).restartable();
 
   /**
    * Task to get and set upstream metadata for upstream datasets

--- a/wherehows-web/app/components/datasets/containers/upstream-dataset.ts
+++ b/wherehows-web/app/components/datasets/containers/upstream-dataset.ts
@@ -147,8 +147,8 @@ export default class UpstreamDatasetContainer extends Component {
     this: UpstreamDatasetContainer
   ): IterableIterator<TaskInstance<Promise<LineageList>> | Promise<Array<IUpstreamWithComplianceMetadata>>> {
     // Fallback logic, if we have lineage then use that otherwise get upstreams again
-    const upstreamLineage =
-      get(this, 'upstreamLineage') || <LineageList>yield get(this, 'getUpstreamDatasetsTask').perform();
+    // prettier-ignore
+    const upstreamLineage = get(this, 'upstreamLineage') || <LineageList>(yield get(this, 'getUpstreamDatasetsTask').perform());
     const upstreamMetadataPromises = datasetsWithComplianceMetadata(upstreamLineage.map(lineage => lineage.dataset));
     const upstreamsMetadata: Array<IUpstreamWithComplianceMetadata> = yield Promise.all(upstreamMetadataPromises);
 

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
@@ -10,11 +10,14 @@
 
 {{else}}
 
-  {{#if complianceInfo.fromUpstream}}
+  {{!-- {{#if complianceInfo.fromUpstream}} --}}
+  {{#if upstreams.length}}
 
     {{datasets/containers/upstream-dataset
       urn=urn
       platform=platform
+      upstreamLineage=upstreams
+      hasResolvedCompliance=complianceInfo.fromUpstream
       upstreamComplianceType=complianceInfo.complianceType
     }}
 

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
@@ -10,7 +10,6 @@
 
 {{else}}
 
-  {{!-- {{#if complianceInfo.fromUpstream}} --}}
   {{#if upstreams.length}}
 
     {{datasets/containers/upstream-dataset

--- a/wherehows-web/app/templates/components/datasets/upstream-dataset.hbs
+++ b/wherehows-web/app/templates/components/datasets/upstream-dataset.hbs
@@ -13,10 +13,10 @@
   <div class="upstream-dataset">
     <span class="upstream-dataset__compliance-status">
       {{tooltip-on-element
-        text=(if parent.hasCompliance "Compliance completed for parent dataset" "Please complete the Compliance on this parent dataset")
+        text=(if hasResolvedCompliance "Compliance completed for parent dataset" "Please complete the Compliance on this parent dataset")
       }}
 
-      {{#if parent.hasCompliance}}
+      {{#if hasResolvedCompliance}}
         {{fa-icon "check" class="upstream-dataset__compliance-status__complete"}}
       {{else}}
         {{fa-icon "exclamation" class="upstream-dataset__compliance-status__incomplete"}}


### PR DESCRIPTION
...to determine whether or not we should show parent datasets.

### v1:
- Use the upstreams API to show parents since this is more reliable
- For now, we still rely on resolved compliance from the `/compliance` call to indicate whether or not the upstream parent has compliance (check mark in the table)
- Passes the upstreams from the dataset compliance container to the upstreams container to avoid making a separate api call to fetch upstreams when we already needed to do that

`ember test` results:
```
1..500
# tests 500
# pass  493
# skip  7
# fail  0

# ok
```