### PR TITLE
Use retention API instead of compliance to determine purge policy

### DIFF
--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -158,7 +158,7 @@
             missingPolicyText="This dataset does not have a current compliance purge policy."
             supportedPurgePolicies=supportedPurgePolicies
             purgeNote=complianceInfo.compliancePurgeNote
-            purgePolicy=(readonly complianceInfo.complianceType)
+            purgePolicy=(readonly (if retentionPolicy retentionPolicy.purgeType complianceInfo.complianceType))
             onPolicyChange=(action "onDatasetPurgePolicyChange")
           }}
 

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
@@ -30,6 +30,7 @@
       fieldReviewOption=@complianceTagFilter
       complianceInfo=complianceInfo
       exportPolicy=exportPolicy
+      retentionPolicy=retentionPolicy
       complianceSuggestion=complianceSuggestion
       suggestionConfidenceThreshold=suggestionConfidenceThreshold
       isNewComplianceInfo=isNewComplianceInfo


### PR DESCRIPTION
As we are already splitting up the save requests for compliance and retention, the next logical step would be to decouple the GET for this information as well. Additionally, some datasets may not have compliance but still have a retention policy, which relying on compliance to find this information would not work.

`ember test` results:
```
1..500
# tests 500
# pass  493
# skip  7
# fail  0

# ok
catran@ca
```