### PR TITLE
Use retention policy for form and create separate reset retention

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -74,6 +74,7 @@ import { isMetadataObject, jsonValuesMatch } from 'wherehows-web/utils/datasets/
 import { typeOf } from '@ember/utils';
 import { pick } from 'wherehows-web/utils/object';
 import { service } from '@ember-decorators/service';
+import { IDatasetRetention } from 'wherehows-web/typings/api/datasets/retention';
 
 const {
   complianceDataException,
@@ -140,6 +141,12 @@ export default class DatasetCompliance extends Component {
    * @memberof DatasetCompliance
    */
   showGuidedComplianceEditMode: boolean = true;
+
+  /**
+   * Pass through object containing the retention policy
+   * @type {IDatasetRetention | null}
+   */
+  retentionPolicy: IDatasetRetention | null;
 
   /**
    * Pass through value for the dataset export policy, to be used by one of our child components on
@@ -1450,14 +1457,10 @@ export default class DatasetCompliance extends Component {
     onDatasetPurgePolicyChange(
       this: DatasetCompliance,
       purgePolicy: PurgePolicy
-    ): IComplianceInfo['complianceType'] | null {
-      const complianceInfo = get(this, 'complianceInfo');
+    ): IDatasetRetention['purgeType'] | null {
+      const retentionPolicy = get(this, 'retentionPolicy');
 
-      if (!complianceInfo) {
-        return null;
-      }
-      // directly set the complianceType to the updated value
-      return set(complianceInfo, 'complianceType', purgePolicy);
+      return retentionPolicy ? set(retentionPolicy, 'purgeType', purgePolicy) : null;
     },
 
     /**

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -158,7 +158,7 @@
             missingPolicyText="This dataset does not have a current compliance purge policy."
             supportedPurgePolicies=supportedPurgePolicies
             purgeNote=complianceInfo.compliancePurgeNote
-            purgePolicy=(readonly (if retentionPolicy retentionPolicy.purgeType complianceInfo.complianceType))
+            purgePolicy=(readonly retentionPolicy.purgeType)
             onPolicyChange=(action "onDatasetPurgePolicyChange")
           }}
 

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-compliance.hbs
@@ -42,7 +42,7 @@
       onSave=(action "savePrivacyCompliancePolicy")
       onSaveRetentionPolicy=(action "saveRetentionPolicy")
       onSaveExportPolicy=(action "saveExportPolicy")
-      onReset=(action "resetPrivacyCompliancePolicy")
+      onReset=(action "resetAll")
       onComplianceJsonUpdate=(action "onComplianceJsonUpdate")
     }}
 

--- a/wherehows-web/app/utils/datasets/retention.ts
+++ b/wherehows-web/app/utils/datasets/retention.ts
@@ -1,26 +1,5 @@
 import { IComplianceInfo } from 'wherehows-web/typings/api/datasets/compliance';
-import { IDatasetRetention } from 'wherehows-web/typings/api/datasets/retention';
 import { nullify, Nullify, Omit, pick } from 'wherehows-web/utils/object';
-import { isExempt } from 'wherehows-web/constants';
-
-/**
- * Extracts values from an IComplianceInfo instance to create an instance of IDatasetRetention
- * @param {IComplianceInfo} complianceInfo the compliance info object
- * @returns {IDatasetRetention}
- */
-const extractRetentionFromComplianceInfo = (complianceInfo: IComplianceInfo): IDatasetRetention => {
-  let { datasetUrn, compliancePurgeNote, complianceType } = pick(complianceInfo, [
-    'complianceType',
-    'compliancePurgeNote',
-    'datasetUrn'
-  ]);
-
-  return {
-    purgeNote: complianceType && isExempt(complianceType) ? compliancePurgeNote : '',
-    purgeType: complianceType,
-    datasetUrn: datasetUrn!
-  };
-};
 
 /**
  * Makes values in IComplianceInfo that are present / have a corollary in IDatasetRetention type null i.e. keys
@@ -38,4 +17,4 @@ const nullifyRetentionFieldsOnComplianceInfo = (
   ...nullify(pick(complianceInfo, ['complianceType', 'compliancePurgeNote']))
 });
 
-export { extractRetentionFromComplianceInfo, nullifyRetentionFieldsOnComplianceInfo };
+export { nullifyRetentionFieldsOnComplianceInfo };


### PR DESCRIPTION
Follow up to previous PR, this PR completes the decoupling of compliance and retention by using retention policy as source of data for purge policy form instead of `complianceInfo`. We also create a separate reset that can be called to reset the retention policy and modify the POST request to retention to use retentionPolicy instead of compliance. This should completely solve the issue where, in cases where a dataset does not have compliance, a user was not able to update the purge policy.

`ember test` results:
```
1..500
# tests 500
# pass  493
# skip  7
# fail  0

# ok
```