### PR TITLE
Dataset deprecation acknowledgement

### DIFF
--- a/wherehows-frontend/app/controllers/Application.java
+++ b/wherehows-frontend/app/controllers/Application.java
@@ -97,6 +97,8 @@ public class Application extends Controller {
       Play.application().configuration().getString("links.wiki.metadataHealth", "");
   private static final String WHZ_WIKI_LINKS__PURGE_KEY =
       Play.application().configuration().getString("links.wiki.purgeKey", "");
+  private static final String WHZ_WIKI_LINKS__DATASET_DECOMMISSION =
+      Play.application().configuration().getString("links.wiki.datasetDecommission");
 
   private static final String WHZ_LINKS__JIT_ACL_CONTACT =
       Play.application().configuration().getString("links.jitAcl.contact", "");
@@ -272,6 +274,7 @@ public class Application extends Controller {
     wikiLinks.put("exportPolicy", WHZ_WIKI_LINKS__EXPORT_POLICY);
     wikiLinks.put("metadataHealth", WHZ_WIKI_LINKS__METADATA_HEALTH);
     wikiLinks.put("purgeKey", WHZ_WIKI_LINKS__PURGE_KEY);
+    wikiLinks.put("datasetDecommission", WHZ_WIKI_LINKS__DATASET_DECOMMISSION);
 
     return wikiLinks;
   }

--- a/wherehows-web/app/components/dataset-deprecation.ts
+++ b/wherehows-web/app/components/dataset-deprecation.ts
@@ -67,6 +67,14 @@ export default class DatasetDeprecation extends Component {
   deprecationNoteAlias: ComputedProperty<DatasetDeprecation['deprecationNote']> = oneWay('deprecationNote');
 
   /**
+   * Before a user can update the deprecation status to deprecated, they must acknowledge that even if the
+   * dataset is deprecated they must still keep it compliant.
+   * @memberof DatasetDeprecation
+   * @type {boolean}
+   */
+  isDeprecationNoticeAcknowledged: boolean = false;
+
+  /**
    * Checks the working / aliased copies of the deprecation properties diverge from the
    * saved versions i.e. deprecationNoteAlias and deprecationAlias
    * @type {ComputedProperty<boolean>}
@@ -122,6 +130,15 @@ export default class DatasetDeprecation extends Component {
   @action
   onDecommissionDateChange(this: DatasetDeprecation, decommissionTime: Date) {
     set(this, 'decommissionTime', new Date(decommissionTime).getTime());
+  }
+
+  /**
+   * When a user clicks the checkbox to acknowledge or cancel acknowledgement of the notice for
+   * deprecating a dataset
+   */
+  @action
+  onAcknowledgeDeprecationNotice(this: DatasetDeprecation) {
+    this.toggleProperty('isDeprecationNoticeAcknowledged');
   }
 
   /**

--- a/wherehows-web/app/styles/base/_checkbox.scss
+++ b/wherehows-web/app/styles/base/_checkbox.scss
@@ -58,3 +58,22 @@ input[type='checkbox'] {
     }
   }
 }
+
+input[type='checkbox'] + label.checkbox-input__wrapper {
+  $checkbox-width: 28px;
+  $container-margin: item-spacing(4);
+  display: flex;
+  padding: item-spacing(2) $container-margin item-spacing(2) ($container-margin + $checkbox-width);
+  box-sizing: content-box;
+  margin: 0 (-1 * $container-margin);
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  &:before,
+  &:after {
+    left: $container-margin;
+    top: item-spacing(2) - 1;
+  }
+}

--- a/wherehows-web/app/styles/components/search/_facet.scss
+++ b/wherehows-web/app/styles/components/search/_facet.scss
@@ -29,22 +29,3 @@
     color: rgba(0, 0, 0, 0.6);
   }
 }
-
-input[type='checkbox'] + label.search-facet__checkbox-wrapper {
-  $checkbox-width: 28px;
-  $container-margin: item-spacing(4);
-  display: flex;
-  padding: item-spacing(2) $container-margin item-spacing(2) ($container-margin + $checkbox-width);
-  box-sizing: content-box;
-  margin: 0 (-1 * $container-margin);
-
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
-
-  &:before,
-  &:after {
-    left: $container-margin;
-    top: item-spacing(2) - 1;
-  }
-}

--- a/wherehows-web/app/templates/components/dataset-deprecation.hbs
+++ b/wherehows-web/app/templates/components/dataset-deprecation.hbs
@@ -91,7 +91,7 @@
         change=(action "onAcknowledgeDeprecationNotice")}}
 
       <label for="acknowledge-deprecation">
-        <p>By checking this box, you acknowledge that you must keep this dataset compliant even after it is deprecated.</p>
+        <p>By checking this box, you acknowledge that you must keep this dataset compliance updated even after it is deprecated.</p>
         <p>
           For more information on how to decommission your dataset, please follow this link:
           <a href={{wikiLinks.datasetDecommission}} target="_blank">

--- a/wherehows-web/app/templates/components/dataset-deprecation.hbs
+++ b/wherehows-web/app/templates/components/dataset-deprecation.hbs
@@ -94,7 +94,7 @@
         <p>By checking this box, you acknowledge that you must keep this dataset compliance updated even after it is deprecated.</p>
         <p>
           For more information on how to decommission your dataset, please follow this link:
-          <a href={{wikiLinks.datasetDecommission}} target="_blank">
+          <a href={{wikiLinks.datasetDecommission}} target="_blank" rel="noopener">
             Dataset Decommission
           </a>
         </p>

--- a/wherehows-web/app/templates/components/dataset-deprecation.hbs
+++ b/wherehows-web/app/templates/components/dataset-deprecation.hbs
@@ -82,13 +82,33 @@
       </strong>
     </p>
 
+    <span>
+      {{input
+        type="checkbox"
+        name="deprecated.acknowledge"
+        id="acknowledge-deprecation"
+        checked=(readonly isDeprecationAcknowledged)
+        change=(action "onAcknowledgeDeprecationNotice")}}
+
+      <label for="acknowledge-deprecation">
+        <p>By checking this box, you acknowledge that you must keep this dataset compliant even after it is deprecated.</p>
+        <p>
+          For more information on how to decommission your dataset, please follow this link:
+          <a href={{wikiLinks.datasetDecommission}} target="_blank">
+            Dataset Decommission
+          </a>
+        </p>
+      </label>
+    </span>
+
+
   {{/if}}
 
   <div class="dataset-deprecation-toggle__actions">
     <button
       type="submit"
       class="nacho-button--large nacho-button--secondary"
-      disabled={{and deprecatedAlias (not decommissionTime)}}>
+      disabled={{and deprecatedAlias (or (not decommissionTime) (not isDeprecationNoticeAcknowledged))}}>
       Update Deprecation Status
     </button>
   </div>

--- a/wherehows-web/app/templates/components/datasets/containers/dataset-properties.hbs
+++ b/wherehows-web/app/templates/components/datasets/containers/dataset-properties.hbs
@@ -2,6 +2,7 @@
   deprecated=deprecated
   deprecationNote=deprecationNote
   decommissionTime=decommissionTime
+  wikiLinks=wikiLinks
   onUpdateDeprecation=(action "updateDeprecation")
 }}
 

--- a/wherehows-web/app/templates/components/search/search-facet.hbs
+++ b/wherehows-web/app/templates/components/search/search-facet.hbs
@@ -21,7 +21,7 @@
             checked=(readonly checked)
             change=(action onChange facet facetValue)
             }}
-          <label for="{{facetValue.value}}" class="search-facet__checkbox-wrapper">
+          <label for="{{facetValue.value}}" class="search-facet__checkbox-wrapper checkbox-input__wrapper">
             <span class="search-facet__label">{{facetValue.label}}</span>
             <span class="search-facet__count">{{readonly count}}</span>
           </label>

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -125,6 +125,7 @@
         urn=encodedUrn
         deprecated=model.deprecated
         deprecationNote=model.deprecationNote
+        wikiLinks=wikiLinks
       }}
     {{/tabs.tabpanel}}
 

--- a/wherehows-web/app/templates/datasets/dataset.hbs
+++ b/wherehows-web/app/templates/datasets/dataset.hbs
@@ -79,7 +79,7 @@
 
         {{#unless isPinot}}
           {{#tablist.tab tabIds.Properties on-select=(action "tabSelectionChanged")}}
-            Properties
+            Status
           {{/tablist.tab}}
         {{/unless}}
 

--- a/wherehows-web/tests/integration/components/dataset-deprecation-test.js
+++ b/wherehows-web/tests/integration/components/dataset-deprecation-test.js
@@ -41,7 +41,7 @@ module('Integration | Component | dataset deprecation', function(hooks) {
 
   test('decommissionTime', async function(assert) {
     let isDisabled;
-    assert.expect(2);
+    assert.expect(3);
 
     this.set('decommissionTime', void 0);
     this.set('deprecated', true);
@@ -55,7 +55,12 @@ module('Integration | Component | dataset deprecation', function(hooks) {
     await fillIn('.comment-new__content', 'text');
 
     isDisabled = this.$('.dataset-deprecation-toggle__actions [type=submit]').is(':disabled');
-    assert.notOk(isDisabled, 'submit button is not disabled');
+    assert.ok(isDisabled, 'submit button is disabled if we only fill in decomissionTime');
+
+    await click('#acknowledge-deprecation');
+
+    isDisabled = this.$('.dataset-deprecation-toggle__actions [type=submit]').is(':disabled');
+    assert.notOk(isDisabled, 'submit button is disabled if we only fill in decomissionTime');
   });
 
   test('triggers the onUpdateDeprecation action when submitted', async function(assert) {
@@ -76,6 +81,8 @@ module('Integration | Component | dataset deprecation', function(hooks) {
     await click('#dataset-is-deprecated');
 
     assert.equal(this.$('#dataset-is-deprecated').is(':checked'), true, 'deprecation checkbox is checked');
+
+    await click('#acknowledge-deprecation');
     await click('.dataset-deprecation-toggle__actions [type=submit]');
 
     assert.equal(submitActionCallCount, 1, 'action is called once');


### PR DESCRIPTION
###v1:
- Deprecated datasets should still have updated compliance. Part of the workflow should include acknowledging that deprecating the dataset does not remove responsibility for keeping compliance updated
- We include a message with checkbox above the update dataset deprecation status button that must be clicked in order to un-disable the update message. This is positioned as such to become a natural part of the user workflow
- We also add an additional link 
- Change the `Properties` tab to `Status`

`ember test` results:
```
1..500
# tests 500
# pass  493
# skip  7
# fail  0

# ok
```

![screen shot 2018-09-27 at 4 41 26 pm](https://user-images.githubusercontent.com/16459843/46180366-d1674100-c274-11e8-80dc-fb0f042910c1.png)
