### PR TITLE
UX improvements for acl access tab

### DIFF
--- a/wherehows-web/app/components/dataset-aclaccess.ts
+++ b/wherehows-web/app/components/dataset-aclaccess.ts
@@ -16,12 +16,6 @@ import { getAvatarProps } from 'wherehows-web/constants/avatars/avatars';
 import moment from 'moment';
 
 /**
- * Returns the number of days in milliseconds, default is 1 day
- * @param {number} [day=1] the number of days to scale
- */
-const millisecondDays = (day = 1) => day * 24 * 60 * 60 * 1000;
-
-/**
  * Date object with the minimum selectable date for acl request expiration,
  * at least 1 day from now
  * @type {Date}
@@ -37,7 +31,11 @@ const minSelectableExpirationDate = new Date(
  * up to 7 days from now
  * @type {Date}
  */
-const maxSelectableExpirationDate = new Date(Date.now() + millisecondDays(7));
+const maxSelectableExpirationDate = new Date(
+  moment()
+    .add(7, 'days')
+    .valueOf()
+);
 
 export default class DatasetAclAccess extends Component {
   /**

--- a/wherehows-web/app/components/dataset-aclaccess.ts
+++ b/wherehows-web/app/components/dataset-aclaccess.ts
@@ -25,7 +25,9 @@ const millisecondDays = (day = 1) => day * 24 * 60 * 60 * 1000;
  * at least 1 day from now
  * @type {Date}
  */
-const minSelectableExpirationDate = new Date(Date.now() + millisecondDays());
+// Making min selectable date to be an hour from the current time allows the user to select the
+// next day on the calendar but normally not the current day unless it's 11PM
+const minSelectableExpirationDate = new Date(Date.now() + millisecondDays(1 / 24));
 
 /**
  * Date object with the maximum selectable date for acl request expiration,

--- a/wherehows-web/app/components/dataset-aclaccess.ts
+++ b/wherehows-web/app/components/dataset-aclaccess.ts
@@ -13,6 +13,7 @@ import { IAvatar } from 'wherehows-web/typings/app/avatars';
 import { arrayMap } from 'wherehows-web/utils/array';
 import { IAppConfig } from 'wherehows-web/typings/api/configurator/configurator';
 import { getAvatarProps } from 'wherehows-web/constants/avatars/avatars';
+import moment from 'moment';
 
 /**
  * Returns the number of days in milliseconds, default is 1 day
@@ -25,9 +26,11 @@ const millisecondDays = (day = 1) => day * 24 * 60 * 60 * 1000;
  * at least 1 day from now
  * @type {Date}
  */
-// Making min selectable date to be an hour from the current time allows the user to select the
-// next day on the calendar but normally not the current day unless it's 11PM
-const minSelectableExpirationDate = new Date(Date.now() + millisecondDays(1 / 24));
+const minSelectableExpirationDate = new Date(
+  moment()
+    .endOf('day')
+    .valueOf()
+);
 
 /**
  * Date object with the maximum selectable date for acl request expiration,

--- a/wherehows-web/app/templates/components/dataset-aclaccess.hbs
+++ b/wherehows-web/app/templates/components/dataset-aclaccess.hbs
@@ -1,9 +1,4 @@
-<div>
-  {{more-info
-    link=@aclMoreInfoLink
-    tooltip="Click for more information on ACL Access"
-  }}
-</div>
+
 
 <header class="acl-permission__header">
   {{#if userHasAclAccess}}
@@ -43,7 +38,13 @@
   <hr class="acl-permission__separator">
 
   <form class="acl-form" {{action (perform requestAccessAndCheckAccessTask) on="submit"}}>
-    <h4 class=" acl-form__meta acl-form__header">Request Access</h4>
+    <h4 class=" acl-form__meta acl-form__header">
+      Request Access
+      {{more-info
+        link=@aclMoreInfoLink
+        tooltip="Click for more information on ACL Access"
+      }}
+    </h4>
     <div class="acl-form__meta">
       <h4 class="acl-form__meta__header">Why do you need access?</h4>
       <p class="acl-form__meta__content ">Please add the business reason why you need to access this data.</p>
@@ -98,7 +99,7 @@
                 {{moment-format calendar.center 'MMMM YYYY'}}
 
                 <p>
-                  {{if hasValidExpiration (concat "Expires in " (moment-from-now calendar.selected))}}
+                  {{if hasValidExpiration (concat "Expires " (moment-from-now calendar.selected))}}
                 </p>
 
               </div>


### PR DESCRIPTION
###v1:
- Moves "more info" link to the request access header to make it easier for users to notice.
- `minSelectableExpirationDate` set to `Date.now() + 24HoursInMilliseconds` creates an interesting issue where the next day on the calendar is actually not selectable and makes the minimum number of days to be 2 days from current time. Setting the property to `Date.now() + 1HourFromNow` in order to allow user to select the next day in most cases. 

`ember test` results:
```
1..502
# tests 502
# pass  495
# skip  7
# fail  0

# ok
```

![screen shot 2018-09-28 at 2 40 50 pm](https://user-images.githubusercontent.com/16459843/46234742-84df3c80-c32c-11e8-9fd7-886b7013d623.png)
