### PR TITLE
Moves fe check for compliance purge policy to retentionPolicy instead of complianceInfo

### DIFF
--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -1188,6 +1188,10 @@ export default class DatasetCompliance extends Component {
      */
     onCancel(this: DatasetCompliance): void {
       this.toggleEditing(false, <any>undefined);
+
+      // Note: [REFACTOR-COMPLIANCE] This should no longer be necessary once we separate the items into
+      // their own components
+      this.onReset();
     },
 
     /**
@@ -1401,13 +1405,13 @@ export default class DatasetCompliance extends Component {
      * @returns {(Promise<void>)}
      */
     didEditPurgePolicy(this: DatasetCompliance): Promise<void> {
-      const { complianceType = null } = get(this, 'complianceInfo') || {};
+      const retentionPolicy = get(this, 'retentionPolicy');
 
-      if (!complianceType) {
+      if (!retentionPolicy || !retentionPolicy.purgeType) {
         return this.needsPurgePolicyType();
       }
 
-      if (isExempt(complianceType)) {
+      if (isExempt(<PurgePolicy>retentionPolicy.purgeType)) {
         return this.showPurgeExemptionWarning();
       }
 

--- a/wherehows-web/app/components/dataset-compliance.ts
+++ b/wherehows-web/app/components/dataset-compliance.ts
@@ -1411,7 +1411,7 @@ export default class DatasetCompliance extends Component {
         return this.needsPurgePolicyType();
       }
 
-      if (isExempt(<PurgePolicy>retentionPolicy.purgeType)) {
+      if (isExempt(retentionPolicy.purgeType)) {
         return this.showPurgeExemptionWarning();
       }
 

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -45,6 +45,7 @@ import { saveDatasetRetentionByUrn, readDatasetRetentionByUrn } from 'wherehows-
 import { IDatasetRetention, IGetDatasetRetentionResponse } from 'wherehows-web/typings/api/datasets/retention';
 import { readUpstreamDatasetsByUrn } from 'wherehows-web/utils/api/datasets/lineage';
 import { LineageList } from 'wherehows-web/typings/api/datasets/relationships';
+import { retentionObjectFactory } from 'wherehows-web/constants/datasets/retention';
 
 /**
  * Type alias for the response when container data items are batched
@@ -240,7 +241,7 @@ export default class DatasetComplianceContainer extends Component {
       schemaless,
       exportPolicy,
       upstreams,
-      retentionPolicy: retentionResponse && retentionResponse.retentionPolicy
+      retentionPolicy: (retentionResponse && retentionResponse.retentionPolicy) || retentionObjectFactory(urn)
     });
   }
 
@@ -277,10 +278,11 @@ export default class DatasetComplianceContainer extends Component {
   getRetentionPolicyTask = task(function*(
     this: DatasetComplianceContainer
   ): IterableIterator<Promise<IGetDatasetRetentionResponse | null>> {
-    const retentionResponse = yield readDatasetRetentionByUrn(get(this, 'urn'));
+    const urn = get(this, 'urn');
+    const retentionResponse = yield readDatasetRetentionByUrn(urn);
 
     const retentionPolicy = retentionResponse && retentionResponse.retentionPolicy;
-    set(this, 'retentionPolicy', retentionPolicy);
+    set(this, 'retentionPolicy', retentionPolicy || retentionObjectFactory(urn));
   }).restartable();
 
   /**

--- a/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-compliance.ts
@@ -278,7 +278,7 @@ export default class DatasetComplianceContainer extends Component {
   getRetentionPolicyTask = task(function*(
     this: DatasetComplianceContainer
   ): IterableIterator<Promise<IGetDatasetRetentionResponse | null>> {
-    const urn = get(this, 'urn');
+    const urn = this.urn;
     const retentionResponse = yield readDatasetRetentionByUrn(urn);
 
     const retentionPolicy = retentionResponse && retentionResponse.retentionPolicy;

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -157,7 +157,7 @@
             platform=platform
             missingPolicyText="This dataset does not have a current compliance purge policy."
             supportedPurgePolicies=supportedPurgePolicies
-            purgeNote=complianceInfo.compliancePurgeNote
+            purgeNote=retentionPolicy.purgeNote
             purgePolicy=(readonly retentionPolicy.purgeType)
             onPolicyChange=(action "onDatasetPurgePolicyChange")
           }}


### PR DESCRIPTION
###v1:
- The original logic is outdated and in a situation where a dataset doesn't have `complianceInfo` but the user tries to edit the purge policy, it creates a false error "Please specify a Compliance Purge Policy"
- This logic also helps fix an issue where you can select multiple radio buttons (due to undefined issue)
- The fix is to create an empty object for `retentionPolicy` when API returns `null`

###### Manually tested on staging environment to ensure application builds and runs as expected.

`ember test` results:
```
1..502
# tests 502
# pass  495
# skip  7
# fail  0

# ok
```