### PR TITLE
Fix issue where dataset names that are too long overlap health gauge

### DIFF
--- a/wherehows-web/app/styles/layout/_dataset.scss
+++ b/wherehows-web/app/styles/layout/_dataset.scss
@@ -6,9 +6,9 @@
 }
 
 .dataset-name {
-  max-width: item-spacing(9) * 10;
+  max-width: item-spacing(8) * 11;
   padding-right: item-spacing(3);
-  overflow: hidden;
+  word-wrap: break-word;
   text-overflow: ellipsis;
   margin: 0;
 }


### PR DESCRIPTION
###v1:
- Sometimes a dataset name that's too long can overlap with the health gauge. Small CSS fix for this

`ember test` results:
```
1..502
# tests 502
# pass  495
# skip  7
# fail  0

# ok
```

<img width="1188" alt="screen shot 2018-10-01 at 2 42 13 pm" src="https://user-images.githubusercontent.com/16459843/46318060-13042e80-c58a-11e8-8ed4-1f9e4a7631ee.png">
