### PR TITLE
Start migrating code in dataset health components away from get helper

### DIFF
--- a/wherehows-web/app/components/datasets/containers/dataset-health.ts
+++ b/wherehows-web/app/components/datasets/containers/dataset-health.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get, computed, setProperties, getProperties } from '@ember/object';
+import { computed, setProperties, getProperties, get } from '@ember/object';
 import { task } from 'ember-concurrency';
 import ComputedProperty from '@ember/object/computed';
 import { IChartDatum } from 'wherehows-web/typings/app/visualization/charts';
@@ -145,7 +145,7 @@ export default class DatasetHealthContainer extends Component {
    * @type {Task<TaskInstance<Promise<any>>, (a?: any) => TaskInstance<TaskInstance<Promise<any>>>>}
    */
   getContainerDataTask = task(function*(this: DatasetHealthContainer): IterableIterator<Promise<IDatasetHealth>> {
-    const health: IDatasetHealth = yield readDatasetHealthByUrn(get(this, 'urn'));
+    const health: IDatasetHealth = yield readDatasetHealthByUrn(this.urn);
 
     const details = health.validations || [];
     const total = details.length;

--- a/wherehows-web/app/components/datasets/containers/health-score-gauge.ts
+++ b/wherehows-web/app/components/datasets/containers/health-score-gauge.ts
@@ -33,7 +33,7 @@ export default class HealthScoreGauge extends Component {
    * @type {Task<TaskInstance<Promise<any>>, (a?: any) => TaskInstance<TaskInstance<Promise<any>>>>}
    */
   getHealthScoreTask = task(function*(this: HealthScoreGauge): IterableIterator<Promise<IDatasetHealth>> {
-    const health: IDatasetHealth = yield readDatasetHealthByUrn(get(this, 'urn'));
+    const health: IDatasetHealth = yield readDatasetHealthByUrn(this.urn);
     set(this, 'healthScore', health.score * 100 || 0);
   }).restartable();
 }


### PR DESCRIPTION
Minor changes only.

`ember test` results:
```
1..502
# tests 502
# pass  495
# skip  7
# fail  0

# ok

```