### PR TITLE
Various ux fixes

### DIFF
--- a/wherehows-web/app/styles/components/dataset-author/_suggested-owners.scss
+++ b/wherehows-web/app/styles/components/dataset-author/_suggested-owners.scss
@@ -113,6 +113,9 @@
       }
 
       &__profile {
+        $max-profile-width: 108px;
+        display: flex;
+
         &__pic {
           float: left;
           margin-right: 6px;
@@ -121,10 +124,10 @@
 
         &__name {
           float: left;
-          max-width: 108px;
+          max-width: $max-profile-width;
 
           &__full {
-            max-width: 108px;
+            max-width: $max-profile-width;
             font-size: 16px;
             font-weight: 400;
             white-space: nowrap;
@@ -135,6 +138,9 @@
 
           &__username {
             font-size: 14px;
+            max-width: $max-profile-width;
+            overflow: hidden;
+            text-overflow: ellipsis;
           }
         }
       }

--- a/wherehows-web/app/styles/components/dataset-property/_dataset-pill.scss
+++ b/wherehows-web/app/styles/components/dataset-property/_dataset-pill.scss
@@ -1,5 +1,5 @@
 .dataset-pill {
-  & + & {
+  & {
     > a {
       @include on-event(true) {
         color: inherit;

--- a/wherehows-web/app/styles/components/dataset-relationships/_dataset-relationships.scss
+++ b/wherehows-web/app/styles/components/dataset-relationships/_dataset-relationships.scss
@@ -2,20 +2,22 @@
   margin-top: item-spacing(5);
 
   .relationship-table {
+    $cell-spacing: item-spacing(8);
+
     &__type {
-      width: 180px;
+      width: $cell-spacing * 3;
     }
 
     &__platform {
-      width: 114px;
+      width: $cell-spacing * 2;
     }
 
     &__actor {
-      width: 228px;
+      width: $cell-spacing * 3;
     }
 
     &__modified {
-      width: 200px;
+      width: $cell-spacing * 3;
     }
   }
 }

--- a/wherehows-web/app/styles/components/dataset-relationships/_dataset-relationships.scss
+++ b/wherehows-web/app/styles/components/dataset-relationships/_dataset-relationships.scss
@@ -1,5 +1,23 @@
 .dataset-relationships-container {
   margin-top: item-spacing(5);
+
+  .relationship-table {
+    &__type {
+      width: 180px;
+    }
+
+    &__platform {
+      width: 114px;
+    }
+
+    &__actor {
+      width: 228px;
+    }
+
+    &__modified {
+      width: 200px;
+    }
+  }
 }
 
 .dataset-relationships {

--- a/wherehows-web/app/templates/components/dataset-compliance.hbs
+++ b/wherehows-web/app/templates/components/dataset-compliance.hbs
@@ -179,7 +179,7 @@
             foldedChangeSet=(readonly foldedChangeSet)
             unspecifiedTags=(readonly unspecifiedTags)
             setUnspecifiedTagsAsNoneTask=setUnspecifiedTagsAsNoneTask
-            toggleEditing=toggleEditing
+            toggleEditing=(action toggleEditing)
             showGuidedEditMode=(action "onShowGuidedEditMode")
             fieldReviewChange=(action "onFieldReviewChange")}}
             {{partial "datasets/dataset-compliance/dataset-compliance-entities"}}

--- a/wherehows-web/app/templates/components/datasets/dataset-relationship-table.hbs
+++ b/wherehows-web/app/templates/components/datasets/dataset-relationship-table.hbs
@@ -1,7 +1,7 @@
-{{#dataset-table fields=filteredRelationships as |relationTable|}}
+{{#dataset-table fields=filteredRelationships class="relationship-table" as |relationTable|}}
   {{#relationTable.head as |head|}}
-    {{#head.column}}Dataset{{/head.column}}
-    {{#head.column}}
+    {{#head.column class="relationship-table__dataset"}}Dataset{{/head.column}}
+    {{#head.column class="relationship-table__type"}}
 
       {{#nacho/dropdown/hover-dropdown
         dropDownItems=relationshipTypes
@@ -11,8 +11,9 @@
       {{/nacho/dropdown/hover-dropdown}}
 
     {{/head.column}}
-    {{#head.column}}Actor{{/head.column}}
-    {{#head.column}}Last Modified{{/head.column}}
+    {{#head.column class="relationship-table__platform"}}Platform{{/head.column}}
+    {{#head.column class="relationship-table__actor"}}Actor{{/head.column}}
+    {{#head.column class="relationship-table__modified"}}Last Modified{{/head.column}}
   {{/relationTable.head}}
 
   {{#relationTable.body as |body|}}
@@ -27,6 +28,9 @@
         {{/row.cell}}
         {{#row.cell}}
           {{titleize lineage.type}}
+        {{/row.cell}}
+        {{#row.cell}}
+          {{titleize lineage.dataset.platform}}
         {{/row.cell}}
         {{#row.cell}}
           {{lineage.actor}}


### PR DESCRIPTION
###v1:
- Corrects some CSS that caused dataset pills did not have the correct text color and made it difficult to read
- Fix a CSS issue where owner names in the suggested owners list in the ownership tab would be under the picture instead of to the right when the text overflowed
- Add platform column to lineage table and resize the cells to better fit the expected content we get

`ember test` results:
```
1..504
# tests 504
# pass  497
# skip  7
# fail  0

# ok
```

Old vs New
![screen shot 2018-10-02 at 10 32 52 am](https://user-images.githubusercontent.com/16459843/46368618-83b45500-c635-11e8-9419-b6d5f4bad6db.png)
![screen shot 2018-10-02 at 10 33 18 am](https://user-images.githubusercontent.com/16459843/46368624-88790900-c635-11e8-8703-c5535c7fcadb.png)
![screen shot 2018-10-02 at 10 35 10 am](https://user-images.githubusercontent.com/16459843/46368636-8f078080-c635-11e8-8f28-2b423ae0fa6b.png)
![screen shot 2018-10-02 at 10 34 32 am](https://user-images.githubusercontent.com/16459843/46368642-93339e00-c635-11e8-9e0d-ccc68d6aa4aa.png)
![screen shot 2018-10-02 at 11 03 40 am](https://user-images.githubusercontent.com/16459843/46368648-975fbb80-c635-11e8-8445-e49499c2ebef.png)
